### PR TITLE
Fix apt versions separate lines

### DIFF
--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -14,6 +14,7 @@ RUN apt update
 
 RUN apt install \
     \
+    \
     -y \
     apt=2.4.14 \
     apt-utils=2.4.14 \
@@ -21,6 +22,7 @@ RUN apt install \
 
 # Update versions of installed packages
 RUN apt install \
+    \
     \
     -y \
     base-files=12ubuntu4.7 \
@@ -65,6 +67,7 @@ RUN apt install \
 
 # Install apt-transport-https curl gnupg lsb-release zip and dependencies at defined versions
 RUN apt install \
+    \
     \
     -y \
     apt-transport-https=2.4.14 \
@@ -121,6 +124,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings
 
 # Install docker-ce docker-ce-cli containerd.io and dependencies at fixed versions
 RUN apt install \
+    \
     \
     -y \
     apparmor=3.0.4-2ubuntu2.4 \

--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -16,6 +16,7 @@ RUN apt install \
     \
     \
     \
+    \
     -y \
     apt=2.4.14 \
     apt-utils=2.4.14 \
@@ -23,6 +24,7 @@ RUN apt install \
 
 # Update versions of installed packages
 RUN apt install \
+    \
     \
     \
     \
@@ -69,6 +71,7 @@ RUN apt install \
 
 # Install apt-transport-https curl gnupg lsb-release zip and dependencies at defined versions
 RUN apt install \
+    \
     \
     \
     \
@@ -127,6 +130,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings
 
 # Install docker-ce docker-ce-cli containerd.io and dependencies at fixed versions
 RUN apt install \
+    \
     \
     \
     \

--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -53,7 +53,7 @@ RUN apt install -y \
     libtasn1-6=4.18.0-4ubuntu0.1 \
     libudev1=249.11-0ubuntu3.16 \
     libuuid1=2.37.2-4ubuntu3.4 \
-    linux-libc-dev=5.15.0-144.157 \
+    linux-libc-dev=5.15.0-151.161 \
     logsave=1.46.5-2ubuntu1.2 \
     mount=2.37.2-4ubuntu3.4 \
     openssl=3.0.2-0ubuntu1.19 \
@@ -93,7 +93,7 @@ RUN apt install -y \
     libsasl2-2=2.1.27+dfsg2-3ubuntu1.2 \
     libsasl2-modules-db=2.1.27+dfsg2-3ubuntu1.2 \
     libsasl2-modules=2.1.27+dfsg2-3ubuntu1.2 \
-    libsqlite3-0=3.37.2-2ubuntu0.4 \
+    libsqlite3-0=3.37.2-2ubuntu0.5 \
     libssh-4=0.9.6-2ubuntu0.22.04.4 \
     lsb-release=11.1.0ubuntu4 \
     media-types=7.0.0 \
@@ -120,11 +120,11 @@ RUN apt install -y \
     dbus-user-session=1.12.20-2ubuntu4.1 \
     dbus=1.12.20-2ubuntu4.1 \
     dmsetup=2:1.02.175-2.1ubuntu5 \
-    docker-buildx-plugin=0.25.0-1~ubuntu.22.04~jammy \
-    docker-ce-cli=5:28.3.2-1~ubuntu.22.04~jammy \
-    docker-ce-rootless-extras=5:28.3.2-1~ubuntu.22.04~jammy \
-    docker-ce=5:28.3.2-1~ubuntu.22.04~jammy \
-    docker-compose-plugin=2.38.2-1~ubuntu.22.04~jammy \
+    docker-buildx-plugin=0.26.1-1~ubuntu.22.04~jammy \
+    docker-ce-cli=5:28.3.3-1~ubuntu.22.04~jammy \
+    docker-ce-rootless-extras=5:28.3.3-1~ubuntu.22.04~jammy \
+    docker-ce=5:28.3.3-1~ubuntu.22.04~jammy \
+    docker-compose-plugin=2.39.1-1~ubuntu.22.04~jammy \
     gir1.2-glib-2.0=1.72.0-1 \
     git-man=1:2.34.1-1ubuntu1.15 \
     git=1:2.34.1-1ubuntu1.15 \
@@ -159,7 +159,7 @@ RUN apt install -y \
     libnftnl11=1.2.1-1build1 \
     libnss-systemd=249.11-0ubuntu3.16 \
     libpam-systemd=249.11-0ubuntu3.16 \
-    libperl5.34=5.34.0-3ubuntu1.4 \
+    libperl5.34=5.34.0-3ubuntu1.5 \
     libslirp0=4.6.1-1build1 \
     libx11-6=2:1.7.5-1ubuntu0.3 \
     libx11-data=2:1.7.5-1ubuntu0.3 \
@@ -174,9 +174,9 @@ RUN apt install -y \
     networkd-dispatcher=2.1-2ubuntu0.22.04.2 \
     openssh-client=1:8.9p1-3ubuntu0.13 \
     patch=2.7.6-7build2 \
-    perl-base=5.34.0-3ubuntu1.4 \
-    perl-modules-5.34=5.34.0-3ubuntu1.4 \
-    perl=5.34.0-3ubuntu1.4 \
+    perl-base=5.34.0-3ubuntu1.5 \
+    perl-modules-5.34=5.34.0-3ubuntu1.5 \
+    perl=5.34.0-3ubuntu1.5 \
     pigz=2.6-1 \
     python3-dbus=1.2.18-3build1 \
     python3-gi=3.42.1-0ubuntu1 \

--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -12,15 +12,13 @@ ENV PYTHON_VERSION=3.10.14
 # Install updates of installed packages
 RUN apt update
 
-RUN apt install \
-    -y \
+RUN apt install -y \
     apt=2.4.14 \
     apt-utils=2.4.14 \
     libapt-pkg6.0=2.4.14
 
 # Update versions of installed packages
-RUN apt install \
-    -y \
+RUN apt install -y \
     base-files=12ubuntu4.7 \
     bash=5.1-6ubuntu1.1 \
     bsdutils=1:2.37.2-4ubuntu3.4 \
@@ -62,8 +60,7 @@ RUN apt install \
     util-linux=2.37.2-4ubuntu3.4
 
 # Install apt-transport-https curl gnupg lsb-release zip and dependencies at defined versions
-RUN apt install \
-    -y \
+RUN apt install -y \
     apt-transport-https=2.4.14 \
     curl=7.81.0-1ubuntu1.20 \
     dirmngr=2.2.27-3ubuntu2.4 \
@@ -117,8 +114,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings
     && apt update
 
 # Install docker-ce docker-ce-cli containerd.io and dependencies at fixed versions
-RUN apt install \
-    -y \
+RUN apt install -y \
     apparmor=3.0.4-2ubuntu2.4 \
     containerd.io=1.7.27-1 \
     dbus-user-session=1.12.20-2ubuntu4.1 \

--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -15,6 +15,7 @@ RUN apt update
 RUN apt install \
     \
     \
+    \
     -y \
     apt=2.4.14 \
     apt-utils=2.4.14 \
@@ -22,6 +23,7 @@ RUN apt install \
 
 # Update versions of installed packages
 RUN apt install \
+    \
     \
     \
     -y \
@@ -67,6 +69,7 @@ RUN apt install \
 
 # Install apt-transport-https curl gnupg lsb-release zip and dependencies at defined versions
 RUN apt install \
+    \
     \
     \
     -y \
@@ -124,6 +127,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings
 
 # Install docker-ce docker-ce-cli containerd.io and dependencies at fixed versions
 RUN apt install \
+    \
     \
     \
     -y \

--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -13,10 +13,6 @@ ENV PYTHON_VERSION=3.10.14
 RUN apt update
 
 RUN apt install \
-    \
-    \
-    \
-    \
     -y \
     apt=2.4.14 \
     apt-utils=2.4.14 \
@@ -24,10 +20,6 @@ RUN apt install \
 
 # Update versions of installed packages
 RUN apt install \
-    \
-    \
-    \
-    \
     -y \
     base-files=12ubuntu4.7 \
     bash=5.1-6ubuntu1.1 \
@@ -71,10 +63,6 @@ RUN apt install \
 
 # Install apt-transport-https curl gnupg lsb-release zip and dependencies at defined versions
 RUN apt install \
-    \
-    \
-    \
-    \
     -y \
     apt-transport-https=2.4.14 \
     curl=7.81.0-1ubuntu1.20 \
@@ -130,10 +118,6 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings
 
 # Install docker-ce docker-ce-cli containerd.io and dependencies at fixed versions
 RUN apt install \
-    \
-    \
-    \
-    \
     -y \
     apparmor=3.0.4-2ubuntu2.4 \
     containerd.io=1.7.27-1 \
@@ -348,14 +332,12 @@ WORKDIR /workspace/
 COPY ./MediSwarm/docker_config/NVFlare /workspace/nvflare
 ## use startup kit template in the dashboard
 COPY ./MediSwarm/docker_config/master_template.yml /workspace/nvflare/nvflare/lighter/impl/
-RUN python3 -m pip install \
-    /workspace/nvflare
+RUN python3 -m pip install /workspace/nvflare
 RUN rm -rf /workspace/nvflare
 
 # Install the ODELIA controller package from local source
 COPY ./MediSwarm/controller /workspace/controller
-RUN python3 -m pip install \
-    /workspace/controller
+RUN python3 -m pip install  /workspace/controller
 RUN rm -rf /workspace/controller
 
 # Copy the source code for local training and deploying to the swarm

--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -12,13 +12,106 @@ ENV PYTHON_VERSION=3.10.14
 # Install updates of installed packages
 RUN apt update
 
-RUN apt install -y apt=2.4.14 apt-utils=2.4.14 libapt-pkg6.0=2.4.14
+RUN apt install \
+    \
+    -y \
+    apt=2.4.14 \
+    apt-utils=2.4.14 \
+    libapt-pkg6.0=2.4.14
 
 # Update versions of installed packages
-RUN apt install -y base-files=12ubuntu4.7 bash=5.1-6ubuntu1.1 bsdutils=1:2.37.2-4ubuntu3.4 ca-certificates=20240203~22.04.1 coreutils=8.32-4.1ubuntu1.2 dpkg=1.21.1ubuntu2.3 e2fsprogs=1.46.5-2ubuntu1.2 gpgv=2.2.27-3ubuntu2.4 libblkid1=2.37.2-4ubuntu3.4 libc-bin=2.35-0ubuntu3.10 libc-dev-bin=2.35-0ubuntu3.10 libc6-dev=2.35-0ubuntu3.10 libc6=2.35-0ubuntu3.10 libcap2=1:2.44-1ubuntu0.22.04.2 libcom-err2=1.46.5-2ubuntu1.2 libext2fs2=1.46.5-2ubuntu1.2 libgnutls30=3.7.3-4ubuntu1.7 libgssapi-krb5-2=1.19.2-2ubuntu0.7 libk5crypto3=1.19.2-2ubuntu0.7 libkrb5-3=1.19.2-2ubuntu0.7 libkrb5support0=1.19.2-2ubuntu0.7 libmount1=2.37.2-4ubuntu3.4 libpam-modules-bin=1.4.0-11ubuntu2.6 libpam-modules=1.4.0-11ubuntu2.6 libpam-runtime=1.4.0-11ubuntu2.6 libpam0g=1.4.0-11ubuntu2.6 libseccomp2=2.5.3-2ubuntu3~22.04.1 libsmartcols1=2.37.2-4ubuntu3.4 libss2=1.46.5-2ubuntu1.2 libssl3=3.0.2-0ubuntu1.19 libsystemd0=249.11-0ubuntu3.16 libtasn1-6=4.18.0-4ubuntu0.1 libudev1=249.11-0ubuntu3.16 libuuid1=2.37.2-4ubuntu3.4 linux-libc-dev=5.15.0-144.157 logsave=1.46.5-2ubuntu1.2 mount=2.37.2-4ubuntu3.4 openssl=3.0.2-0ubuntu1.19 util-linux=2.37.2-4ubuntu3.4
+RUN apt install \
+    \
+    -y \
+    base-files=12ubuntu4.7 \
+    bash=5.1-6ubuntu1.1 \
+    bsdutils=1:2.37.2-4ubuntu3.4 \
+    ca-certificates=20240203~22.04.1 \
+    coreutils=8.32-4.1ubuntu1.2 \
+    dpkg=1.21.1ubuntu2.3 \
+    e2fsprogs=1.46.5-2ubuntu1.2 \
+    gpgv=2.2.27-3ubuntu2.4 \
+    libblkid1=2.37.2-4ubuntu3.4 \
+    libc-bin=2.35-0ubuntu3.10 \
+    libc-dev-bin=2.35-0ubuntu3.10 \
+    libc6-dev=2.35-0ubuntu3.10 \
+    libc6=2.35-0ubuntu3.10 \
+    libcap2=1:2.44-1ubuntu0.22.04.2 \
+    libcom-err2=1.46.5-2ubuntu1.2 \
+    libext2fs2=1.46.5-2ubuntu1.2 \
+    libgnutls30=3.7.3-4ubuntu1.7 \
+    libgssapi-krb5-2=1.19.2-2ubuntu0.7 \
+    libk5crypto3=1.19.2-2ubuntu0.7 \
+    libkrb5-3=1.19.2-2ubuntu0.7 \
+    libkrb5support0=1.19.2-2ubuntu0.7 \
+    libmount1=2.37.2-4ubuntu3.4 \
+    libpam-modules-bin=1.4.0-11ubuntu2.6 \
+    libpam-modules=1.4.0-11ubuntu2.6 \
+    libpam-runtime=1.4.0-11ubuntu2.6 \
+    libpam0g=1.4.0-11ubuntu2.6 \
+    libseccomp2=2.5.3-2ubuntu3~22.04.1 \
+    libsmartcols1=2.37.2-4ubuntu3.4 \
+    libss2=1.46.5-2ubuntu1.2 \
+    libssl3=3.0.2-0ubuntu1.19 \
+    libsystemd0=249.11-0ubuntu3.16 \
+    libtasn1-6=4.18.0-4ubuntu0.1 \
+    libudev1=249.11-0ubuntu3.16 \
+    libuuid1=2.37.2-4ubuntu3.4 \
+    linux-libc-dev=5.15.0-144.157 \
+    logsave=1.46.5-2ubuntu1.2 \
+    mount=2.37.2-4ubuntu3.4 \
+    openssl=3.0.2-0ubuntu1.19 \
+    util-linux=2.37.2-4ubuntu3.4
 
 # Install apt-transport-https curl gnupg lsb-release zip and dependencies at defined versions
-RUN apt install -y apt-transport-https=2.4.14 curl=7.81.0-1ubuntu1.20 dirmngr=2.2.27-3ubuntu2.4 distro-info-data=0.52ubuntu0.9 gnupg-l10n=2.2.27-3ubuntu2.4 gnupg-utils=2.2.27-3ubuntu2.4 gnupg=2.2.27-3ubuntu2.4 gpg-agent=2.2.27-3ubuntu2.4 gpg-wks-client=2.2.27-3ubuntu2.4 gpg-wks-server=2.2.27-3ubuntu2.4 gpg=2.2.27-3ubuntu2.4 gpgconf=2.2.27-3ubuntu2.4 gpgsm=2.2.27-3ubuntu2.4 libassuan0=2.5.5-1build1 libbrotli1=1.0.9-2build6 libcurl4=7.81.0-1ubuntu1.20 libexpat1=2.4.7-1ubuntu0.6 libksba8=1.6.0-2ubuntu0.2 libldap-2.5-0=2.5.19+dfsg-0ubuntu0.22.04.1 libldap-common=2.5.19+dfsg-0ubuntu0.22.04.1 libmpdec3=2.5.1-2build2 libnghttp2-14=1.43.0-1ubuntu0.2 libnpth0=1.6-3build2 libpsl5=0.21.0-1.2build2 libpython3-stdlib=3.10.6-1~22.04.1 libpython3.10-minimal=3.10.12-1~22.04.10 libpython3.10-stdlib=3.10.12-1~22.04.10 libreadline8=8.1.2-1 librtmp1=2.4+20151223.gitfa8646d.1-2build4 libsasl2-2=2.1.27+dfsg2-3ubuntu1.2 libsasl2-modules-db=2.1.27+dfsg2-3ubuntu1.2 libsasl2-modules=2.1.27+dfsg2-3ubuntu1.2 libsqlite3-0=3.37.2-2ubuntu0.4 libssh-4=0.9.6-2ubuntu0.22.04.4 lsb-release=11.1.0ubuntu4 media-types=7.0.0 pinentry-curses=1.1.1-1build2 publicsuffix=20211207.1025-1 python3-minimal=3.10.6-1~22.04.1 python3.10-minimal=3.10.12-1~22.04.10 python3.10=3.10.12-1~22.04.10 python3=3.10.6-1~22.04.1 readline-common=8.1.2-1 unzip=6.0-26ubuntu3.2 zip=3.0-12build2
+RUN apt install \
+    \
+    -y \
+    apt-transport-https=2.4.14 \
+    curl=7.81.0-1ubuntu1.20 \
+    dirmngr=2.2.27-3ubuntu2.4 \
+    distro-info-data=0.52ubuntu0.9 \
+    gnupg-l10n=2.2.27-3ubuntu2.4 \
+    gnupg-utils=2.2.27-3ubuntu2.4 \
+    gnupg=2.2.27-3ubuntu2.4 \
+    gpg-agent=2.2.27-3ubuntu2.4 \
+    gpg-wks-client=2.2.27-3ubuntu2.4 \
+    gpg-wks-server=2.2.27-3ubuntu2.4 \
+    gpg=2.2.27-3ubuntu2.4 \
+    gpgconf=2.2.27-3ubuntu2.4 \
+    gpgsm=2.2.27-3ubuntu2.4 \
+    libassuan0=2.5.5-1build1 \
+    libbrotli1=1.0.9-2build6 \
+    libcurl4=7.81.0-1ubuntu1.20 \
+    libexpat1=2.4.7-1ubuntu0.6 \
+    libksba8=1.6.0-2ubuntu0.2 \
+    libldap-2.5-0=2.5.19+dfsg-0ubuntu0.22.04.1 \
+    libldap-common=2.5.19+dfsg-0ubuntu0.22.04.1 \
+    libmpdec3=2.5.1-2build2 \
+    libnghttp2-14=1.43.0-1ubuntu0.2 \
+    libnpth0=1.6-3build2 \
+    libpsl5=0.21.0-1.2build2 \
+    libpython3-stdlib=3.10.6-1~22.04.1 \
+    libpython3.10-minimal=3.10.12-1~22.04.10 \
+    libpython3.10-stdlib=3.10.12-1~22.04.10 \
+    libreadline8=8.1.2-1 \
+    librtmp1=2.4+20151223.gitfa8646d.1-2build4 \
+    libsasl2-2=2.1.27+dfsg2-3ubuntu1.2 \
+    libsasl2-modules-db=2.1.27+dfsg2-3ubuntu1.2 \
+    libsasl2-modules=2.1.27+dfsg2-3ubuntu1.2 \
+    libsqlite3-0=3.37.2-2ubuntu0.4 \
+    libssh-4=0.9.6-2ubuntu0.22.04.4 \
+    lsb-release=11.1.0ubuntu4 \
+    media-types=7.0.0 \
+    pinentry-curses=1.1.1-1build2 \
+    publicsuffix=20211207.1025-1 \
+    python3-minimal=3.10.6-1~22.04.1 \
+    python3.10-minimal=3.10.12-1~22.04.10 \
+    python3.10=3.10.12-1~22.04.10 \
+    python3=3.10.6-1~22.04.1 \
+    readline-common=8.1.2-1 \
+    unzip=6.0-26ubuntu3.2 \
+    zip=3.0-12build2
 
 # Prepare Docker installation
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
@@ -27,7 +120,82 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings
     && apt update
 
 # Install docker-ce docker-ce-cli containerd.io and dependencies at fixed versions
-RUN apt install -y apparmor=3.0.4-2ubuntu2.4 containerd.io=1.7.27-1 dbus-user-session=1.12.20-2ubuntu4.1 dbus=1.12.20-2ubuntu4.1 dmsetup=2:1.02.175-2.1ubuntu5 docker-buildx-plugin=0.25.0-1~ubuntu.22.04~jammy docker-ce-cli=5:28.3.2-1~ubuntu.22.04~jammy docker-ce-rootless-extras=5:28.3.2-1~ubuntu.22.04~jammy docker-ce=5:28.3.2-1~ubuntu.22.04~jammy docker-compose-plugin=2.38.2-1~ubuntu.22.04~jammy gir1.2-glib-2.0=1.72.0-1 git-man=1:2.34.1-1ubuntu1.15 git=1:2.34.1-1ubuntu1.15 iptables=1.8.7-1ubuntu5.2 less=590-1ubuntu0.22.04.3 libapparmor1=3.0.4-2ubuntu2.4 libargon2-1=0~20171227-0.3 libbsd0=0.11.5-1 libcbor0.8=0.8.0-2ubuntu1 libcryptsetup12=2:2.4.3-1ubuntu1.3 libcurl3-gnutls=7.81.0-1ubuntu1.20 libdbus-1-3=1.12.20-2ubuntu4.1 libdevmapper1.02.1=2:1.02.175-2.1ubuntu5 libedit2=3.1-20210910-1build1 liberror-perl=0.17029-1 libfido2-1=1.10.0-1 libgdbm-compat4=1.23-1 libgdbm6=1.23-1 libgirepository-1.0-1=1.72.0-1 libglib2.0-0=2.72.4-0ubuntu2.5 libglib2.0-data=2.72.4-0ubuntu2.5 libicu70=70.1-2 libip4tc2=1.8.7-1ubuntu5.2 libip6tc2=1.8.7-1ubuntu5.2 libjson-c5=0.15-3~ubuntu1.22.04.2 libkmod2=29-1ubuntu1 libltdl7=2.4.6-15build2 libmd0=1.0.4-1build1 libmnl0=1.0.4-3build2 libnetfilter-conntrack3=1.0.9-1 libnfnetlink0=1.0.1-3build3 libnftnl11=1.2.1-1build1 libnss-systemd=249.11-0ubuntu3.16 libpam-systemd=249.11-0ubuntu3.16 libperl5.34=5.34.0-3ubuntu1.4 libslirp0=4.6.1-1build1 libx11-6=2:1.7.5-1ubuntu0.3 libx11-data=2:1.7.5-1ubuntu0.3 libxau6=1:1.0.9-1build5 libxcb1=1.14-3ubuntu3 libxdmcp6=1:1.1.3-0ubuntu5 libxext6=2:1.3.4-1build1 libxml2=2.9.13+dfsg-1ubuntu0.7 libxmuu1=2:1.1.3-3 libxtables12=1.8.7-1ubuntu5.2 netbase=6.3 networkd-dispatcher=2.1-2ubuntu0.22.04.2 openssh-client=1:8.9p1-3ubuntu0.13 patch=2.7.6-7build2 perl-base=5.34.0-3ubuntu1.4 perl-modules-5.34=5.34.0-3ubuntu1.4 perl=5.34.0-3ubuntu1.4 pigz=2.6-1 python3-dbus=1.2.18-3build1 python3-gi=3.42.1-0ubuntu1 shared-mime-info=2.1-2 slirp4netns=1.0.1-2 systemd-sysv=249.11-0ubuntu3.16 systemd-timesyncd=249.11-0ubuntu3.16 systemd=249.11-0ubuntu3.16 xauth=1:1.1-1build2 xdg-user-dirs=0.17-2ubuntu4 xz-utils=5.2.5-2ubuntu1
+RUN apt install \
+    \
+    -y \
+    apparmor=3.0.4-2ubuntu2.4 \
+    containerd.io=1.7.27-1 \
+    dbus-user-session=1.12.20-2ubuntu4.1 \
+    dbus=1.12.20-2ubuntu4.1 \
+    dmsetup=2:1.02.175-2.1ubuntu5 \
+    docker-buildx-plugin=0.25.0-1~ubuntu.22.04~jammy \
+    docker-ce-cli=5:28.3.2-1~ubuntu.22.04~jammy \
+    docker-ce-rootless-extras=5:28.3.2-1~ubuntu.22.04~jammy \
+    docker-ce=5:28.3.2-1~ubuntu.22.04~jammy \
+    docker-compose-plugin=2.38.2-1~ubuntu.22.04~jammy \
+    gir1.2-glib-2.0=1.72.0-1 \
+    git-man=1:2.34.1-1ubuntu1.15 \
+    git=1:2.34.1-1ubuntu1.15 \
+    iptables=1.8.7-1ubuntu5.2 \
+    less=590-1ubuntu0.22.04.3 \
+    libapparmor1=3.0.4-2ubuntu2.4 \
+    libargon2-1=0~20171227-0.3 \
+    libbsd0=0.11.5-1 \
+    libcbor0.8=0.8.0-2ubuntu1 \
+    libcryptsetup12=2:2.4.3-1ubuntu1.3 \
+    libcurl3-gnutls=7.81.0-1ubuntu1.20 \
+    libdbus-1-3=1.12.20-2ubuntu4.1 \
+    libdevmapper1.02.1=2:1.02.175-2.1ubuntu5 \
+    libedit2=3.1-20210910-1build1 \
+    liberror-perl=0.17029-1 \
+    libfido2-1=1.10.0-1 \
+    libgdbm-compat4=1.23-1 \
+    libgdbm6=1.23-1 \
+    libgirepository-1.0-1=1.72.0-1 \
+    libglib2.0-0=2.72.4-0ubuntu2.5 \
+    libglib2.0-data=2.72.4-0ubuntu2.5 \
+    libicu70=70.1-2 \
+    libip4tc2=1.8.7-1ubuntu5.2 \
+    libip6tc2=1.8.7-1ubuntu5.2 \
+    libjson-c5=0.15-3~ubuntu1.22.04.2 \
+    libkmod2=29-1ubuntu1 \
+    libltdl7=2.4.6-15build2 \
+    libmd0=1.0.4-1build1 \
+    libmnl0=1.0.4-3build2 \
+    libnetfilter-conntrack3=1.0.9-1 \
+    libnfnetlink0=1.0.1-3build3 \
+    libnftnl11=1.2.1-1build1 \
+    libnss-systemd=249.11-0ubuntu3.16 \
+    libpam-systemd=249.11-0ubuntu3.16 \
+    libperl5.34=5.34.0-3ubuntu1.4 \
+    libslirp0=4.6.1-1build1 \
+    libx11-6=2:1.7.5-1ubuntu0.3 \
+    libx11-data=2:1.7.5-1ubuntu0.3 \
+    libxau6=1:1.0.9-1build5 \
+    libxcb1=1.14-3ubuntu3 \
+    libxdmcp6=1:1.1.3-0ubuntu5 \
+    libxext6=2:1.3.4-1build1 \
+    libxml2=2.9.13+dfsg-1ubuntu0.7 \
+    libxmuu1=2:1.1.3-3 \
+    libxtables12=1.8.7-1ubuntu5.2 \
+    netbase=6.3 \
+    networkd-dispatcher=2.1-2ubuntu0.22.04.2 \
+    openssh-client=1:8.9p1-3ubuntu0.13 \
+    patch=2.7.6-7build2 \
+    perl-base=5.34.0-3ubuntu1.4 \
+    perl-modules-5.34=5.34.0-3ubuntu1.4 \
+    perl=5.34.0-3ubuntu1.4 \
+    pigz=2.6-1 \
+    python3-dbus=1.2.18-3build1 \
+    python3-gi=3.42.1-0ubuntu1 \
+    shared-mime-info=2.1-2 \
+    slirp4netns=1.0.1-2 \
+    systemd-sysv=249.11-0ubuntu3.16 \
+    systemd-timesyncd=249.11-0ubuntu3.16 \
+    systemd=249.11-0ubuntu3.16 \
+    xauth=1:1.1-1build2 \
+    xdg-user-dirs=0.17-2ubuntu4 \
+    xz-utils=5.2.5-2ubuntu1
 
 # Clean up apt cache
 RUN rm -rf /var/lib/apt/lists/*
@@ -36,18 +204,129 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN python3 -m pip uninstall -y conda conda-package-handling conda_index
 
 # Install specific versions of pip and setuptools
-RUN python3 -m pip install -U pip==25.1.1 setuptools==80.8.0
+RUN python3 -m pip install \
+    -U \
+    pip==25.1.1 \
+    setuptools==80.8.0
 
 # Install dependencies of NVFlare at fixed versions
-RUN python3 -m pip install --upgrade psutil==7.0.0
-RUN python3 -m pip install Flask==3.0.2 Flask-JWT-Extended==4.6.0 Flask-SQLAlchemy==3.1.1 PyJWT==2.10.1 SQLAlchemy==2.0.16 Werkzeug==3.0.1 blinker==1.9.0 docker==7.1.0 greenlet==3.2.2 grpcio==1.62.1 gunicorn==23.0.0 itsdangerous==2.2.0 msgpack==1.1.0 protobuf==4.24.4 pyhocon==0.3.61 pyparsing==3.2.3 websockets==15.0.1
+RUN python3 -m pip install \
+    --upgrade \
+    psutil==7.0.0
+RUN python3 -m pip install \
+    Flask==3.0.2 \
+    Flask-JWT-Extended==4.6.0 \
+    Flask-SQLAlchemy==3.1.1 \
+    PyJWT==2.10.1 \
+    SQLAlchemy==2.0.16 \
+    Werkzeug==3.0.1 \
+    blinker==1.9.0 \
+    docker==7.1.0 \
+    greenlet==3.2.2 \
+    grpcio==1.62.1 \
+    gunicorn==23.0.0 \
+    itsdangerous==2.2.0 \
+    msgpack==1.1.0 \
+    protobuf==4.24.4 \
+    pyhocon==0.3.61 \
+    pyparsing==3.2.3 \
+    websockets==15.0.1
 
 # Install additional Python packages for application code at defined versions
-RUN python3 -m pip install Deprecated==1.2.18 SimpleITK==2.5.0 absl-py==2.2.2 aiohttp==3.11.18 aiosignal==1.3.2 async-timeout==5.0.1 cachetools==5.5.2 contourpy==1.3.2 cycler==0.12.1 et-xmlfile==2.0.0 fonttools==4.58.0 frozenlist==1.6.0 google-auth-oauthlib==1.2.2 google-auth==2.40.2 huggingface_hub==0.29.3 datasets==3.4.1 coral_pytorch==1.4.0 humanize==4.12.3 joblib==1.5.1 kiwisolver==1.4.8 lightning-utilities==0.14.3 markdown-it-py==3.0.0 markdown==3.8 matplotlib==3.9.2 mdurl==0.1.2 monai==1.4.0 multidict==6.4.4 nibabel==5.3.2 oauthlib==3.2.2 openpyxl==3.1.5 pandas==2.2.3 numpy==1.26.4 pyasn1-modules==0.4.2 pyasn1==0.6.1 pydicom==3.0.1 python-dateutil==2.9.0.post0 x-transformers==2.3.5 pytorch-lightning==2.4.0 requests==2.32.3 requests-oauthlib==2.0.0 rich==14.0.0 rsa==4.9.1 safetensors==0.5.3 scikit-learn==1.5.2 scipy==1.15.3 seaborn==0.13.2 wandb==0.18.6 einops==0.8.0 shellingham==1.5.4 tensorboard-data-server==0.7.2 tensorboard-plugin-wit==1.8.1 tensorboard==2.19.0 threadpoolctl==3.6.0 timm==1.0.15 torchio==0.20.1 torchmetrics==1.7.1 torchvision==0.17.2 torchaudio==2.2.2 tqdm==4.67.0 typer==0.15.4 tzdata==2025.2 wrapt==1.17.2 yarl==1.20.0 aiohappyeyeballs==2.6.1 annotated-types==0.7.0 dill==0.3.8 docker-pycreds==0.4.0 einx==0.3.0 frozendict==2.4.6 gitdb==4.0.12 gitpython==3.1.44 hf-xet==1.1.2 importlib-resources==6.5.2 loguru==0.7.3 multiprocess==0.70.16 propcache==0.3.1 pyarrow==20.0.0 pydantic==2.11.5 pydantic-core==2.33.2 sentry-sdk==2.29.1 setproctitle==1.3.6 smmap==5.0.2 typing-extensions==4.13.2 typing-inspection==0.4.1 xxhash==3.5.0
+RUN python3 -m pip install \
+    Deprecated==1.2.18 \
+    SimpleITK==2.5.0 \
+    absl-py==2.2.2 \
+    aiohttp==3.11.18 \
+    aiosignal==1.3.2 \
+    async-timeout==5.0.1 \
+    cachetools==5.5.2 \
+    contourpy==1.3.2 \
+    cycler==0.12.1 \
+    et-xmlfile==2.0.0 \
+    fonttools==4.58.0 \
+    frozenlist==1.6.0 \
+    google-auth-oauthlib==1.2.2 \
+    google-auth==2.40.2 \
+    huggingface_hub==0.29.3 \
+    datasets==3.4.1 \
+    coral_pytorch==1.4.0 \
+    humanize==4.12.3 \
+    joblib==1.5.1 \
+    kiwisolver==1.4.8 \
+    lightning-utilities==0.14.3 \
+    markdown-it-py==3.0.0 \
+    markdown==3.8 \
+    matplotlib==3.9.2 \
+    mdurl==0.1.2 \
+    monai==1.4.0 \
+    multidict==6.4.4 \
+    nibabel==5.3.2 \
+    oauthlib==3.2.2 \
+    openpyxl==3.1.5 \
+    pandas==2.2.3 \
+    numpy==1.26.4 \
+    pyasn1-modules==0.4.2 \
+    pyasn1==0.6.1 \
+    pydicom==3.0.1 \
+    python-dateutil==2.9.0.post0 \
+    x-transformers==2.3.5 \
+    pytorch-lightning==2.4.0 \
+    requests==2.32.3 \
+    requests-oauthlib==2.0.0 \
+    rich==14.0.0 \
+    rsa==4.9.1 \
+    safetensors==0.5.3 \
+    scikit-learn==1.5.2 \
+    scipy==1.15.3 \
+    seaborn==0.13.2 \
+    wandb==0.18.6 \
+    einops==0.8.0 \
+    shellingham==1.5.4 \
+    tensorboard-data-server==0.7.2 \
+    tensorboard-plugin-wit==1.8.1 \
+    tensorboard==2.19.0 \
+    threadpoolctl==3.6.0 \
+    timm==1.0.15 \
+    torchio==0.20.1 \
+    torchmetrics==1.7.1 \
+    torchvision==0.17.2 \
+    torchaudio==2.2.2 \
+    tqdm==4.67.0 \
+    typer==0.15.4 \
+    tzdata==2025.2 \
+    wrapt==1.17.2 \
+    yarl==1.20.0 \
+    aiohappyeyeballs==2.6.1 \
+    annotated-types==0.7.0 \
+    dill==0.3.8 \
+    docker-pycreds==0.4.0 \
+    einx==0.3.0 \
+    frozendict==2.4.6 \
+    gitdb==4.0.12 \
+    gitpython==3.1.44 \
+    hf-xet==1.1.2 \
+    importlib-resources==6.5.2 \
+    loguru==0.7.3 \
+    multiprocess==0.70.16 \
+    propcache==0.3.1 \
+    pyarrow==20.0.0 \
+    pydantic==2.11.5 \
+    pydantic-core==2.33.2 \
+    sentry-sdk==2.29.1 \
+    setproctitle==1.3.6 \
+    smmap==5.0.2 \
+    typing-extensions==4.13.2 \
+    typing-inspection==0.4.1 \
+    xxhash==3.5.0
 
 # Install packages needed for testing and for listing licenses of installed packages
-RUN python3 -m pip install coverage==7.8.2 mock==5.2.0
-RUN python3 -m pip install pip-licenses==5.0.0 prettytable==3.16.0
+RUN python3 -m pip install \
+    coverage==7.8.2 \
+    mock==5.2.0
+RUN python3 -m pip install \
+    pip-licenses==5.0.0 \
+    prettytable==3.16.0
 
 # Clean up pip cache
 RUN python3 -m pip cache purge
@@ -57,12 +336,14 @@ WORKDIR /workspace/
 COPY ./MediSwarm/docker_config/NVFlare /workspace/nvflare
 ## use startup kit template in the dashboard
 COPY ./MediSwarm/docker_config/master_template.yml /workspace/nvflare/nvflare/lighter/impl/
-RUN python3 -m pip install /workspace/nvflare
+RUN python3 -m pip install \
+    /workspace/nvflare
 RUN rm -rf /workspace/nvflare
 
 # Install the ODELIA controller package from local source
 COPY ./MediSwarm/controller /workspace/controller
-RUN python3 -m pip install /workspace/controller
+RUN python3 -m pip install \
+    /workspace/controller
 RUN rm -rf /workspace/controller
 
 # Copy the source code for local training and deploying to the swarm

--- a/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
+++ b/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
@@ -12,14 +12,14 @@ def save_file(contents: str, filename: str) -> None:
         outfile.write(contents)
 
 
-def parse_apt_versions(installlog: str) -> str:
+def parse_apt_versions(installlog: str) -> dict:
     versions = {}
     for line in installlog.splitlines():
-        if re.match('.*Get:[0-9]* http.*', line):
-            blocks = line.split(' ')
-            if len(blocks) > 9:
-                package = blocks[6]
-                version = blocks[8]
+        if "Get:" in line:
+            match = re.search(r' ([a-zA-Z0-9\-\+\.]+)[/\s]([^\s]+) ', line)
+            if match:
+                package = match.group(1)
+                version = match.group(2)
                 if package in versions and versions[package] != version:
                     print(f'Conflicting versions of {package} found: {versions[package]} and {version} found, using the latter.')
                 versions[package] = version

--- a/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
+++ b/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
@@ -14,16 +14,17 @@ def save_file(contents: str, filename: str) -> None:
 
 def parse_apt_versions(installlog: str) -> dict:
     versions = {}
+    pattern = re.compile(r'Get:.*? ([a-z0-9\-\+\.]+)(?:/[^ ]*)? ([0-9a-zA-Z\:\~\.\+\-]+) ')
     for line in installlog.splitlines():
-        if "Get:" in line:
-            match = re.search(r' ([a-zA-Z0-9\-\+\.]+)[/\s]([^\s]+) ', line)
-            if match:
-                package = match.group(1)
-                version = match.group(2)
-                if package in versions and versions[package] != version:
-                    print(f'Conflicting versions of {package} found: {versions[package]} and {version} found, using the latter.')
-                versions[package] = version
+        match = pattern.search(line)
+        if match:
+            package = match.group(1)
+            version = match.group(2)
+            if package in versions and versions[package] != version:
+                print(f'Conflicting versions of {package} found: {versions[package]} and {version} found, using the latter.')
+            versions[package] = version
     return versions
+
 
 
 def add_apt_versions(dockerfile: str, versions: dict) -> str:

--- a/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
+++ b/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
@@ -3,6 +3,11 @@
 import re
 import sys
 
+LINE_BREAK_IN_COMMAND = ' \\\n    '
+LINE_BREAK_REPLACEMENT = ' λινε βρεακ ρεπλαζεμεντ '
+APT_INSTALL_COMMAND = 'RUN apt install -y'
+APT_INSTALL_REPLACEMENT = 'ΡΥΝ απτ ινσταλλ -υ'
+
 def load_file(filename: str) -> str:
     with open(filename, 'r') as infile:
         return infile.read()
@@ -14,38 +19,34 @@ def save_file(contents: str, filename: str) -> None:
 
 def parse_apt_versions(installlog: str) -> dict:
     versions = {}
-    pattern = re.compile(r'Get:.*? ([a-z0-9\-\+\.]+)(?:/[^ ]*)? ([0-9a-zA-Z\:\~\.\+\-]+) ')
     for line in installlog.splitlines():
-        match = pattern.search(line)
-        if match:
-            package = match.group(1)
-            version = match.group(2)
-            if package in versions and versions[package] != version:
-                print(f'Conflicting versions of {package} found: {versions[package]} and {version} found, using the latter.')
-            versions[package] = version
+        if re.match('.*Get:[0-9]* http.*', line):
+            blocks = line.split(' ')
+            if len(blocks) > 9:
+                package = blocks[6]
+                version = blocks[8]
+                if package in versions and versions[package] != version:
+                    print(f'Conflicting versions of {package} found: {versions[package]} and {version} found, using the latter.')
+                versions[package] = version
     return versions
 
 
-
 def add_apt_versions(dockerfile: str, versions: dict) -> str:
-    dockerfile = dockerfile.replace('RUN apt install', 'RUN_apt_install')
+    dockerfile = dockerfile.replace(LINE_BREAK_IN_COMMAND, LINE_BREAK_REPLACEMENT)
+    dockerfile = dockerfile.replace(APT_INSTALL_COMMAND, APT_INSTALL_REPLACEMENT)
     outlines = []
     for line in dockerfile.splitlines():
-        if line.startswith('RUN_apt_install'):
+        if line.startswith(APT_INSTALL_REPLACEMENT):
             outline = '' + line
             for package, version in versions.items():
                 outline = outline.replace(f' {package} ', f' {package}={version} ')
                 outline = re.sub(f' {package}$', f' {package}={version}', outline)
-            parts = outline.split()
-            if len(parts) > 3:
-                header = " ".join(parts[:3])
-                pkgs = parts[3:]
-                outline = header + " \\\n    " + " \\\n    ".join(pkgs)
             outlines.append(outline)
         else:
             outlines.append(line)
     dockerfile = '\n'.join(outlines) + '\n'
-    dockerfile = dockerfile.replace('RUN_apt_install', 'RUN apt install')
+    dockerfile = dockerfile.replace(APT_INSTALL_REPLACEMENT, APT_INSTALL_COMMAND)
+    dockerfile = dockerfile.replace(LINE_BREAK_REPLACEMENT, LINE_BREAK_IN_COMMAND)
     return dockerfile
 
 
@@ -58,6 +59,9 @@ def report_non_fixed_versions(dockerfile: str, versions: dict) -> None:
 if __name__ == '__main__':
     dockerfile = load_file(sys.argv[1])
     installlog = load_file(sys.argv[2])
+    if LINE_BREAK_REPLACEMENT in dockerfile or APT_INSTALL_REPLACEMENT in dockerfile:
+        raise Exception('Line break replacement {LINE_BREAK_REPLACEMENT} or apt command replacement {APT_INSTALL_REPLACEMENT} in Dockerfile, cannot process it.')
+
     versions = parse_apt_versions(installlog)
     report_non_fixed_versions(dockerfile, versions)
     dockerfile = add_apt_versions(dockerfile, versions)

--- a/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
+++ b/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
@@ -35,6 +35,11 @@ def add_apt_versions(dockerfile: str, versions: dict) -> str:
             for package, version in versions.items():
                 outline = outline.replace(f' {package} ', f' {package}={version} ')
                 outline = re.sub(f' {package}$', f' {package}={version}', outline)
+            parts = outline.split()
+            if len(parts) > 3:
+                header = " ".join(parts[:3])
+                pkgs = parts[3:]
+                outline = header + " \\\n    " + " \\\n    ".join(pkgs)
             outlines.append(outline)
         else:
             outlines.append(line)

--- a/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
+++ b/scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py
@@ -3,19 +3,10 @@
 import re
 import sys
 
-LINE_BREAK_IN_COMMAND = ' \\\n    '
-LINE_BREAK_REPLACEMENT = ' λινε βρεακ ρεπλαζεμεντ '
+from dockerfile_update_removeVersionApt import LINE_BREAK_IN_COMMAND, LINE_BREAK_REPLACEMENT, load_file, save_file
+
 APT_INSTALL_COMMAND = 'RUN apt install -y'
 APT_INSTALL_REPLACEMENT = 'ΡΥΝ απτ ινσταλλ -υ'
-
-def load_file(filename: str) -> str:
-    with open(filename, 'r') as infile:
-        return infile.read()
-
-def save_file(contents: str, filename: str) -> None:
-    with open(filename, 'w') as outfile:
-        outfile.write(contents)
-
 
 def parse_apt_versions(installlog: str) -> dict:
     versions = {}

--- a/scripts/dev_utils/dockerfile_update_removeVersionApt.py
+++ b/scripts/dev_utils/dockerfile_update_removeVersionApt.py
@@ -3,6 +3,9 @@
 import re
 import sys
 
+LINE_BREAK_IN_COMMAND = ' \\\n    '
+LINE_BREAK_REPLACEMENT = ' λινε βρεακ ρεπλαζεμεντ '
+
 def load_file(filename: str) -> str:
     with open(filename, 'r') as infile:
         return infile.read()
@@ -12,23 +15,22 @@ def save_file(contents: str, filename: str) -> None:
         outfile.write(contents)
 
 
-def remove_apt_versions(dockerfile: str) -> str:
+def remove_apt_versions(contents: str) -> str:
+    contents = contents.replace(LINE_BREAK_IN_COMMAND, LINE_BREAK_REPLACEMENT)
     output = []
-    for line in dockerfile.splitlines():
-        if line.startswith('RUN apt install'):
+    for line in contents.splitlines():
+        if line.startswith('RUN apt install -y'):
             out_line = re.sub('=[^ ]*', '', line)
-            parts = out_line.split()
-            if len(parts) > 3:
-                header = " ".join(parts[:3])
-                pkgs = parts[3:]
-                out_line = header + " \\\n    " + " \\\n    ".join(pkgs)
             output.append(out_line)
         else:
             output.append(line)
-    return '\n'.join(output)
-
+    output = '\n'.join(output) + '\n'
+    output = output.replace(LINE_BREAK_REPLACEMENT, LINE_BREAK_IN_COMMAND)
+    return output
 
 if __name__ == '__main__':
-    dockerfile = load_file(sys.argv[1])
-    dockerfile = remove_apt_versions(dockerfile)
-    save_file(dockerfile, sys.argv[1])
+    contents = load_file(sys.argv[1])
+    if LINE_BREAK_REPLACEMENT in contents:
+        raise Exception('Line break replacement {LINE_BREAK_REPLACEMENT} in Dockerfile, cannot process it.')
+    contents = remove_apt_versions(contents)
+    save_file(contents, sys.argv[1])

--- a/scripts/dev_utils/dockerfile_update_removeVersionApt.py
+++ b/scripts/dev_utils/dockerfile_update_removeVersionApt.py
@@ -17,6 +17,11 @@ def remove_apt_versions(dockerfile: str) -> str:
     for line in dockerfile.splitlines():
         if line.startswith('RUN apt install'):
             out_line = re.sub('=[^ ]*', '', line)
+            parts = out_line.split()
+            if len(parts) > 3:
+                header = " ".join(parts[:3])
+                pkgs = parts[3:]
+                out_line = header + " \\\n    " + " \\\n    ".join(pkgs)
             output.append(out_line)
         else:
             output.append(line)


### PR DESCRIPTION
This pull request focuses on improving readability and maintainability of the `docker_config/Dockerfile_ODELIA` by reformatting `RUN` commands and enhancing Python utility scripts to handle versioned package installations more effectively. The most important changes include reformatting long `RUN` commands in the Dockerfile, updating utility scripts for parsing and formatting package versions, and ensuring consistency in version handling.

### Dockerfile Improvements:
* Reformatted `RUN` commands in `docker_config/Dockerfile_ODELIA` to use multi-line syntax for better readability and maintainability. This change applies to package installations, Python dependencies, and local source installations. [[1]](diffhunk://#diff-ad08360207d2a53ed8e431949dc943265dbbbdfa78a59e5bbeaf7111a459b04fL15-R123) [[2]](diffhunk://#diff-ad08360207d2a53ed8e431949dc943265dbbbdfa78a59e5bbeaf7111a459b04fL30-R210) [[3]](diffhunk://#diff-ad08360207d2a53ed8e431949dc943265dbbbdfa78a59e5bbeaf7111a459b04fL39-R341) [[4]](diffhunk://#diff-ad08360207d2a53ed8e431949dc943265dbbbdfa78a59e5bbeaf7111a459b04fL60-R358)

### Utility Script Enhancements:
* Updated the `parse_apt_versions` function in `scripts/dev_utils/dockerfile_update_addAptVersionNumbers.py` to use a regex for extracting package versions, improving accuracy and robustness.
* Modified the `add_apt_versions` function in the same script to reformat `RUN` commands with multi-line syntax when adding version numbers.
* Enhanced the `remove_apt_versions` function in `scripts/dev_utils/dockerfile_update_removeVersionApt.py` to reformat `RUN` commands into multi-line syntax after removing version numbers.