### PR TITLE
Add client stability: VPN auto-reconnect, GPU health, Docker restart

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -819,7 +819,10 @@ docker_cln_sh: |
       /bin/bash -c "/MediSwarm/application/jobs/${JOB_NAME}/app/custom/main.py"
 
   elif [ -n "$START_CLIENT" ]; then
-      docker run -d -t --rm $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=swarm $DOCKER_IMAGE \
+      docker run -d -t --restart=on-failure:5 \
+      --health-cmd="nvidia-smi > /dev/null 2>&1 || exit 1" \
+      --health-interval=120s --health-start-period=180s --health-retries=3 \
+      $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=swarm $DOCKER_IMAGE \
       /bin/bash -c "nohup ./start.sh >> nohup.out 2>&1 && /bin/bash"
 
   elif [ -n "$LIST_LICENSES" ]; then
@@ -895,7 +898,7 @@ docker_svr_sh: |
   echo "Starting docker with $DOCKER_IMAGE as $CONTAINER_NAME"
   # Run docker with appropriate parameters
   if [ -n "$START_SERVER" ]; then
-      docker run -d -t --rm --name=$CONTAINER_NAME \
+      docker run -d -t --restart=on-failure:5 --name=$CONTAINER_NAME \
       -v $DIR/..:/startupkit/ -w /startupkit/startup/ \
       --ipc=host $NETARG $DOCKER_IMAGE \
       /bin/bash -c "nohup ./start.sh >> nohup.out 2>&1 && chmod a+r nohup.out && /bin/bash"

--- a/scripts/client_node_setup/gpu_health_check.sh
+++ b/scripts/client_node_setup/gpu_health_check.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# =============================================================================
+# MediSwarm GPU Health Check
+# =============================================================================
+# Verifies that NVIDIA GPUs are healthy and accessible. Intended as:
+#   - A pre-training check (run before launching FL client)
+#   - A Docker HEALTHCHECK command
+#   - A periodic cron/systemd health probe
+#
+# Exit codes:
+#   0 — healthy: driver loaded, GPU(s) responsive, temperature OK
+#   1 — warning: driver loaded but temperature high or minor issue
+#   2 — critical: driver not responding or no GPUs found
+#
+# Usage:
+#   ./gpu_health_check.sh              # basic check
+#   ./gpu_health_check.sh --json       # output JSON (for monitoring integration)
+#   ./gpu_health_check.sh --docker     # minimal output for Docker HEALTHCHECK
+#   ./gpu_health_check.sh --reset      # attempt nvidia-smi -r if driver is stuck
+#
+# Environment variables (optional):
+#   TEMP_WARNING_C    temperature warning threshold (default: 85)
+#   TEMP_CRITICAL_C   temperature critical threshold (default: 95)
+# =============================================================================
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+TEMP_WARNING_C="${TEMP_WARNING_C:-85}"
+TEMP_CRITICAL_C="${TEMP_CRITICAL_C:-95}"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+log() {
+    local level="$1"; shift
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [$level] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Check nvidia-smi responsiveness
+# ---------------------------------------------------------------------------
+check_driver() {
+    if ! command -v nvidia-smi &>/dev/null; then
+        log CRITICAL "nvidia-smi not found in PATH"
+        return 2
+    fi
+
+    # Timeout after 10 seconds — a hung driver will block indefinitely
+    if ! timeout 10 nvidia-smi &>/dev/null; then
+        log CRITICAL "nvidia-smi did not respond within 10 seconds — driver may be hung"
+        return 2
+    fi
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Query GPU details
+# ---------------------------------------------------------------------------
+query_gpus() {
+    nvidia-smi --query-gpu=index,name,temperature.gpu,utilization.gpu,memory.used,memory.total,power.draw \
+        --format=csv,noheader,nounits 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Evaluate GPU health
+# ---------------------------------------------------------------------------
+evaluate_health() {
+    local worst_status=0
+    local gpu_count=0
+
+    while IFS=', ' read -r idx name temp util mem_used mem_total power; do
+        gpu_count=$((gpu_count + 1))
+
+        # Trim whitespace
+        temp="${temp// /}"
+        util="${util// /}"
+        mem_used="${mem_used// /}"
+        mem_total="${mem_total// /}"
+        power="${power// /}"
+        name="${name// /}"
+
+        local status="OK"
+        local exit_code=0
+
+        if (( temp >= TEMP_CRITICAL_C )); then
+            status="CRITICAL (${temp}°C >= ${TEMP_CRITICAL_C}°C)"
+            exit_code=2
+        elif (( temp >= TEMP_WARNING_C )); then
+            status="WARNING (${temp}°C >= ${TEMP_WARNING_C}°C)"
+            exit_code=1
+        fi
+
+        if [[ "$OUTPUT_MODE" == "json" ]]; then
+            echo "  {\"index\": $idx, \"name\": \"$name\", \"temp_c\": $temp, \"util_pct\": $util, \"mem_used_mib\": $mem_used, \"mem_total_mib\": $mem_total, \"power_w\": $power, \"status\": \"$status\"}"
+        elif [[ "$OUTPUT_MODE" != "docker" ]]; then
+            log INFO "GPU $idx ($name): ${temp}°C, ${util}% util, ${mem_used}/${mem_total} MiB, ${power}W — $status"
+        fi
+
+        if (( exit_code > worst_status )); then
+            worst_status=$exit_code
+        fi
+    done < <(query_gpus)
+
+    if (( gpu_count == 0 )); then
+        log CRITICAL "No GPUs found by nvidia-smi"
+        return 2
+    fi
+
+    if [[ "$OUTPUT_MODE" == "docker" ]]; then
+        if (( worst_status == 0 )); then
+            echo "healthy ($gpu_count GPU(s))"
+        else
+            echo "unhealthy"
+        fi
+    fi
+
+    return $worst_status
+}
+
+# ---------------------------------------------------------------------------
+# Attempt GPU reset
+# ---------------------------------------------------------------------------
+attempt_reset() {
+    log WARNING "Attempting GPU reset via nvidia-smi -r ..."
+    if sudo nvidia-smi -r 2>/dev/null; then
+        log INFO "GPU reset command sent successfully. Waiting 10s for driver to recover..."
+        sleep 10
+        if check_driver; then
+            log INFO "Driver recovered after reset"
+            return 0
+        else
+            log CRITICAL "Driver still unresponsive after reset"
+            return 2
+        fi
+    else
+        log CRITICAL "GPU reset failed — manual intervention may be required"
+        return 2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Docker HEALTHCHECK mode (for use in --health-cmd)
+# ---------------------------------------------------------------------------
+docker_healthcheck() {
+    if ! timeout 10 nvidia-smi &>/dev/null; then
+        echo "unhealthy"
+        exit 1
+    fi
+    echo "healthy"
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+OUTPUT_MODE="text"
+DO_RESET=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json)    OUTPUT_MODE="json" ;;
+        --docker)  OUTPUT_MODE="docker" ;;
+        --reset)   DO_RESET=true ;;
+        -h|--help)
+            echo "Usage: $0 [--json|--docker|--reset|-h]"
+            echo "  --json     JSON output for monitoring systems"
+            echo "  --docker   minimal output for Docker HEALTHCHECK"
+            echo "  --reset    attempt nvidia-smi -r if driver is unresponsive"
+            echo "  -h         show this help"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Fast path for Docker health checks
+if [[ "$OUTPUT_MODE" == "docker" ]]; then
+    docker_healthcheck
+fi
+
+# Full check
+if [[ "$OUTPUT_MODE" == "json" ]]; then
+    echo "{"
+    echo "  \"timestamp\": \"$(date -Iseconds)\","
+fi
+
+if ! check_driver; then
+    if $DO_RESET; then
+        attempt_reset
+        exit $?
+    fi
+    exit 2
+fi
+
+if [[ "$OUTPUT_MODE" == "json" ]]; then
+    echo "  \"driver\": \"ok\","
+    echo "  \"gpus\": ["
+fi
+
+evaluate_health
+status=$?
+
+if [[ "$OUTPUT_MODE" == "json" ]]; then
+    echo "  ],"
+    local_status="healthy"
+    (( status == 1 )) && local_status="warning"
+    (( status == 2 )) && local_status="critical"
+    echo "  \"overall\": \"$local_status\""
+    echo "}"
+fi
+
+exit $status

--- a/scripts/client_node_setup/mediswarm-vpn.service
+++ b/scripts/client_node_setup/mediswarm-vpn.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=MediSwarm VPN Connection (GoodAccess/OpenVPN)
+Documentation=https://github.com/KatherLab/MediSwarm
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# The config path is set by setup_vpntunnel.sh -s during installation.
+# It copies the .ovpn file to /etc/openvpn/client/mediswarm.conf and
+# injects keepalive + credential settings.
+ExecStart=/usr/sbin/openvpn --config /etc/openvpn/client/mediswarm.conf
+Restart=always
+RestartSec=15
+TimeoutStopSec=10
+
+# Security hardening
+ProtectSystem=full
+ProtectHome=true
+NoNewPrivileges=false
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_DAC_OVERRIDE
+LimitNPROC=10
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/client_node_setup/setup_vpntunnel.sh
+++ b/scripts/client_node_setup/setup_vpntunnel.sh
@@ -1,13 +1,40 @@
 #!/usr/bin/env bash
+# =============================================================================
+# MediSwarm VPN Tunnel Setup
+# =============================================================================
+# Sets up and launches an OpenVPN connection using GoodAccess .ovpn configs.
+#
+# Modes:
+#   Legacy (default):  Launches OpenVPN via nohup in the background.
+#   Systemd (-s):      Installs a systemd service with auto-reconnect,
+#                       keepalive, and boot persistence.
+#
+# Usage:
+#   setup_vpntunnel.sh -d <host_index> [-n] [-s]
+#
+#   -d <host_index>  Required. One of: TUD, Ribera, VHIO, Radboud, UKA,
+#                     Utrecht, Mitera, Cambridge, Zurich
+#   -n               First-time setup: installs OpenVPN and prompts for
+#                     VPN credentials
+#   -s               Use systemd service mode (recommended for production).
+#                     Installs mediswarm-vpn.service with auto-reconnect,
+#                     keepalive, and boot persistence.
+#   -h               Show this help message
+# =============================================================================
 
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+
 ACTION="nochange"
+SYSTEMD_MODE=""
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -d)  host_index="$2"; shift ;;
         -n)  ACTION="new";;
+        -s)  SYSTEMD_MODE="1";;
         -h)  ACTION="help";;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
@@ -15,46 +42,145 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 if [[ $ACTION = "help" ]]; then
-   echo "Usage: setup_vpntunnel.sh -d <host_index> [-n]"
-   echo "       -n   one-time setup"
+   echo "Usage: setup_vpntunnel.sh -d <host_index> [-n] [-s]"
+   echo "       -d   host index: TUD, Ribera, VHIO, Radboud, UKA, Utrecht, Mitera, Cambridge, Zurich"
+   echo "       -n   one-time setup (install OpenVPN + configure credentials)"
+   echo "       -s   use systemd service mode (recommended for production)"
    echo ""
-   exit 1
+   exit 0
 fi
 
-if [ -z "$host_index" ]; then
+if [ -z "${host_index:-}" ]; then
    echo "Please specify your host index via option -d <host_index>"
    echo "Host index should be chosen from [TUD, Ribera, VHIO, Radboud, UKA, Utrecht, Mitera, Cambridge, Zurich]"
    exit 1
 fi
 
-if [ $ACTION = "new" ]; then
-    # to the initial setup
-    echo "Setting up VPN tunnel for swarm learning ..."
-    sudo apt-get -y install openvpn
-
-    echo "Please enter your vpn credentials (ask TUD maintainer for the account and password if you don't have the data yet)"
-    read -p "vpn account: " vpn_account
-    stty -echo
-    read -p "vpn password: " vpn_password
-    stty echo
-    printf '%s\n' $vpn_account $vpn_password | sudo tee /etc/openvpn/credentials > /dev/null
-    sudo chmod 600 /etc/openvpn/credentials
-fi
-
-if [[ ! -f ./assets/openvpn_configs/good_access/$host_index.ovpn ]]; then
-    echo "Configuration file ./assets/openvpn_configs/good_access/$host_index.ovpn not found"
+# Locate the .ovpn file
+OVPN_FILE="$REPO_ROOT/assets/openvpn_configs/good_access/$host_index.ovpn"
+if [[ ! -f "$OVPN_FILE" ]]; then
+    echo "Configuration file $OVPN_FILE not found"
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# First-time setup (-n)
+# ---------------------------------------------------------------------------
+if [ "$ACTION" = "new" ]; then
+    echo "Setting up VPN tunnel for swarm learning ..."
+    sudo apt-get update -qq
+    sudo apt-get -y install openvpn
+
+    echo "Please enter your VPN credentials (ask TUD maintainer for the account and password if you don't have them yet)"
+    read -p "VPN account: " vpn_account
+    stty -echo
+    read -p "VPN password: " vpn_password
+    stty echo
+    echo ""
+
+    if [[ -n "$SYSTEMD_MODE" ]]; then
+        # For systemd mode, store credentials in /etc/openvpn/client/
+        sudo mkdir -p /etc/openvpn/client
+        printf '%s\n' "$vpn_account" "$vpn_password" | sudo tee /etc/openvpn/client/mediswarm.auth > /dev/null
+        sudo chmod 600 /etc/openvpn/client/mediswarm.auth
+        sudo chown root:root /etc/openvpn/client/mediswarm.auth
+        echo "Credentials saved to /etc/openvpn/client/mediswarm.auth"
+    else
+        # Legacy mode: store in /etc/openvpn/credentials
+        sudo mkdir -p /etc/openvpn
+        printf '%s\n' "$vpn_account" "$vpn_password" | sudo tee /etc/openvpn/credentials > /dev/null
+        sudo chmod 600 /etc/openvpn/credentials
+        echo "Credentials saved to /etc/openvpn/credentials"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Systemd service mode (-s)
+# ---------------------------------------------------------------------------
+if [[ -n "$SYSTEMD_MODE" ]]; then
+    echo "=== Installing MediSwarm VPN as systemd service ==="
+
+    # Verify credentials exist
+    if [[ ! -f /etc/openvpn/client/mediswarm.auth ]]; then
+        echo "Credentials file /etc/openvpn/client/mediswarm.auth not found."
+        echo "Please run with -n -s to set up credentials first."
+        exit 1
+    fi
+
+    # Copy .ovpn to /etc/openvpn/client/mediswarm.conf and inject settings
+    echo "Copying VPN config to /etc/openvpn/client/mediswarm.conf ..."
+    sudo cp "$OVPN_FILE" /etc/openvpn/client/mediswarm.conf
+
+    # Inject keepalive and credential settings if not already present
+    inject_if_missing() {
+        local setting="$1"
+        local value="$2"
+        local file="/etc/openvpn/client/mediswarm.conf"
+        if ! sudo grep -q "^$setting" "$file"; then
+            echo "$value" | sudo tee -a "$file" > /dev/null
+            echo "  Injected: $value"
+        else
+            echo "  Already present: $setting"
+        fi
+    }
+
+    echo "Injecting keepalive and credential settings ..."
+    inject_if_missing "auth-user-pass"  "auth-user-pass /etc/openvpn/client/mediswarm.auth"
+    inject_if_missing "auth-nocache"    "auth-nocache"
+    inject_if_missing "persist-key"     "persist-key"
+    inject_if_missing "persist-tun"     "persist-tun"
+    inject_if_missing "resolv-retry"    "resolv-retry infinite"
+    inject_if_missing "keepalive"       "keepalive 10 60"
+
+    # Install systemd service
+    echo "Installing systemd service ..."
+    sudo cp "$SCRIPT_DIR/mediswarm-vpn.service" /etc/systemd/system/mediswarm-vpn.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable mediswarm-vpn.service
+    sudo systemctl restart mediswarm-vpn.service
+
+    echo ""
+    echo "=== MediSwarm VPN service installed ==="
+    echo ""
+    echo "Useful commands:"
+    echo "  sudo systemctl status mediswarm-vpn      # check status"
+    echo "  sudo journalctl -u mediswarm-vpn -f       # follow logs"
+    echo "  sudo systemctl restart mediswarm-vpn      # manual restart"
+    echo "  sudo systemctl stop mediswarm-vpn         # stop VPN"
+    echo ""
+
+    # Optionally install the health monitor timer
+    echo "Do you want to install the VPN health monitor timer? (recommended)"
+    read -p "Install health monitor? [Y/n]: " install_health
+    if [[ "${install_health:-Y}" =~ ^[Yy]$ ]]; then
+        "$SCRIPT_DIR/vpn_health_monitor.sh" --install-timer
+    fi
+
+    # Wait and show VPN IP
+    sleep 5
+    echo ""
+    echo "Current IP addresses:"
+    hostname -I
+    echo ""
+    echo "You should see an IP address of the form 172.24.4.x above."
+    echo "If not, check: sudo journalctl -u mediswarm-vpn -f"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Legacy mode (nohup, backward compatible)
+# ---------------------------------------------------------------------------
 if [[ ! -f /etc/openvpn/credentials ]]; then
     echo "Credentials file /etc/openvpn/credentials not found, please use option -n to create it"
     exit 1
 fi
 
-echo "Starting VPN tunnel for swarm learning ..."
-sudo nohup openvpn --config ./assets/openvpn_configs/good_access/$host_index.ovpn &
+echo "Starting VPN tunnel for swarm learning (legacy nohup mode) ..."
+echo "TIP: For production use, re-run with -s for systemd service mode with auto-reconnect."
+echo ""
+sudo nohup openvpn --config "$OVPN_FILE" &
 sleep 3
-sudo chmod a+r nohup.out
+sudo chmod a+r nohup.out 2>/dev/null || true
 
 if [ $? -ne 0 ]; then
     echo "An error occurred while running the script. Please check the output above or nohup.out for more details."

--- a/scripts/client_node_setup/vpn_health_monitor.sh
+++ b/scripts/client_node_setup/vpn_health_monitor.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# =============================================================================
+# MediSwarm VPN Health Monitor
+# =============================================================================
+# Pings the VPN gateway at regular intervals and restarts the systemd VPN
+# service after consecutive failures.
+#
+# Usage:
+#   ./vpn_health_monitor.sh                  # run once (suitable for cron/systemd timer)
+#   ./vpn_health_monitor.sh --daemon         # run in a loop (every INTERVAL seconds)
+#   ./vpn_health_monitor.sh --install-timer  # install a systemd timer that runs every minute
+#
+# Environment variables (all optional):
+#   VPN_GATEWAY        IP to ping              (default: 172.24.4.1)
+#   VPN_SERVICE        systemd service name    (default: mediswarm-vpn)
+#   FAIL_THRESHOLD     consecutive fails before restart (default: 3)
+#   PING_INTERVAL      seconds between checks in daemon mode (default: 60)
+#   STATE_FILE         path for failure counter (default: /tmp/mediswarm_vpn_health.state)
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (override via environment)
+# ---------------------------------------------------------------------------
+VPN_GATEWAY="${VPN_GATEWAY:-172.24.4.1}"
+VPN_SERVICE="${VPN_SERVICE:-mediswarm-vpn}"
+FAIL_THRESHOLD="${FAIL_THRESHOLD:-3}"
+PING_INTERVAL="${PING_INTERVAL:-60}"
+STATE_FILE="${STATE_FILE:-/tmp/mediswarm_vpn_health.state}"
+
+# ---------------------------------------------------------------------------
+# Logging helper
+# ---------------------------------------------------------------------------
+log() {
+    local level="$1"; shift
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [$level] $*"
+    logger -t mediswarm-vpn-health -p "daemon.$level" "$*" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Read / write failure counter
+# ---------------------------------------------------------------------------
+read_failures() {
+    if [[ -f "$STATE_FILE" ]]; then
+        cat "$STATE_FILE"
+    else
+        echo 0
+    fi
+}
+
+write_failures() {
+    echo "$1" > "$STATE_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Single health check
+# ---------------------------------------------------------------------------
+check_vpn() {
+    local failures
+    failures=$(read_failures)
+
+    if ping -c 2 -W 5 "$VPN_GATEWAY" &>/dev/null; then
+        if (( failures > 0 )); then
+            log info "VPN gateway $VPN_GATEWAY reachable again (was at $failures consecutive failures)"
+        fi
+        write_failures 0
+        return 0
+    fi
+
+    failures=$((failures + 1))
+    write_failures "$failures"
+    log warning "VPN gateway $VPN_GATEWAY unreachable ($failures/$FAIL_THRESHOLD consecutive failures)"
+
+    if (( failures >= FAIL_THRESHOLD )); then
+        log err "Failure threshold reached — restarting $VPN_SERVICE"
+        if sudo systemctl restart "$VPN_SERVICE"; then
+            log info "$VPN_SERVICE restarted successfully"
+        else
+            log err "Failed to restart $VPN_SERVICE (exit code $?)"
+        fi
+        write_failures 0
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Install a systemd timer for this script
+# ---------------------------------------------------------------------------
+install_timer() {
+    local script_path
+    script_path="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+    log info "Installing systemd timer for VPN health monitor..."
+
+    sudo tee /etc/systemd/system/mediswarm-vpn-health.service >/dev/null <<EOF
+[Unit]
+Description=MediSwarm VPN Health Check
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$script_path
+Environment=VPN_GATEWAY=$VPN_GATEWAY
+Environment=VPN_SERVICE=$VPN_SERVICE
+Environment=FAIL_THRESHOLD=$FAIL_THRESHOLD
+EOF
+
+    sudo tee /etc/systemd/system/mediswarm-vpn-health.timer >/dev/null <<EOF
+[Unit]
+Description=Run MediSwarm VPN health check every minute
+
+[Timer]
+OnBootSec=120
+OnUnitActiveSec=60
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target
+EOF
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now mediswarm-vpn-health.timer
+    log info "Timer installed and started. Check with: systemctl status mediswarm-vpn-health.timer"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    case "${1:-}" in
+        --daemon)
+            log info "Starting VPN health monitor daemon (gateway=$VPN_GATEWAY, interval=${PING_INTERVAL}s, threshold=$FAIL_THRESHOLD)"
+            while true; do
+                check_vpn
+                sleep "$PING_INTERVAL"
+            done
+            ;;
+        --install-timer)
+            install_timer
+            ;;
+        *)
+            check_vpn
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- **Systemd VPN service** (`mediswarm-vpn.service`): Replaces bare `nohup openvpn` with a proper systemd service featuring auto-reconnect (`Restart=always`), security hardening, and boot persistence
- **VPN health monitor** (`vpn_health_monitor.sh`): Pings VPN gateway at regular intervals, restarts service after consecutive failures. Supports daemon mode and systemd timer installation
- **GPU health check** (`gpu_health_check.sh`): Verifies NVIDIA driver responsiveness, monitors temperature thresholds, supports Docker HEALTHCHECK mode and optional GPU reset
- **Updated `setup_vpntunnel.sh`**: New `-s` flag for systemd service installation with automatic keepalive injection into .ovpn configs. Backward compatible with legacy nohup mode
- **Docker container resilience**: Swarm client containers now use `--restart=on-failure:5` instead of `--rm`, and include `--health-cmd` for periodic GPU health verification. Server containers also get restart policy

## Test plan

- [ ] Verify `setup_vpntunnel.sh -h` shows updated help with `-s` flag
- [ ] Verify `setup_vpntunnel.sh -d TUD -n -s` installs systemd service and injects keepalive settings
- [ ] Verify `vpn_health_monitor.sh` detects unreachable gateway and increments failure counter
- [ ] Verify `vpn_health_monitor.sh --install-timer` creates systemd timer
- [ ] Verify `gpu_health_check.sh` returns exit code 0 on healthy GPU
- [ ] Verify `gpu_health_check.sh --docker` works as Docker HEALTHCHECK
- [ ] Verify Docker client container starts with `--restart=on-failure:5` and health check
- [ ] Verify legacy mode (`setup_vpntunnel.sh -d TUD` without `-s`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)