### PR TITLE
Build Docker image using git archive

### DIFF
--- a/_cacheAndCopyPretrainedModelWeights.sh
+++ b/_cacheAndCopyPretrainedModelWeights.sh
@@ -26,6 +26,7 @@ verify_files () {
     if echo 2e405cee1bad14912278296d4f42e993 $MODEL_WEIGHTS_FILE | md5sum --check - && echo 153d2db1c329326a2d9f881317ea942e $MODEL_LICENSE_FILE | md5sum --check -; then
         echo "File contents verified successfully."
     else
+        echo "Unexpected file contents."
         exit 1
     fi
 }

--- a/_cacheAndCopyPretrainedModelWeights.sh
+++ b/_cacheAndCopyPretrainedModelWeights.sh
@@ -2,27 +2,39 @@
 
 set -e
 
-SOURCE_DIR=$1
-TARGET_DIR=$2
-
 # prepare pre-trained model weights for being included in Docker image
 
+SOURCE_DIR=$1
+TARGET_DIR=$2
 MODEL_WEIGHTS_FILE=$SOURCE_DIR'/docker_config/torch_home_cache/hub/checkpoints/dinov2_vits14_pretrain.pth'
 MODEL_LICENSE_FILE=$SOURCE_DIR'/docker_config/torch_home_cache/hub/facebookresearch_dinov2_main/LICENSE'
-if [[ ! -f $MODEL_WEIGHTS_FILE || ! -f $MODEL_LICENSE_FILE ]]; then
-    echo "Pre-trained model not available. Attempting download"
-    HUBDIR=$(dirname $(dirname $MODEL_LICENSE_FILE))
-    mkdir -p $(dirname $MODEL_WEIGHTS_FILE)
-    wget https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_pretrain.pth -O $MODEL_WEIGHTS_FILE
-    wget https://github.com/facebookresearch/dinov2/archive/refs/heads/main.zip -O /tmp/dinov2.zip
-    unzip /tmp/dinov2.zip -d $HUBDIR
-    mv $HUBDIR/dinov2-main $HUBDIR/$(basename $(dirname $MODEL_LICENSE_FILE))
-    touch $HUBDIR/trusted_list
-fi
 
-if echo 2e405cee1bad14912278296d4f42e993 $MODEL_WEIGHTS_FILE | md5sum --check - && echo 153d2db1c329326a2d9f881317ea942e $MODEL_LICENSE_FILE | md5sum --check -; then
+cache_files () {
+    if [[ ! -f $MODEL_WEIGHTS_FILE || ! -f $MODEL_LICENSE_FILE ]]; then
+        echo "Pre-trained model not available. Attempting download"
+        HUBDIR=$(dirname $(dirname $MODEL_LICENSE_FILE))
+        mkdir -p $(dirname $MODEL_WEIGHTS_FILE)
+        wget https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_pretrain.pth -O $MODEL_WEIGHTS_FILE
+        wget https://github.com/facebookresearch/dinov2/archive/refs/heads/main.zip -O /tmp/dinov2.zip
+        unzip /tmp/dinov2.zip -d $HUBDIR
+        mv $HUBDIR/dinov2-main $HUBDIR/$(basename $(dirname $MODEL_LICENSE_FILE))
+        touch $HUBDIR/trusted_list
+    fi
+}
+
+verify_files () {
+    if echo 2e405cee1bad14912278296d4f42e993 $MODEL_WEIGHTS_FILE | md5sum --check - && echo 153d2db1c329326a2d9f881317ea942e $MODEL_LICENSE_FILE | md5sum --check -; then
+        echo "File contents verified successfully."
+    else
+        exit 1
+    fi
+}
+
+copy_files() {
     cp -r $SOURCE_DIR/docker_config/torch_home_cache $TARGET_DIR/torch_home_cache
-else
-    exit 1
-fi
-chmod a+rX $TARGET_DIR/torch_home_cache -R
+    chmod a+rX $TARGET_DIR/torch_home_cache -R
+}
+
+cache_files
+verify_files
+copy_files

--- a/_cacheAndCopyPretrainedModelWeights.sh
+++ b/_cacheAndCopyPretrainedModelWeights.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+SOURCE_DIR=$1
+TARGET_DIR=$2
+
+# prepare pre-trained model weights for being included in Docker image
+
+MODEL_WEIGHTS_FILE=$SOURCE_DIR'/docker_config/torch_home_cache/hub/checkpoints/dinov2_vits14_pretrain.pth'
+MODEL_LICENSE_FILE=$SOURCE_DIR'/docker_config/torch_home_cache/hub/facebookresearch_dinov2_main/LICENSE'
+if [[ ! -f $MODEL_WEIGHTS_FILE || ! -f $MODEL_LICENSE_FILE ]]; then
+    echo "Pre-trained model not available. Attempting download"
+    HUBDIR=$(dirname $(dirname $MODEL_LICENSE_FILE))
+    mkdir -p $(dirname $MODEL_WEIGHTS_FILE)
+    wget https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_pretrain.pth -O $MODEL_WEIGHTS_FILE
+    wget https://github.com/facebookresearch/dinov2/archive/refs/heads/main.zip -O /tmp/dinov2.zip
+    unzip /tmp/dinov2.zip -d $HUBDIR
+    mv $HUBDIR/dinov2-main $HUBDIR/$(basename $(dirname $MODEL_LICENSE_FILE))
+    touch $HUBDIR/trusted_list
+fi
+
+if echo 2e405cee1bad14912278296d4f42e993 $MODEL_WEIGHTS_FILE | md5sum --check - && echo 153d2db1c329326a2d9f881317ea942e $MODEL_LICENSE_FILE | md5sum --check -; then
+    cp -r $SOURCE_DIR/docker_config/torch_home_cache $TARGET_DIR/torch_home_cache
+else
+    exit 1
+fi
+chmod a+rX $TARGET_DIR/torch_home_cache -R

--- a/buildDockerImageAndStartupKits.sh
+++ b/buildDockerImageAndStartupKits.sh
@@ -44,28 +44,7 @@ chmod a+rX . -R
 sed -i 's#__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_DOCKER_IMAGE__#'$VERSION'#' docker_config/master_template.yml
 sed -i 's#__REPLACED_BY_CONTAINER_VERSION_IDENTIFIER_WHEN_BUILDING_DOCKER_IMAGE__#'$CONTAINER_VERSION_ID'#' docker_config/master_template.yml
 
-# prepare pre-trained model weights for being included in Docker image
-
-MODEL_WEIGHTS_FILE=$CWD'/docker_config/torch_home_cache/hub/checkpoints/dinov2_vits14_pretrain.pth'
-MODEL_LICENSE_FILE=$CWD'/docker_config/torch_home_cache/hub/facebookresearch_dinov2_main/LICENSE'
-if [[ ! -f $MODEL_WEIGHTS_FILE || ! -f $MODEL_LICENSE_FILE ]]; then
-    echo "Pre-trained model not available. Attempting download"
-    HUBDIR=$(dirname $(dirname $MODEL_LICENSE_FILE))
-    mkdir -p $(dirname $MODEL_WEIGHTS_FILE)
-    wget https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_pretrain.pth -O $MODEL_WEIGHTS_FILE
-    wget https://github.com/facebookresearch/dinov2/archive/refs/heads/main.zip -O /tmp/dinov2.zip
-    unzip /tmp/dinov2.zip -d $HUBDIR
-    mv $HUBDIR/dinov2-main $HUBDIR/$(basename $(dirname $MODEL_LICENSE_FILE))
-    touch $HUBDIR/trusted_list
-fi
-
-if echo 2e405cee1bad14912278296d4f42e993 $MODEL_WEIGHTS_FILE | md5sum --check - && echo 153d2db1c329326a2d9f881317ea942e $MODEL_LICENSE_FILE | md5sum --check -; then
-    cp -r $CWD/docker_config/torch_home_cache $CLEAN_SOURCE_DIR/torch_home_cache
-else
-    exit 1
-fi
-chmod a+rX $CLEAN_SOURCE_DIR/torch_home_cache -R
-
+./_cacheAndCopyPretrainedModelWeights.sh $CWD $CLEAN_SOURCE_DIR
 cd $CWD
 
 # build and print follow-up steps

--- a/buildDockerImageAndStartupKits.sh
+++ b/buildDockerImageAndStartupKits.sh
@@ -32,13 +32,12 @@ CONTAINER_VERSION_ID=`git rev-parse --short HEAD`
 CWD=`pwd`
 CLEAN_SOURCE_DIR=`mktemp -d`
 mkdir $CLEAN_SOURCE_DIR/MediSwarm
-rsync -ax --exclude workspace . $CLEAN_SOURCE_DIR/MediSwarm/
-cd $CLEAN_SOURCE_DIR/MediSwarm
-git clean -x -q -f .
+git archive --format=tar HEAD | tar x -C $CLEAN_SOURCE_DIR/MediSwarm/
 cd docker_config/NVFlare
-git clean -x -q -f .
+git archive --format=tar HEAD | tar x -C $CLEAN_SOURCE_DIR/MediSwarm/docker_config/NVFlare
 cd ../..
-rm .git -rf
+
+cd $CLEAN_SOURCE_DIR/MediSwarm
 chmod a+rX . -R
 
 # replacements in copy of source code


### PR DESCRIPTION
Use git archive to obtain a clean source code directory for building the ODELIA Docker image rather than creating a copy and cleaning it up afterwards.
Further changes:
* refactored downloading of cached pretrained model weights using separate script