### PR TITLE
Add STAMP classification job for swarm learning

### DIFF
--- a/application/jobs/STAMP_classification/README.md
+++ b/application/jobs/STAMP_classification/README.md
@@ -1,0 +1,166 @@
+# STAMP Classification — MediSwarm Swarm Learning Job
+
+This job integrates [STAMP](https://github.com/KatherLab/STAMP) (Solid Tumor Associative Modeling in Pathology) with MediSwarm's NVFlare-based swarm learning framework.
+
+## Overview
+
+STAMP analyzes whole-slide images (WSIs) using pre-extracted deep learning features stored in HDF5 files. Unlike ODELIA's 3D CNN pipeline that trains directly on imaging volumes, STAMP works on tile/slide/patient-level feature vectors that have already been extracted from WSIs using foundation models (e.g., UNI, CTransPath, RetCCL).
+
+Only the **training** section of STAMP is integrated into swarm learning. Preprocessing (feature extraction), deployment (inference), and statistics remain standalone workflows.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    STAMP Pipeline                        │
+│                                                          │
+│  Preprocessing ──► Training ──► Deployment ──► Statistics │
+│  (standalone)      (swarm)     (standalone)   (standalone)│
+└─────────────────────────────────────────────────────────┘
+
+Swarm Training Flow:
+  Clinical Table (CSV/XLSX)  ─┐
+                               ├──► STAMP DataLoaders ──► Lightning Model
+  H5 Feature Files (.h5)    ─┘         │                      │
+                                        │     NVFlare patches  │
+                                        │     trainer for      │
+                                        │     federated        │
+                                        │     aggregation      │
+                                        ▼                      ▼
+                                   SwarmClientController ◄── PTClientAPILauncherExecutor
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `app/custom/main.py` | NVFlare entry point — swarm loop, local training, preflight check |
+| `app/custom/stamp_training.py` | Training bridge — loads STAMP data/model, runs training rounds |
+| `app/custom/stamp_model_wrapper.py` | NVFlare persistor bridge — creates model for federated parameter space |
+| `app/config/config_fed_client.conf` | NVFlare client configuration (executors, aggregator, persistor) |
+| `app/config/config_fed_server.conf` | NVFlare server configuration (swarm controller, rounds) |
+| `meta.conf` | Job metadata (name, min_clients, deploy_map) |
+
+## Environment Variables
+
+All STAMP-specific variables use the `STAMP_` prefix to avoid collision with ODELIA variables.
+
+### Required
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `SITE_NAME` | NVFlare site identifier | `site-1` |
+| `SCRATCH_DIR` | Working directory for outputs | `/scratch` |
+| `TRAINING_MODE` | `swarm`, `local_training`, or `preflight_check` | `swarm` |
+| `STAMP_CLINI_TABLE` | Path to clinical data CSV/XLSX | `/data/clinical.csv` |
+| `STAMP_FEATURE_DIR` | Directory containing H5 feature files | `/data/features/` |
+
+### Optional — Data
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STAMP_SLIDE_TABLE` | *(empty)* | Path to slide-level metadata table |
+| `STAMP_OUTPUT_DIR` | *(auto-generated)* | Output directory for checkpoints and logs |
+| `STAMP_TASK` | `classification` | Task type: `classification`, `regression`, or `survival` |
+| `STAMP_GROUND_TRUTH_LABEL` | *(empty)* | Column name for ground truth in clinical table |
+| `STAMP_PATIENT_LABEL` | `PATIENT` | Column name for patient ID |
+| `STAMP_FILENAME_LABEL` | `FILENAME` | Column name for slide filename |
+| `STAMP_TIME_LABEL` | *(empty)* | Column name for survival time (survival task only) |
+| `STAMP_STATUS_LABEL` | *(empty)* | Column name for event status (survival task only) |
+
+### Optional — Model
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STAMP_MODEL_NAME` | `vit` | Model architecture: `vit`, `mlp`, `trans_mil`, `linear`, `barspoon` |
+| `STAMP_FEATURE_TYPE` | *(auto-detect)* | Feature level: `tile`, `slide`, or `patient` |
+| `STAMP_DIM_INPUT` | `1024` | Input feature dimension (UNI/UNI2=1024, CTransPath=768) |
+| `STAMP_NUM_CLASSES` | `3` | Number of output classes |
+
+### Optional — Training
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STAMP_BAG_SIZE` | `512` | Number of tiles per bag (MIL) |
+| `STAMP_BATCH_SIZE` | `64` | Training batch size |
+| `STAMP_MAX_EPOCHS` | `32` | Maximum training epochs |
+| `STAMP_PATIENCE` | `16` | Early stopping patience |
+| `STAMP_MAX_LR` | `1e-4` | Maximum learning rate (OneCycleLR) |
+| `STAMP_DIV_FACTOR` | `25.0` | OneCycleLR div_factor |
+| `STAMP_EPOCHS_PER_ROUND` | `5` | Local epochs per swarm round |
+| `STAMP_NUM_WORKERS` | `min(cpu_count, 8)` | DataLoader workers |
+| `STAMP_SEED` | `42` | Random seed |
+
+## Data Requirements
+
+Each site needs:
+
+1. **Clinical table** (CSV or XLSX) with at minimum:
+   - Patient identifier column (default: `PATIENT`)
+   - Ground truth label column (for classification/regression)
+   - Slide filename column (default: `FILENAME`) if using a slide table
+
+2. **Feature directory** containing HDF5 (`.h5`) files:
+   - One file per slide/patient
+   - Each file contains a `feats` dataset (N×F float array)
+   - Tile-level features also include a `coords` dataset
+   - Feature type (tile/slide/patient) is auto-detected from H5 metadata
+
+3. **Slide table** (optional, CSV or XLSX):
+   - Maps patients to slide filenames
+   - Required when patients have multiple slides
+
+## Supported Models
+
+| Model | `STAMP_MODEL_NAME` | Description |
+|-------|---------------------|-------------|
+| VIT | `vit` | Vision Transformer with ALiBi positional encoding |
+| MLP | `mlp` | Multi-layer perceptron |
+| TransMIL | `trans_mil` | Transformer-based MIL |
+| Linear | `linear` | Linear classifier |
+| Barspoon | `barspoon` | Encoder-decoder transformer |
+
+## Quick Start
+
+### Local Testing
+
+```bash
+export TRAINING_MODE=preflight_check
+export SITE_NAME=test-site
+export SCRATCH_DIR=/tmp/stamp_test
+export STAMP_CLINI_TABLE=/path/to/clinical.csv
+export STAMP_FEATURE_DIR=/path/to/features/
+export STAMP_GROUND_TRUTH_LABEL=diagnosis
+export STAMP_NUM_CLASSES=3
+export STAMP_MODEL_NAME=vit
+
+cd application/jobs/STAMP_classification/app/custom
+python main.py
+```
+
+### Swarm Deployment
+
+Configure the environment variables above in your Docker/deployment configuration, set `TRAINING_MODE=swarm`, and submit the job via NVFlare:
+
+```bash
+nvflare job submit -j application/jobs/STAMP_classification
+```
+
+## Dependencies
+
+- [STAMP](https://github.com/KatherLab/STAMP) (`pip install stamp`)
+- PyTorch + PyTorch Lightning
+- NVFlare 2.5+
+- h5py (for reading feature files)
+
+## Differences from Standalone STAMP
+
+| Aspect | Standalone STAMP | MediSwarm STAMP |
+|--------|-----------------|-----------------|
+| Data splitting | Internal stratified split | Each site has its own data |
+| Training loop | Single `trainer.fit()` | NVFlare-controlled rounds |
+| Model aggregation | N/A | Weighted federated averaging |
+| Privacy | N/A | Percentile privacy filter on gradients |
+| Configuration | YAML config file | Environment variables |
+| Preprocessing | Integrated pipeline | Standalone (run before training) |
+| Deployment | Integrated pipeline | Standalone (run after training) |

--- a/application/jobs/STAMP_classification/app/config/config_fed_client.conf
+++ b/application/jobs/STAMP_classification/app/config/config_fed_client.conf
@@ -1,0 +1,166 @@
+{
+  format_version = 2
+  app_script = "main.py"
+  app_config = ""
+  executors = [
+    {
+      # Training, validation, and model submission tasks handled by external subprocess
+      tasks = [
+        "train",
+        "validate",
+        "submit_model"
+      ]
+      executor {
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        args {
+          launcher_id = "launcher"
+          pipe_id = "pipe"
+          # time to wait for final result transfer from subprocess (10 min)
+          last_result_transfer_timeout = 600
+          # time to wait for subprocess to call flare.init() (10 min)
+          external_pre_init_timeout = 600
+          # time to wait for peer to read sent message (10 min)
+          peer_read_timeout = 600
+          # time without heartbeat before declaring subprocess dead (10 min)
+          heartbeat_timeout = 600
+          params_exchange_format = "pytorch"
+          params_transfer_type = "DIFF"
+          train_with_evaluation = true
+        }
+      }
+    }
+    {
+      # All tasks prefixed with swarm_ are routed to SwarmClientController
+      tasks = ["swarm_*"]
+      executor {
+        # client-side controller for training and logic and aggregation management
+        path = "nvflare.app_common.ccwf.SwarmClientController"
+        args {
+          # train task must be implemented by Executor
+          learn_task_name = "train"
+          # max time for a single training round (2 hours)
+          learn_task_timeout = 7200
+          # time to wait for learn task to abort gracefully (5 min)
+          learn_task_abort_timeout = 300
+          # time for task acknowledgment (2 min)
+          learn_task_ack_timeout = 120
+          # time for final result acknowledgment (5 min)
+          final_result_ack_timeout = 300
+
+          # ids must map to corresponding components
+          persistor_id = "persistor"
+          aggregator_id = "aggregator"
+          shareable_generator_id = "shareable_generator"
+          metric_comparator_id = "metric_comparator"
+          min_responses_required = 2
+          # time to wait for slower clients after minimum responses received (5 min)
+          wait_time_after_min_resps_received = 300
+        }
+      }
+    }
+  ]
+  task_data_filters = []
+  task_result_filters = [
+    {
+      # Apply differential privacy via percentile clipping to training results
+      tasks = ["train"]
+      filters = [
+        {
+          path = "nvflare.app_common.filters.percentile_privacy.PercentilePrivacy"
+          args {
+            percentile = 10
+            gamma = 0.01
+          }
+        }
+      ]
+    }
+  ]
+  components = [
+    {
+      id = "launcher"
+      path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
+      args {
+        script = "python3 custom/{app_script}  {app_config} "
+        launch_once = true
+      }
+    }
+    {
+      id = "aggregator"
+      path = "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator"
+      args {
+        expected_data_kind = "WEIGHT_DIFF"
+      }
+    }
+    {
+      id = "pipe"
+      path = "nvflare.fuel.utils.pipe.cell_pipe.CellPipe"
+      args {
+        mode = "PASSIVE"
+        site_name = "{SITE_NAME}"
+        token = "{JOB_ID}"
+        root_url = "{ROOT_URL}"
+        secure_mode = "{SECURE_MODE}"
+        workspace_dir = "{WORKSPACE}"
+      }
+    }
+    {
+      id = "persistor"
+      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      args {
+        model {
+          path = "stamp_model_wrapper.create_stamp_model"
+          args {
+            # Model will be determined by STAMP_* environment variables
+          }
+        }
+      }
+    }
+    {
+      id = "shareable_generator"
+      path = "nvflare.app_common.ccwf.comps.simple_model_shareable_generator.SimpleModelShareableGenerator"
+      args {}
+    }
+    {
+      id = "metric_comparator"
+      path = "nvflare.app_common.ccwf.common.NumberMetricComparator"
+      args {}
+    }
+    {
+      id = "metrics_pipe"
+      path = "nvflare.fuel.utils.pipe.cell_pipe.CellPipe"
+      args {
+        mode = "PASSIVE"
+        site_name = "{SITE_NAME}"
+        token = "{JOB_ID}"
+        root_url = "{ROOT_URL}"
+        secure_mode = "{SECURE_MODE}"
+        workspace_dir = "{WORKSPACE}"
+      }
+    }
+    {
+      id = "metric_relay"
+      path = "nvflare.app_common.widgets.metric_relay.MetricRelay"
+      args {
+        pipe_id = "metrics_pipe"
+        event_type = "fed.analytix_log_stats"
+        read_interval = 0.1
+      }
+    }
+    {
+      id = "model_selector"
+      path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
+      args {
+        key_metric = "accuracy"
+      }
+    }
+    {
+      id = "config_preparer"
+      path = "nvflare.app_common.widgets.external_configurator.ExternalConfigurator"
+      args {
+        component_ids = [
+          "metric_relay"
+        ]
+      }
+    }
+  ]
+}

--- a/application/jobs/STAMP_classification/app/config/config_fed_server.conf
+++ b/application/jobs/STAMP_classification/app/config/config_fed_server.conf
@@ -1,0 +1,30 @@
+format_version = 2
+task_data_filters = []
+task_result_filters = []
+components = [
+  {
+    # write validation results to json file
+    id = "json_generator"
+    path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
+    args {}
+  }
+]
+workflows = [
+  {
+    # server-side controller to manage job life cycle
+    id = "swarm_controller"
+    path = "nvflare.app_common.ccwf.SwarmServerController"
+    args {
+      # can also set aggregation clients and train clients, see class for all available args
+      num_rounds = 20
+      # time for clients to configure and start (10 min)
+      start_task_timeout = 600
+      # max time without any progress before declaring failure (2 hours)
+      progress_timeout = 7200
+      # time for clients to acknowledge configuration (5 min)
+      configure_task_timeout = 300
+      # interval for clients to report status (5 min)
+      max_status_report_interval = 300
+    }
+  }
+]

--- a/application/jobs/STAMP_classification/app/custom/main.py
+++ b/application/jobs/STAMP_classification/app/custom/main.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+NVFlare entry point for STAMP swarm learning.
+
+This follows the same pattern as the ODELIA main.py but uses STAMP's
+data pipeline (H5 features + clinical tables) and model registry instead
+of ODELIA's 3D CNN pipeline.
+
+Supports three training modes:
+- swarm:            NVFlare-managed federated training
+- local_training:   Single-site training without federation
+- preflight_check:  Quick smoke test with 1 epoch
+"""
+
+import logging
+import os
+
+import torch
+
+import nvflare.client.lightning as flare
+import nvflare.client as flare_util
+
+import stamp_training
+
+logger = logging.getLogger(__name__)
+
+TRAINING_MODE = os.getenv("TRAINING_MODE")
+TM_PREFLIGHT_CHECK = "preflight_check"
+TM_LOCAL_TRAINING = "local_training"
+TM_SWARM = "swarm"
+
+if not TRAINING_MODE:
+    raise ValueError("TRAINING_MODE environment variable must be set")
+
+if TRAINING_MODE == TM_SWARM:
+    flare_util.init(rank="0")
+    SITE_NAME = flare.get_site_name()
+    NUM_EPOCHS = stamp_training.get_num_epochs_per_round(SITE_NAME)
+elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
+    SITE_NAME = os.getenv("SITE_NAME")
+    if not SITE_NAME:
+        raise ValueError("SITE_NAME environment variable must be set for local training")
+    try:
+        NUM_EPOCHS = int(os.getenv("NUM_EPOCHS", "1"))
+    except ValueError:
+        raise ValueError("NUM_EPOCHS must be an integer")
+else:
+    raise ValueError(f"Unsupported TRAINING_MODE: {TRAINING_MODE}")
+
+
+def main():
+    """Main function for STAMP training with NVFlare swarm learning."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"[%(asctime)s] [{SITE_NAME}] %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    logger.info(f"STAMP training starting — mode={TRAINING_MODE}, site={SITE_NAME}")
+
+    try:
+        # Load STAMP environment configuration
+        env = stamp_training.load_stamp_environment()
+        # Override with runtime settings
+        env["site_name"] = SITE_NAME
+
+        # Prepare training (data, model, trainer)
+        train_dl, valid_dl, model, checkpointing, trainer, output_dir, metric_callback = (
+            stamp_training.prepare_training(env, NUM_EPOCHS)
+        )
+
+        if TRAINING_MODE == TM_SWARM:
+            flare.patch(trainer)
+            torch.autograd.set_detect_anomaly(True)
+
+            logger.info(f"Entering swarm learning loop — site: {SITE_NAME}")
+
+            while flare.is_running():
+                input_model = flare.receive()
+                logger.info(f"Round {input_model.current_round}")
+
+                stamp_training.validate_and_train(train_dl, valid_dl, model, trainer)
+
+                # Report validation metric to NVFlare for model selection
+                if metric_callback.last_val_loss is not None:
+                    logger.info(
+                        f"Round {input_model.current_round} — "
+                        f"val_loss={metric_callback.last_val_loss:.4f}"
+                        + (f", val_auroc={metric_callback.last_val_auroc:.4f}"
+                           if metric_callback.last_val_auroc is not None else "")
+                    )
+
+        elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
+            stamp_training.validate_and_train(train_dl, valid_dl, model, trainer)
+
+        if TRAINING_MODE in [TM_LOCAL_TRAINING, TM_SWARM]:
+            stamp_training.finalize_training(model, checkpointing, trainer, output_dir)
+
+    except Exception as e:
+        logger.error(f"STAMP training failed: {e}", exc_info=True)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/application/jobs/STAMP_classification/app/custom/stamp_model_wrapper.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_model_wrapper.py
@@ -1,0 +1,148 @@
+"""
+STAMP model wrapper for NVFlare PTFileModelPersistor.
+
+NVFlare's PTFileModelPersistor needs a callable that returns an nn.Module
+whose state_dict defines the parameter space for federated aggregation.
+This module creates a STAMP model from environment variables and wraps it
+so NVFlare can serialize/deserialize its weights.
+"""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+def _get_stamp_env():
+    """Read STAMP-specific configuration from environment variables."""
+    return {
+        "task": os.environ.get("STAMP_TASK", "classification"),
+        "model_name": os.environ.get("STAMP_MODEL_NAME", "vit"),
+        "feature_type": os.environ.get("STAMP_FEATURE_TYPE", "tile"),
+        # Feature dimension from H5 files (UNI2 = 1024, UNI = 1024, CTransPath = 768, etc.)
+        "dim_input": int(os.environ.get("STAMP_DIM_INPUT", "1024")),
+        "num_classes": int(os.environ.get("STAMP_NUM_CLASSES", "3")),
+        # Model hyperparameters
+        "bag_size": int(os.environ.get("STAMP_BAG_SIZE", "512")),
+        "batch_size": int(os.environ.get("STAMP_BATCH_SIZE", "64")),
+        "max_epochs": int(os.environ.get("STAMP_MAX_EPOCHS", "32")),
+        "max_lr": float(os.environ.get("STAMP_MAX_LR", "1e-4")),
+        "div_factor": float(os.environ.get("STAMP_DIV_FACTOR", "25.0")),
+        # VIT-specific
+        "vit_dim_model": int(os.environ.get("STAMP_VIT_DIM_MODEL", "512")),
+        "vit_dim_feedforward": int(os.environ.get("STAMP_VIT_DIM_FEEDFORWARD", "512")),
+        "vit_n_heads": int(os.environ.get("STAMP_VIT_N_HEADS", "8")),
+        "vit_n_layers": int(os.environ.get("STAMP_VIT_N_LAYERS", "2")),
+        "vit_dropout": float(os.environ.get("STAMP_VIT_DROPOUT", "0.25")),
+        # MLP-specific
+        "mlp_dim_hidden": int(os.environ.get("STAMP_MLP_DIM_HIDDEN", "512")),
+        "mlp_num_layers": int(os.environ.get("STAMP_MLP_NUM_LAYERS", "2")),
+        "mlp_dropout": float(os.environ.get("STAMP_MLP_DROPOUT", "0.25")),
+    }
+
+
+def _build_stamp_model(env: dict) -> nn.Module:
+    """Build a STAMP Lightning model from environment configuration.
+
+    This imports STAMP's model registry and instantiates the correct
+    Lightning wrapper + backbone for the given (feature_type, task, model_name).
+    """
+    try:
+        from stamp.modeling.registry import ModelName, load_model_class
+    except ImportError:
+        raise ImportError(
+            "STAMP is not installed. Install it with: pip install stamp "
+            "or ensure the STAMP source is on PYTHONPATH."
+        )
+
+    task = env["task"]
+    feature_type = env["feature_type"]
+    model_name_str = env["model_name"]
+    dim_input = env["dim_input"]
+    num_classes = env["num_classes"]
+
+    # Resolve model name enum
+    model_name = ModelName(model_name_str)
+
+    # Load the correct Lightning wrapper and backbone class
+    LitModelClass, ModelClass = load_model_class(task, feature_type, model_name)
+
+    # Build model-specific parameters
+    model_specific_params = {}
+    if model_name == ModelName.VIT:
+        model_specific_params = {
+            "dim_model": env["vit_dim_model"],
+            "dim_feedforward": env["vit_dim_feedforward"],
+            "n_heads": env["vit_n_heads"],
+            "n_layers": env["vit_n_layers"],
+            "dropout": env["vit_dropout"],
+        }
+    elif model_name == ModelName.MLP:
+        model_specific_params = {
+            "dim_hidden": env["mlp_dim_hidden"],
+            "num_layers": env["mlp_num_layers"],
+            "dropout": env["mlp_dropout"],
+        }
+    elif model_name == ModelName.TRANS_MIL:
+        model_specific_params = {
+            "dim_hidden": int(os.environ.get("STAMP_TRANSMIL_DIM_HIDDEN", "512")),
+        }
+
+    # Build categories placeholder — actual categories come from training data
+    # For the persistor, we just need the model architecture to be correct
+    categories = [str(i) for i in range(num_classes)]
+
+    # Calculate total_steps placeholder (actual value set during training)
+    total_steps = 100  # placeholder, overridden at training time
+
+    common_params = {
+        "categories": categories,
+        "category_weights": [],
+        "dim_input": dim_input,
+        "total_steps": total_steps,
+        "max_lr": env["max_lr"],
+        "div_factor": env["div_factor"],
+        "model_name": model_name_str,
+        # Metadata fields (no effect on model architecture)
+        "ground_truth_label": None,
+        "time_label": None,
+        "status_label": None,
+        "train_patients": [],
+        "valid_patients": [],
+        "clini_table": Path("/dev/null"),
+        "slide_table": None,
+        "feature_dir": Path("/dev/null"),
+    }
+
+    all_params = {**common_params, **model_specific_params}
+
+    model = LitModelClass(model_class=ModelClass, **all_params)
+
+    logger.info(
+        f"Created STAMP model: {model_name_str} "
+        f"(task={task}, feature_type={feature_type}, "
+        f"dim_input={dim_input}, num_classes={num_classes})"
+    )
+
+    return model
+
+
+def create_stamp_model(**kwargs) -> nn.Module:
+    """Entry point for NVFlare PTFileModelPersistor.
+
+    Called by NVFlare to instantiate the model whose state_dict defines
+    the federated parameter space. Configuration is read from environment
+    variables (STAMP_TASK, STAMP_MODEL_NAME, etc.).
+
+    Any kwargs passed from config_fed_client.conf are merged with env vars,
+    with kwargs taking precedence.
+    """
+    env = _get_stamp_env()
+    # Allow config overrides from NVFlare conf
+    env.update({k: v for k, v in kwargs.items() if v is not None})
+    return _build_stamp_model(env)

--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -1,0 +1,366 @@
+"""
+STAMP training pipeline adapted for MediSwarm/NVFlare swarm learning.
+
+This module bridges STAMP's data loading and model creation with NVFlare's
+federated training loop. Only the training section of STAMP is integrated
+here — preprocessing, deployment, and statistics remain standalone workflows.
+
+Key differences from standalone STAMP training:
+1. Data loading uses STAMP's pipeline (H5 features + clinical tables)
+2. Model creation uses STAMP's registry (VIT, MLP, TransMIL, etc.)
+3. Training loop is controlled by NVFlare via flare.patch(trainer)
+4. No internal train/val split — each site has its own data
+"""
+
+import csv
+import logging
+import os
+import shutil
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import torch
+import torch.multiprocessing as mp
+from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import ModelCheckpoint, Callback, EarlyStopping
+from pytorch_lightning.loggers import TensorBoardLogger
+from torch.utils.data import DataLoader
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Environment configuration
+# ---------------------------------------------------------------------------
+
+def load_stamp_environment():
+    """Load STAMP-specific environment variables for MediSwarm.
+
+    Returns a dict with all configuration needed for STAMP training.
+    Environment variables use the STAMP_ prefix to avoid collision with
+    ODELIA-specific variables.
+    """
+    env = {
+        # Core paths
+        "site_name": os.environ["SITE_NAME"],
+        "scratch_dir": os.environ["SCRATCH_DIR"],
+        "mediswarm_version": os.environ.get("MEDISWARM_VERSION", "unset"),
+
+        # STAMP data paths
+        "clini_table": os.environ["STAMP_CLINI_TABLE"],
+        "feature_dir": os.environ["STAMP_FEATURE_DIR"],
+        "slide_table": os.environ.get("STAMP_SLIDE_TABLE", ""),
+        "output_dir": os.environ.get("STAMP_OUTPUT_DIR", ""),
+
+        # STAMP task configuration
+        "task": os.environ.get("STAMP_TASK", "classification"),
+        "ground_truth_label": os.environ.get("STAMP_GROUND_TRUTH_LABEL", ""),
+        "patient_label": os.environ.get("STAMP_PATIENT_LABEL", "PATIENT"),
+        "filename_label": os.environ.get("STAMP_FILENAME_LABEL", "FILENAME"),
+        "time_label": os.environ.get("STAMP_TIME_LABEL", ""),
+        "status_label": os.environ.get("STAMP_STATUS_LABEL", ""),
+
+        # STAMP model configuration
+        "model_name": os.environ.get("STAMP_MODEL_NAME", "vit"),
+        "feature_type": os.environ.get("STAMP_FEATURE_TYPE", ""),  # auto-detect if empty
+        "dim_input": int(os.environ.get("STAMP_DIM_INPUT", "1024")),
+        "num_classes": int(os.environ.get("STAMP_NUM_CLASSES", "3")),
+
+        # Training hyperparameters
+        "bag_size": int(os.environ.get("STAMP_BAG_SIZE", "512")),
+        "batch_size": int(os.environ.get("STAMP_BATCH_SIZE", "64")),
+        "max_epochs": int(os.environ.get("STAMP_MAX_EPOCHS", "32")),
+        "patience": int(os.environ.get("STAMP_PATIENCE", "16")),
+        "max_lr": float(os.environ.get("STAMP_MAX_LR", "1e-4")),
+        "div_factor": float(os.environ.get("STAMP_DIV_FACTOR", "25.0")),
+        "num_workers": int(os.environ.get("STAMP_NUM_WORKERS", str(min(mp.cpu_count(), 8)))),
+        "seed": int(os.environ.get("STAMP_SEED", "42")),
+    }
+
+    # Derive output_dir if not explicitly set
+    if not env["output_dir"]:
+        current_time = datetime.now().strftime("%Y_%m_%d_%H%M%S")
+        env["output_dir"] = str(
+            Path(env["scratch_dir"]) / "runs" / env["site_name"]
+            / f"STAMP_{env['model_name']}_{current_time}"
+        )
+
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def load_stamp_data(env: dict) -> Tuple[DataLoader, DataLoader, Any, int, list, list]:
+    """Load STAMP data and create train/val dataloaders.
+
+    Uses STAMP's data pipeline:
+    1. Load patient data from clinical table + H5 feature files
+    2. Detect feature type (tile/slide/patient) from H5 metadata
+    3. Create stratified train/val split
+    4. Build dataloaders with appropriate collation
+
+    Returns:
+        train_dl, valid_dl, categories, dim_feats, train_patients, valid_patients
+    """
+    from stamp.modeling.data import load_patient_data_, detect_feature_type
+    from stamp.modeling.train import setup_dataloaders_for_training
+    from stamp.modeling.transforms import VaryPrecisionTransform
+
+    clini_table = Path(env["clini_table"])
+    feature_dir = Path(env["feature_dir"])
+    slide_table = Path(env["slide_table"]) if env["slide_table"] else None
+    task = env["task"]
+    ground_truth_label = env["ground_truth_label"] if env["ground_truth_label"] else None
+    patient_label = env["patient_label"]
+    filename_label = env["filename_label"]
+    time_label = env["time_label"] if env["time_label"] else None
+    status_label = env["status_label"] if env["status_label"] else None
+
+    # Load patient data
+    patient_to_data, feature_type = load_patient_data_(
+        feature_dir=feature_dir,
+        clini_table=clini_table,
+        slide_table=slide_table,
+        task=task,
+        ground_truth_label=ground_truth_label,
+        time_label=time_label,
+        status_label=status_label,
+        patient_label=patient_label,
+        filename_label=filename_label,
+        drop_patients_with_missing_ground_truth=True,
+    )
+
+    # Override feature type if explicitly set
+    if env["feature_type"]:
+        feature_type = env["feature_type"]
+
+    logger.info(f"Loaded {len(patient_to_data)} patients, feature_type={feature_type}")
+    logger.info(f"Task: {task}, model: {env['model_name']}")
+
+    # Create train/val dataloaders with stratified split
+    train_dl, valid_dl, categories, dim_feats, train_patients, valid_patients = (
+        setup_dataloaders_for_training(
+            patient_to_data=patient_to_data,
+            task=task,
+            categories=None,  # auto-infer from data
+            bag_size=env["bag_size"],
+            batch_size=env["batch_size"],
+            num_workers=env["num_workers"],
+            train_transform=VaryPrecisionTransform(min_fraction_bits=1),
+            feature_type=feature_type,
+        )
+    )
+
+    logger.info(
+        f"Train: {len(train_patients)} patients, Val: {len(valid_patients)} patients, "
+        f"dim_feats={dim_feats}, categories={categories}"
+    )
+
+    return train_dl, valid_dl, categories, dim_feats, train_patients, valid_patients
+
+
+# ---------------------------------------------------------------------------
+# Model creation
+# ---------------------------------------------------------------------------
+
+def create_stamp_training_model(
+    env: dict,
+    train_dl: DataLoader,
+    valid_dl: DataLoader,
+    categories: Any,
+    dim_feats: int,
+    train_patients: list,
+    valid_patients: list,
+):
+    """Create a STAMP model configured for training.
+
+    Uses STAMP's setup_model_from_dataloaders() which:
+    1. Computes class weights from training data
+    2. Selects correct Lightning wrapper + backbone via registry
+    3. Calculates OneCycleLR scheduler steps from data size
+    """
+    from stamp.modeling.config import AdvancedConfig, ModelParams
+    from stamp.modeling.train import setup_model_from_dataloaders
+    from stamp.modeling.registry import ModelName
+
+    # Build AdvancedConfig from environment
+    advanced = AdvancedConfig(
+        seed=env["seed"],
+        max_epochs=env["max_epochs"],
+        patience=env["patience"],
+        batch_size=env["batch_size"],
+        bag_size=env["bag_size"],
+        max_lr=env["max_lr"],
+        div_factor=env["div_factor"],
+        model_name=ModelName(env["model_name"]),
+        num_workers=env["num_workers"],
+    )
+
+    clini_table = Path(env["clini_table"])
+    feature_dir = Path(env["feature_dir"])
+    slide_table = Path(env["slide_table"]) if env["slide_table"] else None
+    ground_truth_label = env["ground_truth_label"] if env["ground_truth_label"] else None
+    time_label = env["time_label"] if env["time_label"] else None
+    status_label = env["status_label"] if env["status_label"] else None
+    feature_type = env.get("feature_type", "tile") or "tile"
+
+    model = setup_model_from_dataloaders(
+        train_dl=train_dl,
+        valid_dl=valid_dl,
+        task=env["task"],
+        train_categories=categories,
+        dim_feats=dim_feats,
+        train_patients=train_patients,
+        valid_patients=valid_patients,
+        feature_type=feature_type,
+        advanced=advanced,
+        ground_truth_label=ground_truth_label,
+        time_label=time_label,
+        status_label=status_label,
+        clini_table=clini_table,
+        slide_table=slide_table,
+        feature_dir=feature_dir,
+    )
+
+    logger.info(f"Created STAMP model: {env['model_name']} with {sum(p.numel() for p in model.parameters()):,} parameters")
+
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Training preparation
+# ---------------------------------------------------------------------------
+
+class ValidationMetricCallback(Callback):
+    """Callback to log validation metrics in a format NVFlare can consume."""
+
+    def __init__(self):
+        super().__init__()
+        self.last_val_loss = None
+        self.last_val_auroc = None
+
+    def on_validation_epoch_end(self, trainer, pl_module):
+        metrics = trainer.callback_metrics
+        self.last_val_loss = metrics.get("validation_loss")
+        if self.last_val_loss is not None:
+            self.last_val_loss = self.last_val_loss.item()
+
+        # Try to get AUROC if available (classification only)
+        for key in ["val_auroc", "val_MulticlassAUROC"]:
+            val = metrics.get(key)
+            if val is not None:
+                self.last_val_auroc = val.item()
+                break
+
+
+def get_num_epochs_per_round(site_name: str) -> int:
+    """Get the number of training epochs per swarm round.
+
+    STAMP models are lightweight (H5 features are pre-extracted), so we can
+    afford more epochs per round than ODELIA's 3D CNN training.
+    """
+    default_epochs = int(os.environ.get("STAMP_EPOCHS_PER_ROUND", "5"))
+    NUM_EPOCHS_FOR_SITE = {}  # can be customized per site if needed
+
+    max_epochs = NUM_EPOCHS_FOR_SITE.get(site_name, default_epochs)
+    logger.info(f"Site: {site_name}, epochs per round: {max_epochs}")
+    return max_epochs
+
+
+def prepare_training(env: dict, max_epochs: int):
+    """Set up everything needed for STAMP training.
+
+    Returns:
+        train_dl, valid_dl, model, checkpointing, trainer, output_dir, metric_callback
+    """
+    torch.set_float32_matmul_precision("high")
+
+    output_dir = Path(env["output_dir"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info(f"MediSwarm version: {env['mediswarm_version']}")
+    logger.info(f"Output directory: {output_dir}")
+
+    # Load data
+    train_dl, valid_dl, categories, dim_feats, train_patients, valid_patients = (
+        load_stamp_data(env)
+    )
+
+    # Create model
+    model = create_stamp_training_model(
+        env, train_dl, valid_dl, categories, dim_feats,
+        train_patients, valid_patients,
+    )
+
+    # Determine monitor metric based on task
+    task = env["task"]
+    if task == "survival":
+        monitor_metric, mode = "val_cindex", "max"
+    elif task == "classification":
+        monitor_metric, mode = "validation_loss", "min"
+    else:
+        monitor_metric, mode = "validation_loss", "min"
+
+    # Set up callbacks
+    checkpointing = ModelCheckpoint(
+        dirpath=str(output_dir),
+        monitor=monitor_metric,
+        save_last=True,
+        save_top_k=1,
+        mode=mode,
+    )
+
+    metric_callback = ValidationMetricCallback()
+
+    # STAMP models train on pre-extracted features, so training is fast.
+    # No gradient accumulation needed (batch_size is already 64).
+    trainer = Trainer(
+        accelerator="gpu" if torch.cuda.is_available() else "cpu",
+        precision="16-mixed",
+        default_root_dir=str(output_dir),
+        callbacks=[checkpointing, metric_callback],
+        enable_checkpointing=True,
+        check_val_every_n_epoch=1,
+        log_every_n_steps=max(len(train_dl), 1),
+        max_epochs=max_epochs,
+        num_sanity_val_steps=0,
+        logger=TensorBoardLogger(save_dir=output_dir),
+        devices=1,
+    )
+
+    return train_dl, valid_dl, model, checkpointing, trainer, output_dir, metric_callback
+
+
+# ---------------------------------------------------------------------------
+# Training execution
+# ---------------------------------------------------------------------------
+
+def validate_and_train(
+    train_dl: DataLoader,
+    valid_dl: DataLoader,
+    model,
+    trainer: Trainer,
+):
+    """Run one round of validation + training (called each swarm round)."""
+    logger.info("--- Validate global model ---")
+    trainer.validate(model, dataloaders=valid_dl)
+
+    logger.info("--- Train new model ---")
+    trainer.fit(model, train_dataloaders=train_dl, val_dataloaders=valid_dl)
+
+
+def finalize_training(model, checkpointing, trainer, output_dir: Path):
+    """Save best checkpoint after training completes."""
+    best_path = checkpointing.best_model_path
+    if best_path:
+        final_path = output_dir / "model.ckpt"
+        shutil.copy(best_path, final_path)
+        logger.info(f"Best model saved to: {final_path}")
+    else:
+        logger.warning("No best checkpoint found")
+
+    logger.info("STAMP training completed successfully.")

--- a/application/jobs/STAMP_classification/meta.conf
+++ b/application/jobs/STAMP_classification/meta.conf
@@ -1,0 +1,9 @@
+name = "STAMP_classification"
+resource_spec {}
+deploy_map {
+  app = [
+    "@ALL"
+  ]
+}
+min_clients = 2
+mandatory_clients = []


### PR DESCRIPTION
## Summary
- Integrates [STAMP](https://github.com/KatherLab/STAMP) (Solid Tumor Associative Modeling in Pathology) as a new MediSwarm swarm learning job
- STAMP analyzes whole-slide images using pre-extracted H5 feature files and clinical tables — a completely different data pipeline from ODELIA's 3D MRI volumes
- Only the **training** section is federated; preprocessing, deployment, and statistics remain standalone workflows
- Supports all STAMP model architectures (VIT, MLP, TransMIL, Linear, Barspoon) and tasks (classification, regression, survival) via environment variables

## New files
| File | Purpose |
|------|---------|
| `app/custom/main.py` | NVFlare entry point — swarm loop, local training, preflight check |
| `app/custom/stamp_training.py` | Training bridge — loads STAMP data/model, runs training rounds |
| `app/custom/stamp_model_wrapper.py` | NVFlare persistor bridge — creates model for federated parameter space |
| `app/config/config_fed_client.conf` | NVFlare client config (executors, aggregator, persistor, privacy filter) |
| `app/config/config_fed_server.conf` | NVFlare server config (swarm controller, 20 rounds) |
| `meta.conf` | Job metadata |
| `README.md` | Documentation with env var reference and architecture overview |

## Architecture
- **Data**: Clinical tables (CSV/XLSX) + H5 feature files → STAMP DataLoaders
- **Model**: STAMP model registry → PyTorch Lightning module → NVFlare patches trainer
- **Aggregation**: Weighted federated averaging with percentile privacy filter
- **Config**: All STAMP settings via `STAMP_*` environment variables (no collision with ODELIA's env vars)

## Test plan
- [ ] Verify STAMP package imports correctly in Docker container
- [ ] Run preflight check mode with sample H5 features + clinical table
- [ ] Run local training mode end-to-end
- [ ] Test swarm mode with NVFlare simulator (2 sites)
- [ ] Verify model checkpoint saved correctly after training

🤖 Generated with [Claude Code](https://claude.com/claude-code)