### PR TITLE
Fix #231: Standardize training results to SCRATCH_DIR

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/custom/env_config.py
+++ b/application/jobs/ODELIA_ternary_classification/app/custom/env_config.py
@@ -34,7 +34,7 @@ def prepare_odelia_dataset(logger, log_dataset_details: bool = False):
 
     current_time = datetime.now().strftime("%Y_%m_%d_%H%M%S")
     run_name = f'{model}_{config}_{current_time}'
-    path_run_dir = Path.cwd() / 'runs' / institution / run_name
+    path_run_dir = Path(os.environ.get('SCRATCH_DIR')) / 'runs' / institution / run_name
     path_run_dir.mkdir(parents=True, exist_ok=True)
 
     ODELIA_Dataset3D.log_UID_discrepancies(logger, institutions=[institution], log_dataset_details=log_dataset_details)

--- a/assets/readme/README.participant.md
+++ b/assets/readme/README.participant.md
@@ -134,12 +134,14 @@ To have a baseline for swarm training, train the same model in a comparable way 
       ```bash
       ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training --job challenge_2BCN_AIM 2>&1 | tee local_training_console_output.txt
       ```
-3. Output files are located in the directory of the startup kit:
+3. Output files:
     * Logged output during training: `startup/local_training_console_output.txt`
-    * Class probabilities for each round/epoch for training/validation data: `startup/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/site_model_gt_and_classprob_{train,validation}.csv`
-    * Best checkpoint for local data: `startup/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/epoch=….ckpt`
-    * Last checkpoint for local data: `startup/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/last.ckpt`
-    * TensorBoard logs: `startup/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/lightning_logs`
+    * Training results are stored in `$SCRATCHDIR/runs/$SITE_NAME/<RUN_NAME>/`
+      * `<RUN_NAME>` has the format `<MODEL>_<CONFIG>_<TIMESTAMP>`, e.g. `MST_unilateral_2026_04_03_120000`
+      * Class probabilities: `site_model_gt_and_classprob_{train,validation}.csv`
+      * Best checkpoint: `epoch=….ckpt`
+      * Last checkpoint: `last.ckpt`
+      * TensorBoard logs: `lightning_logs/`
 
 ### Start Swarm Node
 
@@ -165,16 +167,19 @@ To have a baseline for swarm training, train the same model in a comparable way 
    ```bash
    sudo chmod a+r nohup.out
    ```
-4. Output files are located in the directory of the startup kit (note: unlike local training results, this is *not* in the `startup` directory)
-    * Training log: `<JOB_ID>/log.txt`
-      * Note: there is also a log.txt outside the job folders, it does not contain job-specific information.
-    * Class probabilities for each round/epoch for training/validation data: `<JOB_ID>/app_$SITE_NAME/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/{aggregated,site}_model_gt_and_classprob_{train,validation}.csv`
-    * Best checkpoint for local data: `<JOB_ID>/app_$SITE_NAME/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/epoch=….ckpt`
-    * Last checkpoint for local data: `<JOB_ID>/app_$SITE_NAME/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/last.ckpt`
-    * Last aggregated model: `<JOB_ID>/app_$SITE_NAME/FL_global_model.pt`
-    * TensorBoard logs: `<JOB_ID>/app_$SITE_NAME/runs/$SITE_NAME/<MODEL_TASK_CONFIG_TIMESTAMP>/lightning_logs`
-    * Code that was used for training: `<JOB_ID>/app_$SITE_NAME/custom`
-    * TODO describe prediction results once implemented
+4. Output files:
+    * Console output: `startup/nohup.out`
+    * NVFlare log: `log.txt` (in the startup kit root)
+    * Training results are stored in `$SCRATCHDIR/runs/$SITE_NAME/<RUN_NAME>/`
+      * `<RUN_NAME>` has the format `<MODEL>_<CONFIG>_<TIMESTAMP>`, e.g. `MST_unilateral_2026_04_03_120000`
+      * Class probabilities: `{aggregated,site}_model_gt_and_classprob_{train,validation}.csv`
+      * Best checkpoint: `epoch=….ckpt`
+      * Last checkpoint: `last.ckpt`
+      * TensorBoard logs: `lightning_logs/`
+    * NVFlare job artifacts: `<JOB_ID>/app_$SITE_NAME/`
+      * Aggregated model: `FL_global_model.pt`
+      * Best aggregated model: `best_FL_global_model.pt`
+      * Code used for training: `custom/`
 
 ## Troubleshooting
 

--- a/kit_live_sync/live_sync.sh
+++ b/kit_live_sync/live_sync.sh
@@ -63,9 +63,22 @@ extract_run_name_from_nohup() {
 }
 
 find_latest_local_run_name() {
-  local base="$STARTUP_DIR/runs/$SITE_NAME"
-  [ -d "$base" ] || return 0
-  find "$base" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's#.*/##' | sort | tail -n 1 || true
+  local base result=""
+  # Check scratch dir first (primary location since all jobs now use SCRATCH_DIR)
+  if [ -n "$SCRATCHDIR" ]; then
+    base="$SCRATCHDIR/runs/$SITE_NAME"
+    if [ -d "$base" ]; then
+      result="$(find "$base" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's#.*/##' | sort | tail -n 1 || true)"
+    fi
+  fi
+  # Fall back to startup dir (backward compatibility with older builds)
+  if [ -z "$result" ]; then
+    base="$STARTUP_DIR/runs/$SITE_NAME"
+    if [ -d "$base" ]; then
+      result="$(find "$base" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's#.*/##' | sort | tail -n 1 || true)"
+    fi
+  fi
+  printf '%s' "$result"
 }
 
 build_remote_dir() {
@@ -78,13 +91,19 @@ sync_local() {
 
   run_name="$(find_latest_local_run_name || true)"
   [ -n "$run_name" ] || return 0
-  run_dir="$STARTUP_DIR/runs/$SITE_NAME/$run_name"
-  [ -d "$run_dir" ] || return 0
+
+  # Determine run_dir: check scratch dir first, fall back to startup dir
+  run_dir=""
+  if [ -n "$SCRATCHDIR" ] && [ -d "$SCRATCHDIR/runs/$SITE_NAME/$run_name" ]; then
+    run_dir="$SCRATCHDIR/runs/$SITE_NAME/$run_name"
+  elif [ -d "$STARTUP_DIR/runs/$SITE_NAME/$run_name" ]; then
+    run_dir="$STARTUP_DIR/runs/$SITE_NAME/$run_name"
+  fi
+  [ -n "$run_dir" ] || return 0
 
   remote_dir="$(build_remote_dir "$run_name")"
   ensure_remote_dir "$remote_dir"
 
-  export SCRATCHDIR=""
   hb_file="$STATE_DIR/local_heartbeat.json"
   "$SCRIPT_DIR/build_heartbeat.sh" "$SITE_NAME" "local" "$KIT_ROOT" "" "$run_name" "running" "$hb_file" >/dev/null
 
@@ -116,7 +135,7 @@ sync_local() {
 }
 
 sync_swarm() {
-  local job_id run_name remote_dir hb_file now last scratch_run_dir
+  local job_id run_name remote_dir hb_file now last
 
   job_id="$(find_latest_job_id || true)"
   [ -n "$job_id" ] || return 0
@@ -145,18 +164,20 @@ sync_swarm() {
     rsync_cmd "$KIT_ROOT/$job_id/app_${SITE_NAME}/best_FL_global_model.pt" \
       "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/best_FL_global_model.pt" || true
 
-  if [ -n "$SCRATCHDIR" ] && [ -n "$run_name" ]; then
-    scratch_run_dir="$SCRATCHDIR/runs/$SITE_NAME/$run_name"
-  else
-    scratch_run_dir=""
+  # Determine run dir: check scratch dir first, fall back to startup dir
+  local run_dir_for_sync=""
+  if [ -n "$SCRATCHDIR" ] && [ -n "$run_name" ] && [ -d "$SCRATCHDIR/runs/$SITE_NAME/$run_name" ]; then
+    run_dir_for_sync="$SCRATCHDIR/runs/$SITE_NAME/$run_name"
+  elif [ -n "$run_name" ] && [ -d "$STARTUP_DIR/runs/$SITE_NAME/$run_name" ]; then
+    run_dir_for_sync="$STARTUP_DIR/runs/$SITE_NAME/$run_name"
   fi
 
-  if [ -n "$scratch_run_dir" ] && [ -d "$scratch_run_dir" ]; then
+  if [ -n "$run_dir_for_sync" ]; then
     rsync_cmd \
       --include='*/' \
       --include='events.out.tfevents*' \
       --exclude='*' \
-      "$scratch_run_dir/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
+      "$run_dir_for_sync/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
 
     now="$(date +%s)"
     last="$(cat "$LAST_CKPT_SYNC_FILE" 2>/dev/null || echo 0)"
@@ -167,7 +188,7 @@ sync_swarm() {
         --include='epoch=*.ckpt' \
         --include='*_model_gt_and_classprob_*.csv' \
         --exclude='*' \
-        "$scratch_run_dir/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
+        "$run_dir_for_sync/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
       echo "$now" > "$LAST_CKPT_SYNC_FILE"
     fi
   fi
@@ -176,19 +197,28 @@ sync_swarm() {
 final_sync() {
   if [ "$MODE" = "local" ]; then
     sync_local || true
-    local run_name
+    local run_name run_dir
     run_name="$(find_latest_local_run_name || true)"
     if [ -n "$run_name" ]; then
+      # Determine run_dir: check scratch dir first, fall back to startup dir
+      run_dir=""
+      if [ -n "$SCRATCHDIR" ] && [ -d "$SCRATCHDIR/runs/$SITE_NAME/$run_name" ]; then
+        run_dir="$SCRATCHDIR/runs/$SITE_NAME/$run_name"
+      elif [ -d "$STARTUP_DIR/runs/$SITE_NAME/$run_name" ]; then
+        run_dir="$STARTUP_DIR/runs/$SITE_NAME/$run_name"
+      fi
+
       remote_dir="$(build_remote_dir "$run_name")"
       hb_file="$STATE_DIR/local_heartbeat_final.json"
-      export SCRATCHDIR=""
       "$SCRIPT_DIR/build_heartbeat.sh" "$SITE_NAME" "local" "$KIT_ROOT" "" "$run_name" "finished" "$hb_file" >/dev/null
       rsync_cmd "$hb_file" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/heartbeat_final.json" || true
-      rsync_cmd "$STARTUP_DIR/runs/$SITE_NAME/$run_name/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
+      if [ -n "$run_dir" ]; then
+        rsync_cmd "$run_dir/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
+      fi
     fi
   else
     sync_swarm || true
-    local job_id run_name remote_dir hb_file scratch_run_dir
+    local job_id run_name remote_dir hb_file
     job_id="$(find_latest_job_id || true)"
     run_name="$(extract_run_name_from_nohup || true)"
     if [ -n "$job_id" ]; then
@@ -212,10 +242,15 @@ final_sync() {
         rsync_cmd "$KIT_ROOT/$job_id/app_${SITE_NAME}/best_FL_global_model.pt" \
           "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/best_FL_global_model.pt" || true
 
-      if [ -n "$SCRATCHDIR" ] && [ -n "$run_name" ]; then
-        scratch_run_dir="$SCRATCHDIR/runs/$SITE_NAME/$run_name"
-        [ -d "$scratch_run_dir" ] && \
-          rsync_cmd "$scratch_run_dir/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
+      # Sync run dir: check scratch dir first, fall back to startup dir
+      local final_run_dir=""
+      if [ -n "$SCRATCHDIR" ] && [ -n "$run_name" ] && [ -d "$SCRATCHDIR/runs/$SITE_NAME/$run_name" ]; then
+        final_run_dir="$SCRATCHDIR/runs/$SITE_NAME/$run_name"
+      elif [ -n "$run_name" ] && [ -d "$STARTUP_DIR/runs/$SITE_NAME/$run_name" ]; then
+        final_run_dir="$STARTUP_DIR/runs/$SITE_NAME/$run_name"
+      fi
+      if [ -n "$final_run_dir" ]; then
+        rsync_cmd "$final_run_dir/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
       fi
     fi
   fi

--- a/odelia_image.version
+++ b/odelia_image.version
@@ -1,2 +1,2 @@
 # version of the ODELIA Docker image, read by different scripts
-1.1.0
+1.2.0

--- a/server_tools/README.md
+++ b/server_tools/README.md
@@ -169,6 +169,10 @@ The links open:
 
 ## 7) Uploaded directory layout expected by the monitor
 
+The `live_sync` daemon on each training site uploads artifacts here via rsync.
+All training jobs (ODELIA and challenge models) write results to `$SCRATCHDIR/runs/$SITE_NAME/<RUN_NAME>/` on the host,
+and `live_sync` uploads them to the `run_dir/` subdirectory below.
+
 The monitor expects uploads in this structure:
 
 ```text


### PR DESCRIPTION
## Summary
- **Standardize results storage**: Changed ODELIA `env_config.py` to use `SCRATCH_DIR` instead of `CWD` for `path_run_dir`, making it consistent with all 5 challenge jobs. All training results now write to `$SCRATCHDIR/runs/$SITE_NAME/<RUN_NAME>/`.
- **Fix live_sync coverage**: Updated `live_sync.sh` to check `$SCRATCHDIR/runs/` first with fallback to `$STARTUP_DIR/runs/` in all sync functions (`sync_local`, `sync_swarm`, `final_sync`), ensuring results are found and uploaded regardless of job type.
- **Update documentation**: Corrected result paths in `README.participant.md` for both local and swarm training, and added clarification to `server_tools/README.md`.
- **Version bump**: `odelia_image.version` bumped to 1.2.0.

Closes #231

## Test plan
- [x] `deploy_and_test.sh build` succeeds — Docker image `jefftud/odelia:1.2.0-dev.260403.b113a45` built
- [x] All 15 startup kits generated with live_sync injection
- [ ] Run `--local_training` on a test site → verify results appear in `$SCRATCHDIR/runs/` not `startup/runs/`
- [ ] Run `--local_training` and verify live_sync uploads to server monitor at `http://172.24.4.65:8080/`
- [ ] Submit a swarm job → verify live_sync uploads training metrics to server

🤖 Generated with [Claude Code](https://claude.com/claude-code)