### PR TITLE
Fix #227: parse CLI args before SITE_NAME resolution

### DIFF
--- a/_injectLiveSyncIntoStartupKits.sh
+++ b/_injectLiveSyncIntoStartupKits.sh
@@ -83,14 +83,14 @@ parse_args() {
   done
 }
 
+parse_args "$@"
+
 SITE_NAME_FALLBACK="$(basename "$KIT_ROOT")"
 if [ -n "$SITE_NAME_FROM_ARGS" ]; then
   export SITE_NAME="$SITE_NAME_FROM_ARGS"
 elif [ -z "${SITE_NAME:-}" ]; then
   export SITE_NAME="$SITE_NAME_FALLBACK"
 fi
-
-parse_args "$@"
 
 start_local_sync() {
   "$SCRIPT_DIR/live_sync.sh" \


### PR DESCRIPTION
## Summary
- Moves `parse_args "$@"` above the `SITE_NAME` fallback resolution block in the generated `startup/docker.sh` wrapper template (`_injectLiveSyncIntoStartupKits.sh`)
- This ensures `--site_name` CLI arguments are properly captured before `SITE_NAME` is exported
- Previously, `SITE_NAME_FROM_ARGS` was always empty when checked because `parse_args` ran after the resolution block

Closes #227

## Test plan
- [ ] Build startup kits (`deploy_and_test.sh build`) and inspect generated `docker.sh` to confirm `parse_args` appears before the `SITE_NAME` block
- [ ] Run `docker.sh --site_name CUSTOM_NAME --local_training ...` and verify `SITE_NAME=CUSTOM_NAME` is used (not the directory fallback)
- [ ] Run without `--site_name` and verify directory-based fallback still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)