### PR TITLE
Fix usage of GPU when running all tests

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -96,3 +96,8 @@ jobs:
         continue-on-error: false
         run: |
           ./runIntegrationTests.sh run_data_access_preflight_check
+
+      - name: Run dummy training in swarm
+        continue-on-error: false
+        run: |
+          ./runIntegrationTests.sh run_dummy_training_in_swarm

--- a/assets/readme/README.developer.md
+++ b/assets/readme/README.developer.md
@@ -26,6 +26,11 @@ The project description specifies the swarm nodes etc. to be used for a swarm tr
 
 ## Running Tests
 
+* If you have multiple GPUs, use `GPU_FOR_TESTING="device=0" (or another device)
+* If you have a sliced multiple GPUs, use `GPU_FOR_TESTING="device=0:0" (or another slice)
+* Otherwise, leave this environment variable unset to use all GPUs.
+* To run only specific tests, look at the options at the end of the script.
+
    ```bash
    ./runIntegrationTests.sh
    ```

--- a/assets/readme/README.developer.md
+++ b/assets/readme/README.developer.md
@@ -42,9 +42,11 @@ You should see
 3. output of a successful proof-of-concept run of a dummy training with two nodes
 4. output of a successful simulation run of a 3D CNN training using synthetic data with two nodes
 5. output of a set of startup kits being generated
-6. output of a Docker/GPU preflight check using one of the startup kits
-7. output of a data access preflight check using one of the startup kits
-8. output of a dummy training run in a swarm consisting of one server and two client nodes
+6. output of pushing the Docker image to a local registry and pulling it from there (takes several minutes)
+7. output of a Docker/GPU preflight check using one of the startup kits
+8. output of a data access preflight check using one of the startup kits
+9. output of an outdated client startup kit failing to connect to the server
+10. output of a dummy training run in a swarm consisting of one server and two client nodes
 
 Optionally, uncomment running NVFlare unit tests.
 

--- a/assets/readme/README.developer.md
+++ b/assets/readme/README.developer.md
@@ -48,8 +48,6 @@ You should see
 9. output of an outdated client startup kit failing to connect to the server
 10. output of a dummy training run in a swarm consisting of one server and two client nodes
 
-Optionally, uncomment running NVFlare unit tests.
-
 ## Distributing Startup Kits
 
 Distribute the startup kits to the clients.

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -197,7 +197,7 @@ run_docker_gpu_preflight_check () {
     echo "[Run] Docker/GPU preflight check (local dummy training via startup kit) ..."
     cd "$PROJECT_DIR/prod_00/client_A/startup/"
     CONSOLE_OUTPUT=docker_gpu_preflight_check_console_output.txt
-    ./docker.sh --scratch_dir "$SCRATCH_DIR"/client_A --GPU device=$GPU_FOR_TESTING --dummy_training --no_pull 2>&1 | tee "$CONSOLE_OUTPUT"
+    ./docker.sh --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --dummy_training --no_pull 2>&1 | tee "$CONSOLE_OUTPUT"
 
     if grep -q "Epoch 1: 100%" "$CONSOLE_OUTPUT" && grep -q "Training completed successfully" "$CONSOLE_OUTPUT"; then
         echo "Expected output of Docker/GPU preflight check found"
@@ -216,7 +216,7 @@ run_data_access_preflight_check () {
     cd "$PROJECT_DIR"/prod_00
     cd client_A/startup
     CONSOLE_OUTPUT=data_access_preflight_check_console_output.txt
-    ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU device=$GPU_FOR_TESTING --preflight_check --no_pull 2>&1 | tee $CONSOLE_OUTPUT
+    ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --preflight_check --no_pull 2>&1 | tee $CONSOLE_OUTPUT
 
     if grep -q "Train set: 18, Val set: 6" "$CONSOLE_OUTPUT" && grep -q "Epoch 0: 100%" "$CONSOLE_OUTPUT"; then
         echo "Expected output of Docker/GPU preflight check found"
@@ -246,10 +246,10 @@ start_server_and_clients () {
     sleep 10
 
     cd client_A/startup
-    ./docker.sh --no_pull --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU device=$GPU_FOR_TESTING --start_client
+    ./docker.sh --no_pull --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --start_client
     cd ../..
     cd client_B/startup
-    ./docker.sh --no_pull --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_B --GPU device=$GPU_FOR_TESTING --start_client
+    ./docker.sh --no_pull --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_B --GPU "$GPU_FOR_TESTING" --start_client
     sleep 8
 
     cd "$CWD"
@@ -301,7 +301,7 @@ verify_wrong_client_does_not_connect () {
     sed -i 's#CONTAINER_NAME=odelia_swarm_client_client_A_095c1b7#CONTAINER_NAME=odelia_swarm_client_client_A_'$CONTAINER_VERSION_SUFFIX'#' client_A/startup/docker.sh
 
     cd client_A/startup
-    ./docker.sh --no_pull --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU device=$GPU_FOR_TESTING --start_client
+    ./docker.sh --no_pull --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --start_client
     cd ../..
 
     sleep 20

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -507,7 +507,6 @@ case "$1" in
         run_dummy_training_in_swarm
         kill_server_and_clients
         cleanup_temporary_data
-        # TODO add to CI if we want this (currently not working)
         ;;
 
     all | "")

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -236,8 +236,8 @@ run_3dcnn_simulation_mode () {
 }
 
 
-start_server_and_clients () {
-    echo "[Run] Start server and client Docker containers ..."
+start_server () {
+    echo "[Run] Start server Docker container ..."
 
     cd "$PROJECT_DIR"/prod_00
     cd localhost/startup
@@ -245,6 +245,14 @@ start_server_and_clients () {
     cd ../..
     sleep 10
 
+    cd "$CWD"
+}
+
+
+start_clients () {
+    echo "[Run] Start client Docker containers ..."
+
+    cd "$PROJECT_DIR"/prod_00
     cd client_A/startup
     ./docker.sh --no_pull --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --start_client
     cd ../..
@@ -253,6 +261,11 @@ start_server_and_clients () {
     sleep 8
 
     cd "$CWD"
+}
+
+start_server_and_clients () {
+    start_server()
+    start_clients()
 }
 
 

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -516,7 +516,7 @@ case "$1" in
         run_dummy_training_standalone
         run_dummy_training_simulation_mode
         run_dummy_training_poc_mode
-        # run_nvflare_unit_tests  # uncomment to enable NVFlare unit tests
+        run_nvflare_unit_tests
         create_synthetic_data
         run_3dcnn_simulation_mode
         create_startup_kits_and_check_contained_files

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -337,6 +337,7 @@ verify_wrong_client_does_not_connect () {
     fi
 
     docker kill odelia_swarm_server_flserver_$CONTAINER_VERSION_SUFFIX odelia_swarm_client_client_A_$CONTAINER_VERSION_SUFFIX
+    sleep 3
     rm -rf "$PROJECT_DIR"/prod_wrong_client
 
     cd "$CWD"

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -264,8 +264,8 @@ start_clients () {
 }
 
 start_server_and_clients () {
-    start_server()
-    start_clients()
+    start_server
+    start_clients
 }
 
 

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -524,8 +524,8 @@ case "$1" in
         kill_registry_docker
         run_docker_gpu_preflight_check
         run_data_access_preflight_check
-        start_server_and_clients
         verify_wrong_client_does_not_connect
+        start_server_and_clients
         run_dummy_training_in_swarm
         kill_server_and_clients
         cleanup_temporary_data


### PR DESCRIPTION
This PR 
* fixes the problem that ./runIntegrationTests.sh did not allow running all tests due to inconsistent use of the GPU_FOR_TESTING environment variable
* extends the documentation of the integration tests
* includes the NVFlare unit tests in running "all" tests
* includes the swarm tests in running "all" tests