### PR TITLE
Fix #222: update CI actions to Node.js 22+

### DIFF
--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository (with submodules)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create Pull Request
         if: env.NO_CHANGES == 'false'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore: update apt versions in Dockerfile_ODELIA"
           branch: ci/apt-update


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v3 → v4 (supports Node.js 20/22)
- Update `peter-evans/create-pull-request` from v5 → v7 (supports Node.js 22 since v7.0.7)
- Resolves the Node.js 20 deprecation warning from CI runners

No breaking changes affect our workflow — verified that none of the v7 breaking changes (`git-token` rename, `push-to-fork` format, `reviewers` timing) are used in our workflow file.

Closes #222

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify no Node.js deprecation warnings appear
- [ ] Verify the APT update workflow still creates PRs correctly when package versions change

🤖 Generated with [Claude Code](https://claude.com/claude-code)