### PR TITLE
Add STAMP CI/CD pipeline with unit tests and workflow integration

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate-swarm:
     runs-on: self-hosted
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     env:
       PYTHONUNBUFFERED: 1
@@ -87,6 +87,38 @@ jobs:
         run: |
           ./scripts/ci/runIntegrationTests.sh run_3dcnn_simulation_mode
 
+      # ---------------------------------------------------------------
+      # STAMP pipeline tests
+      # ---------------------------------------------------------------
+      - name: Build STAMP Docker image
+        run: |
+          chmod +x scripts/build/buildDockerImageAndStartupKits.sh
+          ./scripts/build/buildDockerImageAndStartupKits.sh \
+            -p tests/provision/dummy_stamp_project_for_testing.yml \
+            -d docker_config/Dockerfile_STAMP \
+            --use-docker-cache
+
+      - name: Run STAMP preflight check
+        continue-on-error: false
+        env:
+          STAMP_DOCKER_IMAGE: "localhost:5000/stamp:${{ steps.get_version.outputs.version }}"
+        run: |
+          ./scripts/ci/runIntegrationTests.sh run_stamp_preflight_check
+
+      - name: Run STAMP local training
+        continue-on-error: false
+        env:
+          STAMP_DOCKER_IMAGE: "localhost:5000/stamp:${{ steps.get_version.outputs.version }}"
+        run: |
+          ./scripts/ci/runIntegrationTests.sh run_stamp_local_training
+
+      - name: Run STAMP simulation mode
+        continue-on-error: false
+        env:
+          STAMP_DOCKER_IMAGE: "localhost:5000/stamp:${{ steps.get_version.outputs.version }}"
+        run: |
+          ./scripts/ci/runIntegrationTests.sh run_stamp_simulation_mode
+
       - name: Run integration test creating startup kits
         continue-on-error: false
         run: |
@@ -115,9 +147,9 @@ jobs:
       - name: Kill orphaned containers from this run (if any)
         if: always()
         run: |
-          # Kill any odelia Docker containers that may still be running
-          docker ps --format '{{.Names}}' | grep -E 'odelia|nvflare' | xargs -r docker kill 2>/dev/null || true
-          docker ps -a --format '{{.Names}}' | grep -E 'odelia|nvflare' | xargs -r docker rm -f 2>/dev/null || true
+          # Kill any odelia/stamp Docker containers that may still be running
+          docker ps --format '{{.Names}}' | grep -E 'odelia|stamp|nvflare' | xargs -r docker kill 2>/dev/null || true
+          docker ps -a --format '{{.Names}}' | grep -E 'odelia|stamp|nvflare' | xargs -r docker rm -f 2>/dev/null || true
           # Also clean up root-owned workspace files so next run's checkout succeeds
           if [ -d "$GITHUB_WORKSPACE/workspace" ]; then
             docker run --rm -v "$GITHUB_WORKSPACE":/ws alpine sh -c "rm -rf /ws/workspace"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,7 +38,9 @@ jobs:
           python -m pip install --upgrade pip
           # CPU-only PyTorch (much smaller download than full CUDA build)
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install pytorch-lightning scikit-learn pytest
+          # Install unified 'lightning' package — provides both lightning.*
+          # (needed by STAMP tests) and pytorch_lightning.* (needed by ODELIA tests)
+          pip install lightning scikit-learn pytest
 
       - name: Run unit tests
         run: |

--- a/tests/provision/dummy_stamp_project_for_testing.yml
+++ b/tests/provision/dummy_stamp_project_for_testing.yml
@@ -1,0 +1,40 @@
+api_version: 3
+name: stamp___REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS___dummy_stamp_project_for_testing
+description: >
+  Test setup for STAMP classification pipeline.
+
+participants:
+  - name: localhost
+    type: server
+    org: Test_Org
+    fed_learn_port: 8002
+    admin_port: 8003
+  - name: client_A
+    type: client
+    org: Test_Org
+  - name: client_B
+    type: client
+    org: Test_Org
+  - name: admin@test.odelia
+    type: admin
+    org: Test_Org
+    role: project_admin
+
+builders:
+  - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
+    args:
+      template_file: master_template.yml
+  - path: nvflare.lighter.impl.template.TemplateBuilder
+  - path: nvflare.lighter.impl.static_file.StaticFileBuilder
+    args:
+      config_folder: config
+      scheme: http
+      docker_image: localhost:5000/stamp:__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__
+      overseer_agent:
+        path: nvflare.ha.dummy_overseer_agent.DummyOverseerAgent
+        overseer_exists: false
+        args:
+          sp_end_point: localhost:8002:8003
+
+  - path: nvflare.lighter.impl.cert.CertBuilder
+  - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/tests/unit_tests/test_fedprox_callback.py
+++ b/tests/unit_tests/test_fedprox_callback.py
@@ -1,0 +1,285 @@
+"""
+Unit tests for fedprox_callback.py — FedProx proximal term callback.
+
+The FedProx callback adds a proximal term to gradient updates that penalises
+the local model for deviating from the global model.  This regularises
+local training in federated learning with non-IID data across sites.
+
+The callback is compatible with both ODELIA (pytorch_lightning) and STAMP
+(lightning) training pipelines via a try/except import pattern.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Ensure the shared custom directory is importable
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_CUSTOM_DIR = REPO_ROOT / "application" / "jobs" / "_shared" / "custom"
+
+
+def _clear_fedprox_modules():
+    """Remove cached fedprox_callback module so reimport works cleanly."""
+    for mod_name in list(sys.modules):
+        if mod_name in ("fedprox_callback",):
+            del sys.modules[mod_name]
+
+
+@pytest.fixture(autouse=True)
+def _importable_fedprox():
+    """Add shared custom dir to sys.path and clean up after."""
+    original_path = sys.path[:]
+    if str(SHARED_CUSTOM_DIR) not in sys.path:
+        sys.path.insert(0, str(SHARED_CUSTOM_DIR))
+
+    _clear_fedprox_modules()
+    yield
+    _clear_fedprox_modules()
+    sys.path[:] = original_path
+
+
+def _import_fedprox():
+    _clear_fedprox_modules()
+    import fedprox_callback
+    return fedprox_callback
+
+
+# ===================================================================
+# Tests for FedProxCallback initialisation
+# ===================================================================
+
+class TestFedProxCallbackInit:
+    """Test FedProxCallback constructor and validation."""
+
+    def test_default_mu(self):
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback()
+        assert cb.mu == 0.01
+
+    def test_custom_mu(self):
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.5)
+        assert cb.mu == 0.5
+
+    def test_zero_mu(self):
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.0)
+        assert cb.mu == 0.0
+
+    def test_negative_mu_raises(self):
+        mod = _import_fedprox()
+        with pytest.raises(ValueError, match="mu must be >= 0"):
+            mod.FedProxCallback(mu=-0.1)
+
+    def test_global_params_empty_at_init(self):
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback()
+        assert len(cb._global_params) == 0
+
+
+# ===================================================================
+# Tests for on_train_start — global model snapshot
+# ===================================================================
+
+class TestOnTrainStart:
+    """Test on_train_start snapshots the global model."""
+
+    def _make_module(self):
+        """Create a mock Lightning module with real parameters."""
+        module = MagicMock()
+        p1 = torch.nn.Parameter(torch.randn(4, 4))
+        p2 = torch.nn.Parameter(torch.randn(3))
+        # A frozen parameter (requires_grad=False) should be excluded
+        p3 = torch.nn.Parameter(torch.randn(2), requires_grad=False)
+        module.named_parameters.return_value = [
+            ("layer1.weight", p1),
+            ("layer1.bias", p2),
+            ("frozen_param", p3),
+        ]
+        return module, {"layer1.weight": p1, "layer1.bias": p2}
+
+    def test_captures_trainable_params(self):
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.1)
+        module, _ = self._make_module()
+
+        cb.on_train_start(MagicMock(), module)
+
+        assert "layer1.weight" in cb._global_params
+        assert "layer1.bias" in cb._global_params
+
+    def test_excludes_frozen_params(self):
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.1)
+        module, _ = self._make_module()
+
+        cb.on_train_start(MagicMock(), module)
+
+        assert "frozen_param" not in cb._global_params
+
+    def test_snapshots_are_detached_copies(self):
+        """Snapshots should be independent of the original parameters."""
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.1)
+        module, params = self._make_module()
+
+        cb.on_train_start(MagicMock(), module)
+
+        # Modify original param — snapshot should not change
+        original_snapshot = cb._global_params["layer1.weight"].clone()
+        params["layer1.weight"].data.fill_(999.0)
+        assert torch.equal(cb._global_params["layer1.weight"], original_snapshot)
+
+    def test_snapshot_count_matches_trainable(self):
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.1)
+        module, _ = self._make_module()
+
+        cb.on_train_start(MagicMock(), module)
+
+        # 2 trainable params (layer1.weight and layer1.bias), not 3
+        assert len(cb._global_params) == 2
+
+
+# ===================================================================
+# Tests for on_after_backward — proximal gradient injection
+# ===================================================================
+
+class TestOnAfterBackward:
+    """Test on_after_backward adds proximal term to gradients."""
+
+    def _setup(self, mu=0.1):
+        """Create callback with a mock module and captured global params."""
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=mu)
+
+        # Create real parameters with gradients
+        w = torch.nn.Parameter(torch.randn(4, 4))
+        b = torch.nn.Parameter(torch.randn(3))
+
+        module = MagicMock()
+        module.named_parameters.return_value = [
+            ("layer1.weight", w),
+            ("layer1.bias", b),
+        ]
+
+        # Snapshot the global model (simulates start of round)
+        cb.on_train_start(MagicMock(), module)
+
+        # Now modify params to simulate local training
+        w.data.add_(torch.randn_like(w.data) * 0.5)
+        b.data.add_(torch.randn_like(b.data) * 0.5)
+
+        # Simulate backward pass — set some gradients
+        w.grad = torch.zeros_like(w)
+        b.grad = torch.zeros_like(b)
+
+        return cb, module, w, b
+
+    def test_adds_proximal_gradient(self):
+        cb, module, w, b = self._setup(mu=0.1)
+        global_w = cb._global_params["layer1.weight"]
+
+        cb.on_after_backward(MagicMock(), module)
+
+        # Gradient should be mu * (w_local - w_global)
+        expected = 0.1 * (w.data - global_w)
+        assert torch.allclose(w.grad, expected, atol=1e-6)
+
+    def test_bias_gets_proximal_gradient(self):
+        cb, module, w, b = self._setup(mu=0.1)
+        global_b = cb._global_params["layer1.bias"]
+
+        cb.on_after_backward(MagicMock(), module)
+
+        expected = 0.1 * (b.data - global_b)
+        assert torch.allclose(b.grad, expected, atol=1e-6)
+
+    def test_zero_mu_no_gradient_change(self):
+        cb, module, w, b = self._setup(mu=0.0)
+        original_grad = w.grad.clone()
+
+        cb.on_after_backward(MagicMock(), module)
+
+        # With mu=0, gradients should remain zero
+        assert torch.equal(w.grad, original_grad)
+
+    def test_accumulates_with_existing_gradients(self):
+        """Proximal term should add to existing gradients, not replace them."""
+        cb, module, w, b = self._setup(mu=0.1)
+        global_w = cb._global_params["layer1.weight"]
+
+        # Set some existing gradient (from main backward pass)
+        existing_grad = torch.randn_like(w)
+        w.grad = existing_grad.clone()
+
+        cb.on_after_backward(MagicMock(), module)
+
+        expected = existing_grad + 0.1 * (w.data - global_w)
+        assert torch.allclose(w.grad, expected, atol=1e-6)
+
+    def test_no_grad_param_skipped(self):
+        """Parameters without .grad should be skipped (no error)."""
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.1)
+
+        w = torch.nn.Parameter(torch.randn(4))
+        module = MagicMock()
+        module.named_parameters.return_value = [("w", w)]
+
+        cb.on_train_start(MagicMock(), module)
+        w.data.add_(0.5)
+        # w.grad is None — should not crash
+        cb.on_after_backward(MagicMock(), module)
+
+        assert w.grad is None
+
+    def test_empty_global_params_is_noop(self):
+        """If on_train_start was never called, on_after_backward is a no-op."""
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.1)
+
+        w = torch.nn.Parameter(torch.randn(4))
+        w.grad = torch.zeros_like(w)
+        module = MagicMock()
+        module.named_parameters.return_value = [("w", w)]
+
+        original_grad = w.grad.clone()
+        cb.on_after_backward(MagicMock(), module)
+
+        assert torch.equal(w.grad, original_grad)
+
+    def test_large_mu_strong_regularisation(self):
+        """With large mu, proximal gradient dominates."""
+        cb, module, w, b = self._setup(mu=10.0)
+        global_w = cb._global_params["layer1.weight"]
+
+        cb.on_after_backward(MagicMock(), module)
+
+        expected = 10.0 * (w.data - global_w)
+        assert torch.allclose(w.grad, expected, atol=1e-6)
+
+    def test_proximal_term_is_zero_when_params_equal(self):
+        """When local params haven't changed, proximal gradient is zero."""
+        mod = _import_fedprox()
+        cb = mod.FedProxCallback(mu=0.5)
+
+        w = torch.nn.Parameter(torch.randn(4))
+        module = MagicMock()
+        module.named_parameters.return_value = [("w", w)]
+
+        # Snapshot — params are same as current
+        cb.on_train_start(MagicMock(), module)
+
+        # Don't modify params — set gradients to zero
+        w.grad = torch.zeros_like(w)
+
+        cb.on_after_backward(MagicMock(), module)
+
+        # Proximal gradient should be zero since w == w_global
+        assert torch.allclose(w.grad, torch.zeros_like(w), atol=1e-7)

--- a/tests/unit_tests/test_stamp_model_wrapper.py
+++ b/tests/unit_tests/test_stamp_model_wrapper.py
@@ -1,0 +1,256 @@
+"""
+Unit tests for stamp_model_wrapper.py — environment reading and model creation.
+
+stamp_model_wrapper.py imports STAMP at function level (inside _build_stamp_model).
+_get_stamp_env() is pure os.environ logic and needs no STAMP dependencies.
+create_stamp_model() and _build_stamp_model() require STAMP and are tested
+with mocked imports.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Ensure the STAMP custom directory is importable
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP_CUSTOM_DIR = (
+    REPO_ROOT / "application" / "jobs" / "STAMP_classification" / "app" / "custom"
+)
+
+
+def _clear_wrapper_modules():
+    """Remove cached stamp_model_wrapper module."""
+    for mod_name in list(sys.modules):
+        if mod_name in ("stamp_model_wrapper",):
+            del sys.modules[mod_name]
+
+
+@pytest.fixture(autouse=True)
+def _importable_wrapper():
+    """Add STAMP custom dir to sys.path and clean up after."""
+    original_path = sys.path[:]
+    if str(STAMP_CUSTOM_DIR) not in sys.path:
+        sys.path.insert(0, str(STAMP_CUSTOM_DIR))
+
+    _clear_wrapper_modules()
+    yield
+    _clear_wrapper_modules()
+    sys.path[:] = original_path
+
+
+def _import_wrapper():
+    _clear_wrapper_modules()
+    import stamp_model_wrapper
+    return stamp_model_wrapper
+
+
+# ===================================================================
+# Tests for _get_stamp_env()
+# ===================================================================
+
+class TestGetStampEnv:
+    """Test _get_stamp_env() environment variable reading."""
+
+    def test_returns_dict(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert isinstance(result, dict)
+
+    def test_default_task(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert result["task"] == "classification"
+
+    def test_default_model_name(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert result["model_name"] == "vit"
+
+    def test_default_feature_type(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert result["feature_type"] == "tile"
+
+    def test_default_dim_input(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert result["dim_input"] == 1024
+
+    def test_default_num_classes(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert result["num_classes"] == 3
+
+    def test_default_max_lr(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert result["max_lr"] == 1e-4
+
+    def test_default_div_factor(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert result["div_factor"] == 25.0
+
+    def test_custom_overrides(self):
+        env = {
+            "STAMP_TASK": "survival",
+            "STAMP_MODEL_NAME": "attmil",
+            "STAMP_FEATURE_TYPE": "conch",
+            "STAMP_DIM_INPUT": "768",
+            "STAMP_NUM_CLASSES": "5",
+            "STAMP_MAX_LR": "2e-3",
+            "STAMP_DIV_FACTOR": "50.0",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            smw = _import_wrapper()
+            result = smw._get_stamp_env()
+            assert result["task"] == "survival"
+            assert result["model_name"] == "attmil"
+            assert result["feature_type"] == "conch"
+            assert result["dim_input"] == 768
+            assert result["num_classes"] == 5
+            assert result["max_lr"] == 2e-3
+            assert result["div_factor"] == 50.0
+
+    def test_returns_expected_keys(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        expected_keys = {
+            "task", "model_name", "feature_type",
+            "dim_input", "num_classes", "max_lr", "div_factor",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_dim_input_is_int(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert isinstance(result["dim_input"], int)
+
+    def test_num_classes_is_int(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert isinstance(result["num_classes"], int)
+
+    def test_max_lr_is_float(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert isinstance(result["max_lr"], float)
+
+    def test_div_factor_is_float(self):
+        smw = _import_wrapper()
+        result = smw._get_stamp_env()
+        assert isinstance(result["div_factor"], float)
+
+
+# ===================================================================
+# Tests for _build_stamp_model() — with mocked STAMP
+# ===================================================================
+
+class TestBuildStampModel:
+    """Test _build_stamp_model() with mocked STAMP imports."""
+
+    def _setup_stamp_mocks(self):
+        """Create mocks for STAMP registry and config modules."""
+        mock_model = MagicMock()
+        mock_model.parameters.return_value = [torch.randn(10, 10)]
+
+        mock_lit_class = MagicMock(return_value=mock_model)
+        mock_model_class = MagicMock()
+        mock_model_name = MagicMock()
+        mock_model_params = MagicMock()
+        mock_model_params.model_dump.return_value = {"vit": {"use_alibi": True}}
+
+        return {
+            "lit_class": mock_lit_class,
+            "model_class": mock_model_class,
+            "model_name": mock_model_name,
+            "model_params": mock_model_params,
+            "model": mock_model,
+        }
+
+    def test_build_returns_model(self):
+        mocks = self._setup_stamp_mocks()
+
+        # Mock the STAMP imports
+        mock_registry = MagicMock()
+        mock_registry.ModelName.return_value = mocks["model_name"]
+        mock_registry.load_model_class.return_value = (
+            mocks["lit_class"], mocks["model_class"]
+        )
+
+        mock_config = MagicMock()
+        mock_config.ModelParams.return_value = mocks["model_params"]
+
+        stamp_modules = {
+            "stamp": MagicMock(),
+            "stamp.modeling": MagicMock(),
+            "stamp.modeling.registry": mock_registry,
+            "stamp.modeling.config": mock_config,
+        }
+
+        with patch.dict(sys.modules, stamp_modules):
+            smw = _import_wrapper()
+            env = smw._get_stamp_env()
+            model = smw._build_stamp_model(env)
+            assert model is mocks["model"]
+
+    def test_build_raises_without_stamp(self):
+        """Without STAMP installed, _build_stamp_model should raise ImportError."""
+        # Ensure stamp is NOT in sys.modules
+        saved = {}
+        for key in list(sys.modules):
+            if key.startswith("stamp"):
+                saved[key] = sys.modules.pop(key)
+
+        try:
+            smw = _import_wrapper()
+            env = smw._get_stamp_env()
+            with pytest.raises(ImportError, match="STAMP is not installed"):
+                smw._build_stamp_model(env)
+        finally:
+            sys.modules.update(saved)
+
+
+# ===================================================================
+# Tests for create_stamp_model() — kwargs override
+# ===================================================================
+
+class TestCreateStampModel:
+    """Test create_stamp_model() entry point with kwargs."""
+
+    def test_kwargs_override_env(self):
+        """create_stamp_model() should merge kwargs with env vars."""
+        smw = _import_wrapper()
+
+        # Mock _build_stamp_model to capture the env dict
+        captured_env = {}
+
+        def fake_build(env):
+            captured_env.update(env)
+            return MagicMock()
+
+        with patch.object(smw, "_build_stamp_model", side_effect=fake_build):
+            smw.create_stamp_model(num_classes=5, dim_input=768)
+            assert captured_env["num_classes"] == 5
+            assert captured_env["dim_input"] == 768
+
+    def test_none_kwargs_ignored(self):
+        """None kwargs should not override env vars."""
+        smw = _import_wrapper()
+
+        captured_env = {}
+
+        def fake_build(env):
+            captured_env.update(env)
+            return MagicMock()
+
+        with patch.object(smw, "_build_stamp_model", side_effect=fake_build):
+            smw.create_stamp_model(num_classes=None)
+            # Should use default from env, not None
+            assert captured_env["num_classes"] == 3  # default

--- a/tests/unit_tests/test_stamp_training.py
+++ b/tests/unit_tests/test_stamp_training.py
@@ -1,0 +1,464 @@
+"""
+Unit tests for stamp_training.py — environment loading, weighted epochs,
+and validation metric callback.
+
+stamp_training.py imports lightning, torch, and STAMP (at function level).
+We can test load_stamp_environment() and compute_weighted_epochs() without
+any STAMP dependencies since they are pure Python / os.environ logic.
+ValidationMetricCallback only needs lightning (available in CI).
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Ensure the STAMP custom directory is importable
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP_CUSTOM_DIR = (
+    REPO_ROOT / "application" / "jobs" / "STAMP_classification" / "app" / "custom"
+)
+SHARED_CUSTOM_DIR = REPO_ROOT / "application" / "jobs" / "_shared" / "custom"
+
+
+def _clear_stamp_modules():
+    """Remove cached stamp_training module so reimport works cleanly."""
+    for mod_name in list(sys.modules):
+        if mod_name in ("stamp_training",):
+            del sys.modules[mod_name]
+
+
+@pytest.fixture(autouse=True)
+def _importable_stamp_training():
+    """
+    Add the STAMP custom dir to sys.path, mock STAMP-specific imports,
+    and clear the cached module so each test gets a fresh import.
+    """
+    paths_to_add = [str(STAMP_CUSTOM_DIR), str(SHARED_CUSTOM_DIR)]
+    original_path = sys.path[:]
+
+    for p in paths_to_add:
+        if p not in sys.path:
+            sys.path.insert(0, p)
+
+    # Mock the stamp package and its submodules — they're not installed in CI
+    stamp_mocks = {}
+    stamp_modules = [
+        "stamp", "stamp.modeling", "stamp.modeling.data",
+        "stamp.modeling.config", "stamp.modeling.train",
+        "stamp.modeling.transforms", "stamp.modeling.registry",
+    ]
+    for mod in stamp_modules:
+        stamp_mocks[mod] = MagicMock()
+
+    with patch.dict(sys.modules, stamp_mocks):
+        _clear_stamp_modules()
+        yield
+
+    _clear_stamp_modules()
+    sys.path[:] = original_path
+
+
+def _import_stamp_training():
+    _clear_stamp_modules()
+    import stamp_training
+    return stamp_training
+
+
+# ===================================================================
+# Tests for load_stamp_environment()
+# ===================================================================
+
+class TestLoadStampEnvironment:
+    """Test load_stamp_environment() with mocked os.environ."""
+
+    @pytest.fixture
+    def stamp_env_vars(self, tmp_path):
+        """Minimal required env vars for load_stamp_environment()."""
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        return {
+            "SITE_NAME": "TEST_SITE_A",
+            "SCRATCH_DIR": str(scratch),
+            "STAMP_CLINI_TABLE": str(tmp_path / "clini.csv"),
+            "STAMP_FEATURE_DIR": str(tmp_path / "features"),
+        }
+
+    def test_returns_dict(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert isinstance(result, dict)
+
+    def test_reads_site_name(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["site_name"] == "TEST_SITE_A"
+
+    def test_reads_scratch_dir(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["scratch_dir"] == stamp_env_vars["SCRATCH_DIR"]
+
+    def test_reads_clini_table(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["clini_table"] == stamp_env_vars["STAMP_CLINI_TABLE"]
+
+    def test_reads_feature_dir(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["feature_dir"] == stamp_env_vars["STAMP_FEATURE_DIR"]
+
+    def test_default_task_is_classification(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["task"] == "classification"
+
+    def test_default_model_name_is_vit(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["model_name"] == "vit"
+
+    def test_default_dim_input(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["dim_input"] == 1024
+
+    def test_default_num_classes(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["num_classes"] == 3
+
+    def test_default_bag_size(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["bag_size"] == 512
+
+    def test_default_batch_size(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["batch_size"] == 64
+
+    def test_default_max_epochs(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["max_epochs"] == 32
+
+    def test_default_patience(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["patience"] == 16
+
+    def test_custom_overrides(self, stamp_env_vars):
+        env = {
+            **stamp_env_vars,
+            "STAMP_TASK": "survival",
+            "STAMP_MODEL_NAME": "attmil",
+            "STAMP_DIM_INPUT": "768",
+            "STAMP_NUM_CLASSES": "2",
+            "STAMP_BAG_SIZE": "256",
+            "STAMP_BATCH_SIZE": "32",
+            "STAMP_MAX_EPOCHS": "50",
+            "STAMP_PATIENCE": "10",
+            "STAMP_MAX_LR": "5e-5",
+            "STAMP_DIV_FACTOR": "10.0",
+            "STAMP_SEED": "123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["task"] == "survival"
+            assert result["model_name"] == "attmil"
+            assert result["dim_input"] == 768
+            assert result["num_classes"] == 2
+            assert result["bag_size"] == 256
+            assert result["batch_size"] == 32
+            assert result["max_epochs"] == 50
+            assert result["patience"] == 10
+            assert result["max_lr"] == 5e-5
+            assert result["div_factor"] == 10.0
+            assert result["seed"] == 123
+
+    def test_output_dir_auto_generated(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["output_dir"]
+            assert "TEST_SITE_A" in result["output_dir"]
+            assert "STAMP_vit" in result["output_dir"]
+
+    def test_output_dir_explicit(self, stamp_env_vars, tmp_path):
+        env = {**stamp_env_vars, "STAMP_OUTPUT_DIR": str(tmp_path / "custom_out")}
+        with patch.dict(os.environ, env, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["output_dir"] == str(tmp_path / "custom_out")
+
+    def test_raises_without_site_name(self, stamp_env_vars):
+        env = {k: v for k, v in stamp_env_vars.items() if k != "SITE_NAME"}
+        with patch.dict(os.environ, env, clear=True):
+            st = _import_stamp_training()
+            with pytest.raises(KeyError):
+                st.load_stamp_environment()
+
+    def test_raises_without_scratch_dir(self, stamp_env_vars):
+        env = {k: v for k, v in stamp_env_vars.items() if k != "SCRATCH_DIR"}
+        with patch.dict(os.environ, env, clear=True):
+            st = _import_stamp_training()
+            with pytest.raises(KeyError):
+                st.load_stamp_environment()
+
+    def test_raises_without_clini_table(self, stamp_env_vars):
+        env = {k: v for k, v in stamp_env_vars.items() if k != "STAMP_CLINI_TABLE"}
+        with patch.dict(os.environ, env, clear=True):
+            st = _import_stamp_training()
+            with pytest.raises(KeyError):
+                st.load_stamp_environment()
+
+    def test_raises_without_feature_dir(self, stamp_env_vars):
+        env = {k: v for k, v in stamp_env_vars.items() if k != "STAMP_FEATURE_DIR"}
+        with patch.dict(os.environ, env, clear=True):
+            st = _import_stamp_training()
+            with pytest.raises(KeyError):
+                st.load_stamp_environment()
+
+    def test_mediswarm_version_default(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["mediswarm_version"] == "unset"
+
+    def test_mediswarm_version_custom(self, stamp_env_vars):
+        env = {**stamp_env_vars, "MEDISWARM_VERSION": "1.3.0"}
+        with patch.dict(os.environ, env, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            assert result["mediswarm_version"] == "1.3.0"
+
+    def test_returns_all_expected_keys(self, stamp_env_vars):
+        with patch.dict(os.environ, stamp_env_vars, clear=False):
+            st = _import_stamp_training()
+            result = st.load_stamp_environment()
+            expected_keys = {
+                "site_name", "scratch_dir", "mediswarm_version",
+                "clini_table", "feature_dir", "slide_table", "output_dir",
+                "task", "ground_truth_label", "patient_label",
+                "filename_label", "time_label", "status_label",
+                "model_name", "feature_type", "dim_input", "num_classes",
+                "bag_size", "batch_size", "max_epochs", "patience",
+                "max_lr", "div_factor", "num_workers", "seed",
+            }
+            assert set(result.keys()) == expected_keys
+
+
+# ===================================================================
+# Tests for compute_weighted_epochs()
+# ===================================================================
+
+class TestComputeWeightedEpochs:
+    """Test compute_weighted_epochs() logic."""
+
+    def test_reference_size_returns_base(self):
+        """Site with exactly reference_size samples gets base_epochs."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "5",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(200, "test_site")
+            assert result == 5
+
+    def test_half_size_doubles_epochs(self):
+        """Site with half the reference size gets double epochs."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "5",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(100, "test_site")
+            assert result == 10
+
+    def test_double_size_halves_epochs(self):
+        """Site with double the reference size gets half epochs (min 1)."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "4",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(400, "test_site")
+            assert result == 2
+
+    def test_very_large_site_gets_minimum_1(self):
+        """Very large site is clamped to minimum of 1 epoch."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "5",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(100000, "test_site")
+            assert result == 1
+
+    def test_very_small_site_capped_at_max(self):
+        """Very small site is clamped to max_cap."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "5",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(5, "test_site")
+            assert result == 20
+
+    def test_zero_samples_returns_base(self):
+        """Zero samples falls back to base_epochs."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "5",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(0, "test_site")
+            assert result == 5
+
+    def test_negative_samples_returns_base(self):
+        """Negative samples falls back to base_epochs."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "5",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(-10, "test_site")
+            assert result == 5
+
+    def test_returns_integer(self):
+        """Result is always an integer."""
+        with patch.dict(os.environ, {
+            "STAMP_EPOCHS_PER_ROUND": "5",
+            "STAMP_EPOCHS_REFERENCE_DATASET_SIZE": "200",
+            "STAMP_EPOCHS_MAX_CAP": "20",
+        }, clear=False):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(150, "test_site")
+            assert isinstance(result, int)
+
+    def test_defaults_from_env(self):
+        """Test default env var values (no STAMP_EPOCHS_* set)."""
+        # Clear any existing STAMP_EPOCHS_ vars
+        env_clean = {k: v for k, v in os.environ.items()
+                     if not k.startswith("STAMP_EPOCHS_")}
+        with patch.dict(os.environ, env_clean, clear=True):
+            st = _import_stamp_training()
+            result = st.compute_weighted_epochs(200, "test_site")
+            # Default: base=5, reference=200, so 200/200*5 = 5
+            assert result == 5
+
+
+# ===================================================================
+# Tests for ValidationMetricCallback
+# ===================================================================
+
+class TestValidationMetricCallback:
+    """Test ValidationMetricCallback attributes."""
+
+    def test_init_defaults(self):
+        st = _import_stamp_training()
+        cb = st.ValidationMetricCallback()
+        assert cb.last_val_loss is None
+        assert cb.last_val_auroc is None
+
+    def test_on_validation_epoch_end_captures_loss(self):
+        st = _import_stamp_training()
+        cb = st.ValidationMetricCallback()
+
+        # Mock trainer with callback_metrics
+        mock_trainer = MagicMock()
+        mock_trainer.callback_metrics = {
+            "validation_loss": torch.tensor(0.42),
+        }
+        mock_module = MagicMock()
+
+        cb.on_validation_epoch_end(mock_trainer, mock_module)
+        assert cb.last_val_loss is not None
+        assert abs(cb.last_val_loss - 0.42) < 1e-6
+
+    def test_on_validation_epoch_end_captures_auroc(self):
+        st = _import_stamp_training()
+        cb = st.ValidationMetricCallback()
+
+        mock_trainer = MagicMock()
+        mock_trainer.callback_metrics = {
+            "validation_loss": torch.tensor(0.5),
+            "val_MulticlassAUROC": torch.tensor(0.85),
+        }
+        mock_module = MagicMock()
+
+        cb.on_validation_epoch_end(mock_trainer, mock_module)
+        assert cb.last_val_auroc is not None
+        assert abs(cb.last_val_auroc - 0.85) < 1e-6
+
+    def test_on_validation_epoch_end_no_loss(self):
+        st = _import_stamp_training()
+        cb = st.ValidationMetricCallback()
+
+        mock_trainer = MagicMock()
+        mock_trainer.callback_metrics = {}
+        mock_module = MagicMock()
+
+        cb.on_validation_epoch_end(mock_trainer, mock_module)
+        assert cb.last_val_loss is None
+
+    def test_on_validation_epoch_end_val_auroc_key(self):
+        """Test that val_auroc key also works (alternative to val_MulticlassAUROC)."""
+        st = _import_stamp_training()
+        cb = st.ValidationMetricCallback()
+
+        mock_trainer = MagicMock()
+        mock_trainer.callback_metrics = {
+            "validation_loss": torch.tensor(0.3),
+            "val_auroc": torch.tensor(0.91),
+        }
+        mock_module = MagicMock()
+
+        cb.on_validation_epoch_end(mock_trainer, mock_module)
+        assert cb.last_val_auroc is not None
+        assert abs(cb.last_val_auroc - 0.91) < 1e-6
+
+    def test_on_validation_epoch_end_prefers_val_auroc(self):
+        """When both val_auroc and val_MulticlassAUROC exist, val_auroc comes first."""
+        st = _import_stamp_training()
+        cb = st.ValidationMetricCallback()
+
+        mock_trainer = MagicMock()
+        mock_trainer.callback_metrics = {
+            "validation_loss": torch.tensor(0.3),
+            "val_auroc": torch.tensor(0.80),
+            "val_MulticlassAUROC": torch.tensor(0.90),
+        }
+        mock_module = MagicMock()
+
+        cb.on_validation_epoch_end(mock_trainer, mock_module)
+        # val_auroc is checked first in the for loop
+        assert abs(cb.last_val_auroc - 0.80) < 1e-6


### PR DESCRIPTION
## Summary

- Add **unit tests** for STAMP training pipeline:
  - `test_stamp_training.py` (~465 lines) — tests for `load_stamp_environment()`, `compute_weighted_epochs()`, `ValidationMetricCallback`, environment variable parsing, and edge cases
  - `test_stamp_model_wrapper.py` (~257 lines) — tests for `_get_stamp_env()`, `create_stamp_model()`, NVFlare model wrapper interface
  - `test_fedprox_callback.py` (~286 lines) — tests for `FedProxCallback` proximal term computation, μ=0 passthrough, Lightning compatibility
- Add **STAMP integration test steps** to `pr-test.yaml` GitHub Actions workflow:
  - Docker build with `Dockerfile_STAMP`
  - Preflight check, local training, and NVFlare simulation mode
  - Cleanup step expanded to kill `stamp` and `nvflare` containers alongside `odelia`
- Switch `unit-tests.yaml` from `pytorch-lightning` to unified `lightning` package for cross-pipeline compatibility
- Add STAMP dummy provision file for CI testing
- Increase PR test timeout from 45 to 60 minutes

### Test infrastructure

| Test type | Runner | Environment | Scope |
|-----------|--------|-------------|-------|
| Unit tests | ubuntu-latest (CPU) | Python 3.11+ | stamp_training, model_wrapper, fedprox_callback |
| Integration tests | self-hosted GPU | STAMP Docker image | Preflight, local training, simulation |

## Test plan

- [ ] Unit tests pass on ubuntu-latest with `pytest`
- [ ] `lightning` package provides both `lightning.pytorch` and `pytorch_lightning` namespaces
- [ ] STAMP Docker build succeeds in CI
- [ ] STAMP integration tests (preflight, local training, simulation) pass on GPU runner
- [ ] ODELIA CI tests unaffected by changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)