### PR TITLE
Release v1.4.1

### DIFF
--- a/application/provision/project_deploy_test_2site.yml
+++ b/application/provision/project_deploy_test_2site.yml
@@ -1,6 +1,6 @@
 api_version: 3
 name: odelia_deploy_test___REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS___model_test
-description: ODELIA 2-client deploy test across Tailscale VPN (dl2, dl3; server on Cosmos) — dl0 excluded
+description: ODELIA 2-client deploy test across Tailscale VPN (dl0, dl2; server on Cosmos)
 
 participants:
   - name: dl3.tud.de
@@ -8,10 +8,10 @@ participants:
     org: TUD
     fed_learn_port: 8002
     admin_port: 8003
-  - name: MHA_1
+  - name: RUMC_1
     type: client
     org: TUD
-  - name: CAM_1
+  - name: MHA_1
     type: client
     org: TUD
   - name: jiefu.zhu@tu-dresden.de

--- a/deploy_sites_2node_test.conf
+++ b/deploy_sites_2node_test.conf
@@ -1,20 +1,30 @@
 # 2-client ODELIA deploy test configuration (Tailscale VPN)
 # ============================================================================
 # Cosmos = server + admin ONLY (no training client — RTX 5070 not supported)
+# dl0    = RUMC_1 client
 # dl2    = MHA_1 client
-# dl3    = CAM_1 client
 #
-# dl0 (RUMC_1) excluded due to persistent EXECUTION_EXCEPTION crashes.
+# dl3 excluded due to GPU contention with other training jobs.
 # ============================================================================
 
 # CLIENT_SITES lists only the training client entries.
-CLIENT_SITES=(DL2 DL3A)
+CLIENT_SITES=(DL0 DL2)
 
 # ── Cosmos (server + admin only) ──────────────────────────────
 COSMOS_HOST=localhost
 COSMOS_USER=jeff
 COSMOS_PASS=''
 COSMOS_DEPLOY_DIR=/home/jeff/deploy_test
+
+# ── dl0 ────────────────────────────────────────────────
+DL0_HOST=100.127.161.36
+DL0_USER=swarm
+DL0_PASS='Ekfz2ekfz'
+DL0_SITE_NAME=RUMC_1
+DL0_DATADIR=/mnt/dlhd0/odelia_data
+DL0_SCRATCHDIR=/mnt/dlhd0/deploy_test
+DL0_DEPLOY_DIR=/home/swarm/deploy_test
+DL0_GPU="device=0"
 
 # ── dl2 ────────────────────────────────────────────────
 DL2_HOST=100.64.251.72
@@ -25,16 +35,6 @@ DL2_DATADIR=/mnt/sda1/odelia_data
 DL2_SCRATCHDIR=/mnt/sda1/deploy_test
 DL2_DEPLOY_DIR=/home/swarm/deploy_test
 DL2_GPU="device=0"
-
-# ── dl3: CAM_1 ────────────────────────────────────────
-DL3A_HOST=100.126.224.113
-DL3A_USER=swarm
-DL3A_PASS='Ekfz2ekfz'
-DL3A_SITE_NAME=CAM_1
-DL3A_DATADIR=/mnt/swarm_alpha/Odelia_challange/ODELIA_Challenge_unilateral
-DL3A_SCRATCHDIR=/mnt/scratch/deploy_test
-DL3A_DEPLOY_DIR=/home/swarm/deploy_test
-DL3A_GPU="device=0"
 
 # ── Defaults ───────────────────────────────────────────
 PROJECT_FILE=application/provision/project_deploy_test_2site.yml

--- a/odelia_image.version
+++ b/odelia_image.version
@@ -1,2 +1,2 @@
 # version of the ODELIA Docker image, read by different scripts
-1.4.0
+1.4.1


### PR DESCRIPTION
## Summary
- Bump version from 1.4.0 to 1.4.1
- Update 2-site deploy test configuration to use DL0 (RUMC_1) + DL2 (MHA_1) instead of DL2 + DL3 to avoid GPU contention on DL3

## Deploy Test Results
Successfully validated with `challenge_1DivideAndConquer` over Tailscale VPN:
- **30+ error-free training rounds** across two consecutive runs
- **RUMC_1** (DL0, 100.127.161.36): ~11-14 min per round
- **MHA_1** (DL2, 100.64.251.72): ~14-16 min per round
- P2P model exchange (689MB): ~2-3 seconds between rounds
- Both `swarm_config` and `swarm_start` phases completed cleanly
- Adaptive epoch calculation working correctly with EPOCHS_MAX_CAP=10

## Test plan
- [x] 2-site deploy test with DL0 + DL2 over Tailscale VPN
- [x] 30+ cumulative error-free rounds completed
- [x] Both clients training and exchanging models successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)