### PR TITLE
Replace hardcoded per-site epochs with data-size-weighted computation

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/main.py
+++ b/application/jobs/STAMP_classification/app/custom/main.py
@@ -35,7 +35,10 @@ if not TRAINING_MODE:
 if TRAINING_MODE == TM_SWARM:
     flare_util.init(rank="0")
     SITE_NAME = flare.get_site_name()
-    NUM_EPOCHS = stamp_training.get_num_epochs_per_round(SITE_NAME)
+    # Epoch count will be computed from training data size inside
+    # prepare_training (weighted_epochs=True).
+    NUM_EPOCHS = 1  # placeholder — replaced by weighted computation
+    USE_WEIGHTED_EPOCHS = True
 elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
     SITE_NAME = os.getenv("SITE_NAME")
     if not SITE_NAME:
@@ -44,6 +47,7 @@ elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
         NUM_EPOCHS = int(os.getenv("NUM_EPOCHS", "1"))
     except ValueError:
         raise ValueError("NUM_EPOCHS must be an integer")
+    USE_WEIGHTED_EPOCHS = False
 else:
     raise ValueError(f"Unsupported TRAINING_MODE: {TRAINING_MODE}")
 
@@ -65,7 +69,7 @@ def main():
 
         # Prepare training (data, model, trainer)
         train_dl, valid_dl, model, checkpointing, trainer, output_dir, metric_callback = (
-            stamp_training.prepare_training(env, NUM_EPOCHS)
+            stamp_training.prepare_training(env, NUM_EPOCHS, weighted_epochs=USE_WEIGHTED_EPOCHS)
         )
 
         if TRAINING_MODE == TM_SWARM:

--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -257,22 +257,52 @@ class ValidationMetricCallback(Callback):
                 break
 
 
-def get_num_epochs_per_round(site_name: str) -> int:
-    """Get the number of training epochs per swarm round.
+def compute_weighted_epochs(num_train_samples: int, site_name: str = "") -> int:
+    """Compute per-round epoch count weighted by local dataset size.
 
-    STAMP models are lightweight (H5 features are pre-extracted), so we can
-    afford more epochs per round than ODELIA's 3D CNN training.
+    Sites with fewer training samples get more local epochs per round so
+    that every site contributes roughly the same number of gradient updates
+    to each aggregation round.  The formula is::
+
+        epochs = base_epochs * (reference_size / num_train_samples)
+
+    clamped to [1, max_cap].
+
+    Environment variables (use STAMP_ prefix to avoid collision with ODELIA):
+        STAMP_EPOCHS_PER_ROUND              Base epoch count (default 5).
+        STAMP_EPOCHS_REFERENCE_DATASET_SIZE Reference dataset size — a site
+                                            with exactly this many patients
+                                            trains for base_epochs (default 200).
+        STAMP_EPOCHS_MAX_CAP                Upper bound (default 20).
     """
-    default_epochs = int(os.environ.get("STAMP_EPOCHS_PER_ROUND", "5"))
-    NUM_EPOCHS_FOR_SITE = {}  # can be customized per site if needed
+    base_epochs = int(os.environ.get("STAMP_EPOCHS_PER_ROUND", "5"))
+    reference_size = int(os.environ.get("STAMP_EPOCHS_REFERENCE_DATASET_SIZE", "200"))
+    max_cap = int(os.environ.get("STAMP_EPOCHS_MAX_CAP", "20"))
 
-    max_epochs = NUM_EPOCHS_FOR_SITE.get(site_name, default_epochs)
-    logger.info(f"Site: {site_name}, epochs per round: {max_epochs}")
-    return max_epochs
+    if num_train_samples <= 0:
+        logger.warning(f"num_train_samples={num_train_samples}; falling back to base_epochs={base_epochs}")
+        return base_epochs
+
+    raw = base_epochs * (reference_size / num_train_samples)
+    epochs = max(1, min(int(round(raw)), max_cap))
+
+    logger.info(
+        f"Weighted epochs — site={site_name}, train_samples={num_train_samples}, "
+        f"reference_size={reference_size}, base={base_epochs}, "
+        f"raw={raw:.1f}, clamped={epochs}"
+    )
+    return epochs
 
 
-def prepare_training(env: dict, max_epochs: int):
+def prepare_training(env: dict, max_epochs: int, weighted_epochs: bool = False):
     """Set up everything needed for STAMP training.
+
+    Args:
+        env: Environment configuration dict from load_stamp_environment().
+        max_epochs: Maximum training epochs (used as-is for local/preflight,
+                    or as base when weighted_epochs is False).
+        weighted_epochs: If True, compute per-round epoch count from training
+                         data size via compute_weighted_epochs().
 
     Returns:
         train_dl, valid_dl, model, checkpointing, trainer, output_dir, metric_callback
@@ -289,6 +319,12 @@ def prepare_training(env: dict, max_epochs: int):
     train_dl, valid_dl, categories, dim_feats, train_patients, valid_patients = (
         load_stamp_data(env)
     )
+
+    # Compute weighted epochs from training data size
+    if weighted_epochs:
+        max_epochs = compute_weighted_epochs(
+            len(train_patients), env.get("site_name", "")
+        )
 
     # Create model
     model = create_stamp_training_model(
@@ -354,13 +390,25 @@ def validate_and_train(
 
 
 def finalize_training(model, checkpointing, trainer, output_dir: Path):
-    """Save best checkpoint after training completes."""
+    """Save best and latest checkpoints after training completes."""
+    # Save best checkpoint (selected by monitor metric)
     best_path = checkpointing.best_model_path
     if best_path:
-        final_path = output_dir / "model.ckpt"
-        shutil.copy(best_path, final_path)
-        logger.info(f"Best model saved to: {final_path}")
+        final_best = output_dir / "best_model.ckpt"
+        shutil.copy(best_path, final_best)
+        logger.info(f"Best model saved to: {final_best}")
     else:
         logger.warning("No best checkpoint found")
+
+    # Save latest (last) checkpoint — useful for resuming training or when
+    # the best checkpoint was from an early round and the final aggregated
+    # model is preferred for deployment.
+    last_path = checkpointing.last_model_path
+    if last_path:
+        final_last = output_dir / "last_model.ckpt"
+        shutil.copy(last_path, final_last)
+        logger.info(f"Last model saved to: {final_last}")
+    else:
+        logger.warning("No last checkpoint found")
 
     logger.info("STAMP training completed successfully.")

--- a/application/jobs/_shared/custom/main.py
+++ b/application/jobs/_shared/custom/main.py
@@ -20,7 +20,11 @@ if not TRAINING_MODE:
 if TRAINING_MODE == TM_SWARM:
     flare_util.init(rank="0")
     SITE_NAME = flare.get_site_name()
-    NUM_EPOCHS = threedcnn_ptl.get_num_epochs_per_round(SITE_NAME)
+    # Epoch count will be computed from training data size inside
+    # prepare_training (weighted_epochs=True).  The placeholder value here
+    # is overridden before the Trainer is created.
+    NUM_EPOCHS = 1  # placeholder — replaced by weighted computation
+    USE_WEIGHTED_EPOCHS = True
 elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
     SITE_NAME = os.getenv("SITE_NAME")
     if not SITE_NAME:
@@ -29,6 +33,7 @@ elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
         NUM_EPOCHS = int(os.getenv("NUM_EPOCHS", "1"))
     except ValueError:
         raise ValueError("NUM_EPOCHS must be an integer")
+    USE_WEIGHTED_EPOCHS = False
 else:
     raise ValueError(f"Unsupported TRAINING_MODE: {TRAINING_MODE}")
 
@@ -41,7 +46,8 @@ def main():
 
     try:
         data_module, model, checkpointing, trainer, path_run_dir, env_vars = threedcnn_ptl.prepare_training(
-            logger, NUM_EPOCHS, SITE_NAME, LOG_DATASET_DETAILS
+            logger, NUM_EPOCHS, SITE_NAME, LOG_DATASET_DETAILS,
+            weighted_epochs=USE_WEIGHTED_EPOCHS,
         )
 
         if TRAINING_MODE == TM_SWARM:

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -19,15 +19,47 @@ FILENAME_GT_PREDPROB_SITE_MODEL_TRAIN = 'site_model_gt_and_classprob_train.csv'
 FILENAME_GT_PREDPROB_AGGREGATED_MODEL_VALIDATION = 'aggregated_model_gt_and_classprob_validation.csv'
 FILENAME_GT_PREDPROB_SITE_MODEL_VALIDATION = 'site_model_gt_and_classprob_validation.csv'
 
-def get_num_epochs_per_round(site_name: str) -> int:
-    NUM_EPOCHS_FOR_SITE = {
-        "TUD_1": 2, "TUD_2": 4, "TUD_3": 8,
-        "MEVIS_1": 2, "MEVIS_2": 4,
-    }
-    max_epochs = NUM_EPOCHS_FOR_SITE.get(site_name, 5)
-    print(f"Site name: {site_name}")
-    print(f"Max epochs set to: {max_epochs}")
-    return max_epochs
+import os
+
+
+def compute_weighted_epochs(num_train_samples: int, site_name: str = "") -> int:
+    """Compute per-round epoch count weighted by local dataset size.
+
+    Sites with fewer training samples get more local epochs per round so
+    that every site contributes roughly the same number of gradient updates
+    to each aggregation round.  The formula is::
+
+        epochs = base_epochs * (reference_size / num_train_samples)
+
+    clamped to [1, max_cap].
+
+    Environment variables:
+        EPOCHS_PER_ROUND              Base epoch count (default 5).
+        EPOCHS_REFERENCE_DATASET_SIZE Reference dataset size — a site with
+                                      exactly this many samples trains for
+                                      base_epochs (default 500).
+        EPOCHS_MAX_CAP                Upper bound on computed epochs to
+                                      prevent very small sites from running
+                                      excessively many epochs (default 20).
+    """
+    logger = logging.getLogger(__name__)
+    base_epochs = int(os.environ.get("EPOCHS_PER_ROUND", "5"))
+    reference_size = int(os.environ.get("EPOCHS_REFERENCE_DATASET_SIZE", "500"))
+    max_cap = int(os.environ.get("EPOCHS_MAX_CAP", "20"))
+
+    if num_train_samples <= 0:
+        logger.warning(f"num_train_samples={num_train_samples}; falling back to base_epochs={base_epochs}")
+        return base_epochs
+
+    raw = base_epochs * (reference_size / num_train_samples)
+    epochs = max(1, min(int(round(raw)), max_cap))
+
+    logger.info(
+        f"Weighted epochs — site={site_name}, train_samples={num_train_samples}, "
+        f"reference_size={reference_size}, base={base_epochs}, "
+        f"raw={raw:.1f}, clamped={epochs}"
+    )
+    return epochs
 
 
 def set_up_logging():
@@ -274,17 +306,24 @@ class GT_PredProb_Output_Callback(Callback):
 
 
 def prepare_training(logger, max_epochs: int, site_name: str = None,
-                     log_dataset_details: bool = False, model_variant: str = None):
+                     log_dataset_details: bool = False, model_variant: str = None,
+                     weighted_epochs: bool = False):
     """
     Unified prepare_training that supports both ODELIA and challenge job patterns.
 
     Args:
         logger: Logger instance
-        max_epochs: Maximum training epochs
+        max_epochs: Maximum training epochs (used as-is for local/preflight,
+                    or as base_epochs for weighted computation)
         site_name: Site name (used for logging, read from env if not provided)
         log_dataset_details: Whether to log detailed dataset information
         model_variant: Optional model variant override. If provided, overrides MODEL_NAME env var.
                        Can be 'MST', 'ResNet101', 'challenge', '1DivideAndConquer', etc.
+        weighted_epochs: If True, compute per-round epoch count from training
+                         data size via compute_weighted_epochs(). The max_epochs
+                         parameter is ignored in this case; configuration comes
+                         from EPOCHS_PER_ROUND / EPOCHS_REFERENCE_DATASET_SIZE
+                         environment variables instead.
     """
     try:
         env_vars = load_environment_variables()
@@ -294,6 +333,11 @@ def prepare_training(logger, max_epochs: int, site_name: str = None,
             env_vars['model_name'] = model_variant
 
         data_module, path_run_dir, run_name, num_classes, loss_kwargs = set_up_data_module(logger, log_dataset_details)
+
+        # Compute weighted epochs based on training data size
+        if weighted_epochs:
+            num_train_samples = len(data_module.ds_train)
+            max_epochs = compute_weighted_epochs(num_train_samples, site_name or "")
 
         # Use the centralized model factory for all models
         model = create_model(
@@ -362,8 +406,26 @@ def validate_and_train(logger, data_module, model, trainer, path_run_dir, output
 
 
 def finalize_training(logger, model, checkpointing, trainer, path_run_dir, env_vars) -> None:
-    model.save_best_checkpoint(trainer.logger.log_dir, checkpointing.best_model_path)
+    """Save best and latest checkpoints after training completes."""
+    import shutil
 
-    logger.info('Prediction currently not implemented.')
+    # Save best checkpoint (highest val/ACC)
+    best_path = checkpointing.best_model_path
+    if best_path:
+        model.save_best_checkpoint(trainer.logger.log_dir, best_path)
+        logger.info(f'Best model checkpoint: {best_path}')
+    else:
+        logger.warning('No best checkpoint found.')
+
+    # Save latest (last) checkpoint — useful for resuming training or when
+    # the best checkpoint was from an early round and the final aggregated
+    # model is preferred for deployment.
+    last_path = checkpointing.last_model_path
+    if last_path:
+        final_last = path_run_dir / "last_global_model.ckpt"
+        shutil.copy(last_path, final_last)
+        logger.info(f'Last model saved to: {final_last}')
+    else:
+        logger.warning('No last checkpoint found.')
 
     logger.info('Training completed successfully.')

--- a/application/jobs/minimal_training_pytorch_cnn/app/custom/minimal_training.py
+++ b/application/jobs/minimal_training_pytorch_cnn/app/custom/minimal_training.py
@@ -112,5 +112,23 @@ def validate_and_train(logger, data_module, model, trainer) -> None:
     trainer.fit(model, datamodule=data_module)
 
 def finalize_training(logger, model, checkpointing, trainer) -> None:
-    model.save_best_checkpoint(trainer.logger.log_dir, checkpointing.best_model_path)
+    import shutil
+
+    # Save best checkpoint
+    best_path = checkpointing.best_model_path
+    if best_path:
+        model.save_best_checkpoint(trainer.logger.log_dir, best_path)
+        logger.info(f'Best model checkpoint: {best_path}')
+    else:
+        logger.warning('No best checkpoint found.')
+
+    # Save latest (last) checkpoint
+    last_path = checkpointing.last_model_path
+    if last_path:
+        final_last = os.path.join(os.path.dirname(last_path), "last_global_model.ckpt")
+        shutil.copy(last_path, final_last)
+        logger.info(f'Last model saved to: {final_last}')
+    else:
+        logger.warning('No last checkpoint found.')
+
     logger.info('Training completed successfully')


### PR DESCRIPTION
## Summary
- **Weighted epochs**: Replaces hardcoded per-site epoch dictionaries with a formula-based approach: `epochs = base_epochs * (reference_size / num_train_samples)`, clamped to `[1, max_cap]`. Sites with fewer training samples get more local epochs per round, equalizing gradient updates across sites during swarm aggregation. Configurable via `EPOCHS_PER_ROUND`, `EPOCHS_REFERENCE_DATASET_SIZE`, and `EPOCHS_MAX_CAP` environment variables (STAMP uses `STAMP_` prefix).
- **Best + last checkpoints**: `finalize_training()` now saves both the best checkpoint (by monitor metric) and the latest checkpoint across all three job types (ODELIA/challenge, STAMP, minimal CNN). Deployers can choose between peak-validation and final-aggregated models.
- **Epoch computation timing**: Moved epoch count computation from module import time into `prepare_training()`, which runs after data loading — necessary since weighted epochs require knowing the training set size.

## Files changed
| File | Changes |
|------|---------|
| `_shared/custom/threedcnn_ptl.py` | New `compute_weighted_epochs()`, updated `prepare_training()` and `finalize_training()` |
| `_shared/custom/main.py` | `USE_WEIGHTED_EPOCHS` flag, passed to `prepare_training()` |
| `STAMP_classification/app/custom/stamp_training.py` | STAMP version of `compute_weighted_epochs()`, updated `prepare_training()` and `finalize_training()` |
| `STAMP_classification/app/custom/main.py` | Same weighted epochs flag pattern |
| `minimal_training_pytorch_cnn/app/custom/minimal_training.py` | Updated `finalize_training()` for consistency |

## Test plan
- [ ] Verify weighted epoch computation: site with 500 samples → 5 epochs (reference), site with 250 samples → 10 epochs, site with 1000 samples → 3 epochs
- [ ] Verify `EPOCHS_PER_ROUND`, `EPOCHS_REFERENCE_DATASET_SIZE`, `EPOCHS_MAX_CAP` env vars are respected
- [ ] Verify both `best_model.ckpt` and `last_model.ckpt` (or `last_global_model.ckpt`) are saved after training
- [ ] Verify local_training and preflight_check modes still use fixed `NUM_EPOCHS` (no weighted computation)
- [ ] Run integration tests with Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)