### PR TITLE
Dev apt version ci

### DIFF
--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -2,7 +2,7 @@ name: Auto Update APT Versions
 
 on:
   schedule:
-    - cron: '0 5 * * 1'  # Every Monday at 05:00 UTC
+  - cron: '0 5 * * 0'  # Every Sunday at 05:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -46,7 +46,7 @@ jobs:
         if: env.NO_CHANGES == 'false'
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: chore: update apt versions in Dockerfile_ODELIA
+          commit-message: "chore: update apt versions in Dockerfile_ODELIA"
           branch: ci/apt-update
           title: 'chore: Update APT versions in Dockerfile'
           body: |

--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           commit-message: "chore: update apt versions in Dockerfile_ODELIA"
           branch: ci/apt-update
-          title: 'chore: Update APT versions in Dockerfile'
+          title: "chore: Update APT versions in Dockerfile"
           body: |
             This PR automatically updates APT package version numbers in `Dockerfile_ODELIA`
             based on a rebuild and inspection of installation logs.

--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -38,12 +38,13 @@ jobs:
         run: scripts/ci/update_apt_versions.sh
 
       - name: Commit updated Dockerfile if changes exist
-        if: env.NO_CHANGES == 'false'
+          echo "NO_CHANGES=false" >> $GITHUB_ENV
+
         run: |
           git commit -m "chore: update apt versions in Dockerfile_ODELIA"
 
       - name: Create Pull Request
-        if: env.NO_CHANGES == 'false'
+          echo "NO_CHANGES=false" >> $GITHUB_ENV
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "chore: update apt versions in Dockerfile_ODELIA"

--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -1,0 +1,55 @@
+name: Auto Update APT Versions
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Every Monday at 05:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update-apt:
+    name: Update APT Package Versions in Dockerfile
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y git
+
+      - name: Configure Git for CI
+        run: |
+          git config --global user.email "ci@github.com"
+          git config --global user.name "GitHub CI"
+
+      - name: Create and switch to apt-update branch
+        run: |
+          git checkout -b ci/apt-update || git switch ci/apt-update
+
+      - name: Make update script executable
+        run: chmod +x scripts/ci/update_apt_versions.sh
+
+      - name: Run apt update script
+        run: scripts/ci/update_apt_versions.sh
+
+      - name: Commit updated Dockerfile if changes exist
+        if: env.NO_CHANGES == 'false'
+        run: |
+          git commit -m "chore: update apt versions in Dockerfile_ODELIA"
+
+      - name: Create Pull Request
+        if: env.NO_CHANGES == 'false'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: chore: update apt versions in Dockerfile_ODELIA
+          branch: ci/apt-update
+          title: 'chore: Update APT versions in Dockerfile'
+          body: |
+            This PR automatically updates APT package version numbers in `Dockerfile_ODELIA`
+            based on a rebuild and inspection of installation logs.
+          base: main

--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -37,12 +37,7 @@ jobs:
       - name: Run apt update script
         run: scripts/ci/update_apt_versions.sh
 
-      - name: Commit updated Dockerfile if changes exist
-          echo "NO_CHANGES=false" >> $GITHUB_ENV
-
-        run: |
-          git commit -m "chore: update apt versions in Dockerfile_ODELIA"
-
+      # Removed redundant commit step
       - name: Create Pull Request
           echo "NO_CHANGES=false" >> $GITHUB_ENV
         uses: peter-evans/create-pull-request@v5

--- a/scripts/ci/update_apt_versions.sh
+++ b/scripts/ci/update_apt_versions.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "[INFO] Removing apt version pins from Dockerfile..."
+scripts/dev_utils/dockerfile_update_removeVersionApt.py docker_config/Dockerfile_ODELIA
+
+echo "[INFO] Committing temporarily without version constraints..."
+git config user.email "ci@github.com"
+git config user.name "GitHub CI"
+git commit docker_config/Dockerfile_ODELIA -m "WIP: remove apt versions for rebuild"
+
+echo "[INFO] Rebuilding Docker image and capturing logs..."
+./buildDockerImageAndStartupKits.sh -p tests/provision/dummy_project_for_testing.yml 2>&1 | tee out.txt
+
+echo "[INFO] Re-adding updated apt version pins..."
+scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py docker_config/Dockerfile_ODELIA out.txt
+rm out.txt
+
+if git diff --quiet; then
+  echo "[INFO] No changes to apt versions found. Cleaning up..."
+  git reset --hard HEAD~1
+else
+  git commit docker_config/Dockerfile_ODELIA --amend -m "chore: update apt versions based on rebuild"
+  echo "[INFO] Updated apt versions committed."
+fi


### PR DESCRIPTION
This pull request introduces a workflow to automate the update of APT package versions in the `Dockerfile_ODELIA` and adds a corresponding script to handle the update process. The workflow is scheduled to run weekly and can also be triggered manually. The script ensures that APT version pins are removed, the Docker image is rebuilt, and updated version pins are added back based on the rebuild logs.

### Workflow automation:

* [`.github/workflows/update-apt-versions.yml`](diffhunk://#diff-7faef3afa141cd5c07eeab616fd4391539d69117a9995e2006b0b248c8e59fecR1-R56): Added a new GitHub Actions workflow named "Auto Update APT Versions" that runs weekly and on-demand to update APT package versions in `Dockerfile_ODELIA`. It includes steps for repository checkout, Python setup, dependency installation, branch creation, script execution, and pull request creation.

### Script for APT version updates:

* [`scripts/ci/update_apt_versions.sh`](diffhunk://#diff-f683e6b0993111dd7057d745a9857544f6b59d8f652afeae977d2841cddd73e2R1-R26): Added a Bash script to automate the removal of APT version pins, rebuild the Docker image, capture logs, and re-add updated version pins to `Dockerfile_ODELIA`. The script commits changes only if updates are detected.