### PR TITLE
Add STAMP deploy test and participant guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ to be extended with new tasks through a simple compatibility interface
 
 Choose your role and follow the instructions:
 
-- [Swarm Participant (Medical Site / Data Scientist)](assets/readme/README.participant.md)
+- [Swarm Participant — ODELIA / Breast MRI](assets/readme/README.participant.md)
+- [Swarm Participant — STAMP / Computational Pathology](assets/readme/README.participant.STAMP.md)
 - [Developer (Docker, Code, Pipeline)](assets/readme/README.developer.md)
 - [Swarm Operator (Provisioning, VPN, Server)](assets/readme/README.operator.md)
 - [Automated Deploy & Test Workflow](DEPLOY_README.md)

--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -1,0 +1,356 @@
+# MediSwarm Participant Guide — STAMP (Computational Pathology)
+
+This guide is for data scientists and medical research sites participating in a
+STAMP (Solid Tumor Associative Modeling in Pathology) swarm learning project. If
+you are joining an ODELIA (breast MRI) project instead, see
+[README.participant.md](README.participant.md).
+
+## Overview
+
+STAMP trains classification, regression, or survival models on **pre-extracted
+feature vectors** from whole-slide pathology images (WSIs). Unlike ODELIA, which
+trains on raw 3D NIfTI volumes, STAMP expects HDF5 (`.h5`) feature files that
+have already been extracted from WSIs using a foundation model (e.g. UNI,
+CTransPath, RetCCL).
+
+Only the **training** step is federated. Feature extraction (preprocessing) and
+inference (deployment) remain standalone steps that each site runs locally.
+
+## Prerequisites
+
+- **Hardware:** Min. 32 GB RAM, 8 cores, NVIDIA GPU with 12+ GB VRAM, 1 TB storage
+  (STAMP is lighter on GPU memory than ODELIA because it operates on extracted
+  features rather than full imaging volumes)
+- **OS:** Ubuntu 20.04 LTS, 22.04 LTS, or 24.04 LTS
+- **Software:** Docker, OpenVPN
+- **Data:** Pre-extracted H5 feature files + clinical metadata CSV (see
+  [Prepare Dataset](#prepare-dataset) below)
+
+## Setup
+
+0. Add this line to your `/etc/hosts`: `172.24.4.65 dl3.tud.de dl3`
+1. Make sure your compute node satisfies the specification and has the necessary
+   software installed.
+2. Set up the VPN. A VPN is necessary so that the swarm nodes can communicate
+   with each other securely across firewalls.
+    1. Install OpenVPN
+       ```bash
+       sudo apt-get install openvpn
+       ```
+    2. If you have a graphical user interface (GUI), follow this guide to connect
+       to the VPN: [VPN setup guide(GUI).pdf](../VPN%20setup%20guide%28GUI%29.pdf)
+    3. If you have a command line interface (CLI), follow this guide to connect
+       to the VPN: [VPN setup guide(CLI).md](../VPN%20setup%20guide%28CLI%29.md)
+    4. You may want to clone this repository or selectively download VPN-related
+       scripts for this purpose.
+
+## Prepare Dataset
+
+STAMP requires two inputs per site: a **feature directory** containing one H5
+file per slide/patient, and a **clinical table** (CSV) with ground-truth labels.
+
+### Feature Extraction (Prerequisite)
+
+Before joining a swarm project you must extract features from your whole-slide
+images using the agreed-upon foundation model and tile size. This is done with
+standalone [STAMP](https://github.com/KatherLab/STAMP) preprocessing and
+produces one `.h5` file per slide.
+
+Coordinate with your swarm operator to ensure all sites use the **same feature
+extractor, tile size, and feature dimension** — mismatched features will cause
+training failures.
+
+### Folder Structure
+
+```
+<name of your site>/
+├── features/
+│   ├── slide_001.h5
+│   ├── slide_002.h5
+│   ├── slide_003.h5
+│   └── ...
+└── clini_table.csv
+```
+
+* The name of your site should match your NVFlare site identifier (e.g.
+  `UKA_1`), unless instructed otherwise by your swarm operator.
+* The `features/` directory contains one `.h5` file per slide (or per patient,
+  depending on feature extraction settings).
+
+### H5 Feature File Format
+
+Each `.h5` file must contain:
+
+| Dataset   | Shape           | Dtype   | Description |
+|-----------|-----------------|---------|-------------|
+| `feats`   | (N_tiles, dim)  | float32 | Feature vectors (e.g. 1024-dim for UNI) |
+| `coords`  | (N_tiles, 2)    | float32 | Tile coordinates (for tile-level features) |
+
+Optional HDF5 attributes: `feat_type` (`tile`, `slide`, or `patient`),
+`tile_size`, `unit`.
+
+The feature dimension (`dim`) must match the `STAMP_DIM_INPUT` environment
+variable (default: 1024 for UNI/UNI2; use 768 for CTransPath).
+
+### Clinical Table Format
+
+`clini_table.csv` is a CSV file with at minimum the following columns:
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| Patient ID column | Unique patient identifier (default column name: `PATIENT`) | `P_001` |
+| Ground truth column | Class label for classification, or continuous value for regression | `tumor`, `normal`, `adenoma` |
+
+The patient ID column name is configured via `STAMP_PATIENT_LABEL` (default:
+`PATIENT`) and the ground truth column via `STAMP_GROUND_TRUTH_LABEL`.
+
+**Important:** The H5 filenames (without `.h5`) must match the patient
+identifiers in the clinical table, or a separate slide table must be provided
+to map between them.
+
+#### Optional: Slide Table
+
+If patients have multiple slides, provide a slide table (`STAMP_SLIDE_TABLE`)
+that maps patient IDs to slide filenames.
+
+### Synthetic Test Data
+
+To verify your setup before using real data, you can generate a synthetic
+dataset:
+
+```bash
+python application/jobs/STAMP_classification/app/scripts/create_synthetic_dataset/create_synthetic_stamp_dataset.py \
+    --output_dir /tmp/stamp_synthetic_data
+```
+
+This creates two test sites (`client_A/`, `client_B/`) each with 15 synthetic
+patients across 3 classes.
+
+## Prepare Training Participation
+
+1. Extract the startup kit provided by your swarm operator for the current
+   experiment.
+
+### Configure STAMP Environment Variables
+
+STAMP uses environment variables (all prefixed with `STAMP_`) to configure the
+training. These must be exported **before** calling `docker.sh` — the script
+automatically forwards all `STAMP_*` variables into the Docker container.
+
+```bash
+# ── Required ──
+export STAMP_CLINI_TABLE="/data/<SITE_NAME>/clini_table.csv"
+export STAMP_FEATURE_DIR="/data/<SITE_NAME>/features"
+export STAMP_GROUND_TRUTH_LABEL="<column name>"   # e.g. "Diagnosis"
+export STAMP_PATIENT_LABEL="PATIENT"               # patient ID column name
+
+# ── Task & Model ──
+export STAMP_TASK="classification"                 # classification, regression, or survival
+export STAMP_MODEL_NAME="vit"                      # vit, mlp, trans_mil, linear, barspoon
+export STAMP_DIM_INPUT="1024"                      # must match your feature extractor
+export STAMP_NUM_CLASSES="3"                        # number of output classes
+
+# ── Training (defaults shown — adjust as needed) ──
+export STAMP_BAG_SIZE="512"                        # tiles per bag
+export STAMP_BATCH_SIZE="64"                       # training batch size
+export STAMP_MAX_EPOCHS="32"                       # max epochs per round
+export STAMP_PATIENCE="16"                         # early stopping patience
+export STAMP_SEED="42"                             # random seed
+export STAMP_NUM_WORKERS="0"                       # DataLoader workers (0 = main thread)
+```
+
+**Note:** The paths in `STAMP_CLINI_TABLE` and `STAMP_FEATURE_DIR` are
+**container paths**. The host `--data_dir` is mounted at `/data/` inside the
+container (read-only), so if your host data is at
+`/mnt/data/stamp/UKA_1/features/`, pass `--data_dir /mnt/data/stamp` and set
+`STAMP_FEATURE_DIR="/data/UKA_1/features"`.
+
+Your swarm operator will tell you the correct values for `STAMP_MODEL_NAME`,
+`STAMP_DIM_INPUT`, `STAMP_NUM_CLASSES`, `STAMP_GROUND_TRUTH_LABEL`, and
+`STAMP_TASK` — these must be consistent across all sites.
+
+### Available Models
+
+| Model | `STAMP_MODEL_NAME` | Description |
+|-------|---------------------|-------------|
+| VIT | `vit` | Vision Transformer with ALiBi positional encoding |
+| MLP | `mlp` | Multi-layer perceptron |
+| TransMIL | `trans_mil` | Transformer-based multiple instance learning |
+| Linear | `linear` | Linear classifier |
+| Barspoon | `barspoon` | Encoder-decoder transformer |
+
+### Local Testing on Your Data
+
+1. Set up directories:
+   ```bash
+   export SITE_NAME=<name of your site, e.g., UKA_1>
+   export DATADIR=<path to the folder containing your $SITE_NAME directory>
+   export SCRATCHDIR=<path to where training can store temporary files>
+   mkdir -p $SCRATCHDIR
+   ```
+
+2. From the directory where you unpacked the startup kit:
+   ```bash
+   cd $SITE_NAME/startup
+   ```
+
+3. Verify that your Docker/GPU setup is working:
+   ```bash
+   ./docker.sh --scratch_dir $SCRATCHDIR --GPU device=0 --dummy_training 2>&1 | tee dummy_training_console_output.txt
+   ```
+   * This will pull the Docker image, which might take a while.
+   * If you have multiple GPUs and 0 is busy, use a different one.
+   * The "training" itself should take less than a minute and does not use STAMP
+     — it runs a minimal CNN on CIFAR-10 to verify Docker + GPU.
+
+4. Export your STAMP environment variables (see
+   [Configure STAMP Environment Variables](#configure-stamp-environment-variables)
+   above), then verify that your local data can be accessed:
+   ```bash
+   ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check 2>&1 | tee preflight_check_console_output.txt
+   ```
+   * This runs 1 epoch of training on your local data as a quick smoke test.
+   * Check `preflight_check_console_output.txt` for errors about missing H5
+     files, mismatched patient IDs, or incorrect feature dimensions.
+
+5. Check your local dataset for discrepancies:
+   * There should be no duplicate patient IDs in the clinical table.
+   * Every H5 file in the feature directory should have a corresponding entry in
+     the clinical table (and vice versa).
+   * Feature dimensions in H5 files should match `STAMP_DIM_INPUT`.
+   * You can add `--log_dataset_details` for more detailed output:
+     ```bash
+     ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --log_dataset_details
+     ```
+     (This output may contain confidential patient IDs — do not share it!)
+
+### Run Local Training
+
+To have a baseline for swarm training, train the same model locally:
+
+1. From the directory where you unpacked the startup kit (unless you just ran the
+   preflight check):
+   ```bash
+   cd $SITE_NAME/startup
+   ```
+
+2. Make sure your STAMP environment variables are exported, then start local
+   training:
+   ```bash
+   ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training 2>&1 | tee local_training_console_output.txt
+   ```
+
+3. Output files:
+   * Console output: `startup/local_training_console_output.txt`
+   * Training results are stored in `$SCRATCHDIR/` under a timestamped run
+     directory, including:
+     * Model checkpoints (`best.ckpt`, `last.ckpt`)
+     * Training logs
+     * Validation metrics
+
+### Start Swarm Node
+
+#### VPN
+
+1. Connect to VPN as described in [VPN setup guide(GUI).pdf](../VPN%20setup%20guide%28GUI%29.pdf)
+   (GUI) or [VPN setup guide(CLI).md](../VPN%20setup%20guide%28CLI%29.md)
+   (command line).
+
+#### Start the Client
+
+1. From the directory where you unpacked the startup kit:
+   ```bash
+   cd $SITE_NAME/startup  # Skip this if you just ran the preflight check
+   ```
+
+2. Make sure your STAMP environment variables are exported (see
+   [Configure STAMP Environment Variables](#configure-stamp-environment-variables)),
+   then start the client:
+   ```bash
+   ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --start_client
+   ```
+   If you have multiple GPUs and 0 is busy, use a different one.
+
+3. Console output is captured in `nohup.out`, which may have been created with
+   limited permissions in the container, so make it readable if necessary:
+   ```bash
+   sudo chmod a+r nohup.out
+   ```
+
+4. Output files:
+   * Console output: `startup/nohup.out`
+   * NVFlare log: `log.txt` (in the startup kit root)
+   * Training results are stored in `$SCRATCHDIR/` under a timestamped run
+     directory
+   * NVFlare job artifacts: `<JOB_ID>/app_$SITE_NAME/`
+     * Aggregated model: `FL_global_model.pt`
+     * Best aggregated model: `best_FL_global_model.pt`
+
+## Troubleshooting
+
+### Container Running Properly?
+
+```bash
+docker ps          # Check if stamp_swarm_client_$SITE_NAME is listed
+nvidia-smi         # Check if the GPU is busy training
+tail -f nohup.out  # Follow training log
+```
+
+For any issues, check if the commands above point to problems and contact your
+Swarm Operator.
+
+### STAMP Environment Variables Not Forwarded?
+
+If training fails with errors about missing `STAMP_CLINI_TABLE` or
+`STAMP_FEATURE_DIR`, verify that:
+
+1. You exported the `STAMP_*` variables in the **same shell session** before
+   calling `docker.sh`.
+2. The paths use **container paths** (starting with `/data/`) not host paths.
+3. Run `env | grep STAMP_` to confirm all variables are set.
+
+### Data Issues?
+
+* **"No H5 files found"** — Check that `STAMP_FEATURE_DIR` points to the
+  correct directory inside the container (`/data/<SITE_NAME>/features`).
+* **"Patient ID not found"** — Ensure H5 filenames (without `.h5`) match the
+  patient ID column in the clinical table.
+* **"Feature dimension mismatch"** — Ensure `STAMP_DIM_INPUT` matches the
+  dimension of features in your H5 files (check with
+  `python -c "import h5py; f=h5py.File('slide.h5','r'); print(f['feats'].shape)"`).
+
+### Connection to Swarm Server Working?
+
+Let the following command run for an hour or so:
+
+```bash
+ping dl3.tud.de
+```
+
+* If dl3.tud.de cannot be resolved, double-check whether it is contained in
+  `/etc/hosts`.
+* If it cannot be reached at all, double-check if the VPN connection is working.
+* If intermittent packet loss occurs, double-check if your network connection is
+  working properly. Creating new VPN credentials and certificate may also help —
+  contact your Swarm Operator.
+
+### Further Possible Issues
+
+* Ensure `STAMP_GROUND_TRUTH_LABEL` exactly matches the column name in your
+  clinical CSV (including capitalization).
+* Ensure `STAMP_PATIENT_LABEL` exactly matches the patient ID column name.
+* Feature files and clinical table entries need correct filenames including
+  capitalization.
+* Symlinks inside the data directory do not work — they are not available inside
+  the Docker mount (which is read-only).
+* The correct startup kit needs to be used. `SSLCertVerificationError` or
+  `authentication failed` may indicate an incorrect startup kit incompatible
+  with the current experiment.
+* Do not start the VPN connection more than once on the same machine; do not use
+  the same credentials on more than one machine at the same time.
+* Disk full — see the [ODELIA participant guide](README.participant.md) for
+  general disk management tips (Docker image cleanup, checkpoint accumulation,
+  etc.).
+* Docker storage configuration — if you have a small system partition and large
+  data partition, configure Docker's `data-root` accordingly (see
+  [ODELIA participant guide](README.participant.md) for details).

--- a/deploy_sites_2node_stamp_test.conf
+++ b/deploy_sites_2node_stamp_test.conf
@@ -1,0 +1,44 @@
+# 2-client STAMP deploy test configuration (Tailscale VPN)
+# ============================================================================
+# Cosmos = server + admin ONLY (no training client — RTX 5070 not supported)
+# dl0    = RUMC_1 client
+# dl2    = MHA_1 client
+#
+# Separate data paths, scratch dirs, and deploy dirs from ODELIA to avoid
+# collision. STAMP uses pre-extracted H5 feature files, not NIfTI volumes.
+# ============================================================================
+
+# CLIENT_SITES lists only the training client entries.
+CLIENT_SITES=(DL0 DL2)
+
+# ── Cosmos (server + admin only) ──────────────────────────────
+COSMOS_HOST=localhost
+COSMOS_USER=jeff
+COSMOS_PASS=''
+COSMOS_DEPLOY_DIR=/home/jeff/deploy_test_stamp
+
+# ── dl0 ────────────────────────────────────────────────
+DL0_HOST=100.127.161.36
+DL0_USER=swarm
+DL0_PASS='Ekfz2ekfz'
+DL0_SITE_NAME=RUMC_1
+DL0_DATADIR=/mnt/dlhd0/stamp_test_data
+DL0_SCRATCHDIR=/mnt/dlhd0/deploy_test_stamp
+DL0_DEPLOY_DIR=/home/swarm/deploy_test_stamp
+DL0_GPU="device=0"
+
+# ── dl2 ────────────────────────────────────────────────
+DL2_HOST=100.64.251.72
+DL2_USER=swarm
+DL2_PASS='Ekfz2ekfz'
+DL2_SITE_NAME=MHA_1
+DL2_DATADIR=/mnt/sda1/stamp_test_data
+DL2_SCRATCHDIR=/mnt/sda1/deploy_test_stamp
+DL2_DEPLOY_DIR=/home/swarm/deploy_test_stamp
+DL2_GPU="device=0"
+
+# ── Defaults ───────────────────────────────────────────
+PROJECT_FILE=application/provision/project_deploy_test_2site.yml
+DEFAULT_JOB=STAMP_classification
+ADMIN_USER=jiefu.zhu@tu-dresden.de
+SERVER_NAME=dl3.tud.de

--- a/docker_config/Dockerfile_STAMP
+++ b/docker_config/Dockerfile_STAMP
@@ -57,9 +57,10 @@ RUN python3 -m pip install --no-cache-dir \
 
 WORKDIR /workspace/
 COPY ./MediSwarm/docker_config/NVFlare /workspace/nvflare
-# Override with MediSwarm master_template.yml (contains version placeholders
-# injected by build script)
-COPY ./MediSwarm/docker_config/master_template.yml /workspace/nvflare/nvflare/lighter/templates/
+# Override with MediSwarm STAMP master template (contains version placeholders
+# injected by build script). Destination must be master_template.yml because
+# NVFlare's provisioning tool hardcodes that filename.
+COPY ./MediSwarm/docker_config/master_template_STAMP.yml /workspace/nvflare/nvflare/lighter/templates/master_template.yml
 RUN python3 -m pip install --no-cache-dir /workspace/nvflare && rm -rf /workspace/nvflare
 
 # ---------------------------------------------------------------------------

--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -1,0 +1,1432 @@
+readme_am: |
+  *********************************
+  Admin Client package
+  *********************************
+  The package includes at least the following files:
+  readme.txt
+  rootCA.pem
+  client.crt
+  client.key
+  fl_admin.sh
+
+  Please install the nvflare package by 'python3 -m pip nvflare.'  This will install a set of Python codes
+  in your environment.  After installation, you can run the fl_admin.sh file to start communicating to the admin server.
+
+  The rootCA.pem file is pointed by "ca_cert" in fl_admin.sh.  If you plan to move/copy it to a different place,
+  you will need to modify fl_admin.sh.  The same applies to the other two files, client.crt and client.key.
+
+  The email in your submission to participate this Federated Learning project is embedded in the CN field of client
+  certificate, which uniquely identifies the participant.  As such, please safeguard its private key, client.key.
+
+readme_fc: |
+  *********************************
+  Federated Learning Client package
+  *********************************
+  The package includes at least the following files:
+  readme.txt
+  rootCA.pem
+  client.crt
+  client.key
+  fed_client.json
+  start.sh
+  sub_start.sh
+  stop_fl.sh
+
+  Run start.sh to start the client.
+
+  The rootCA.pem file is pointed by "ssl_root_cert" in fed_client.json.  If you plan to move/copy it to a different place,
+  you will need to modify fed_client.json.  The same applies to the other two files, client.crt and client.key.
+
+  The client name in your submission to participate this Federated Learning project is embedded in the CN field of client
+  certificate, which uniquely identifies the participant.  As such, please safeguard its private key, client.key.
+
+readme_fs: |
+  *********************************
+  Federated Learning Server package
+  *********************************
+  The package includes at least the following files:
+  readme.txt
+  rootCA.pem
+  server.crt
+  server.key
+  authorization.json
+  fed_server.json
+  start.sh
+  sub_start.sh
+  stop_fl.sh
+  signature.json
+
+  Run start.sh to start the server.
+
+  The rootCA.pem file is pointed by "ssl_root_cert" in fed_server.json.  If you plan to move/copy it to a different place,
+  you will need to modify fed_server.json.  The same applies to the other two files, server.crt and server.key.
+
+  Please always safeguard the server.key.
+
+local_client_resources: |
+  {
+    "format_version": 2,
+    "client": {
+      "retry_timeout": 30,
+      "compression": "Gzip"
+    },
+    "components": [
+      {
+        "id": "resource_manager",
+        "path": "nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager",
+        "args": {
+          "num_of_gpus": {~~num_gpus~~},
+          "mem_per_gpu_in_GiB": {~~gpu_mem~~}
+        }
+      },
+      {
+        "id": "resource_consumer",
+        "path": "nvflare.app_common.resource_consumers.gpu_resource_consumer.GPUResourceConsumer",
+        "args": {}
+      },
+      {
+        "id": "process_launcher",
+        "path": "nvflare.app_common.job_launcher.client_process_launcher.ClientProcessJobLauncher",
+        "args": {}
+      },
+      {
+          "id": "error_log_sender",
+          "path": "nvflare.app_common.logging.log_sender.ErrorLogSender",
+          "args": {}
+      }
+    ]
+  }
+
+fed_client: |
+  {
+    "format_version": 2,
+    "servers": [
+      {
+        "name": "{~~name~~}",
+        "service": {
+          "scheme": "{~~scheme~~}"
+        },
+        "identity": "{~~server_identity~~}"
+      }
+    ],
+    "client": {
+      "ssl_private_key": "client.key",
+      "ssl_cert": "client.crt",
+      "ssl_root_cert": "rootCA.pem",
+      "fqsn": "{~~fqsn~~}",
+      "is_leaf": {~~is_leaf~~},
+      "connection_security": "{~~conn_sec~~}"
+    },
+    "overseer_agent": {
+      "path": "nvflare.ha.dummy_overseer_agent.DummyOverseerAgent",
+      "args": {
+        "sp_end_point": "{~~sp_end_point~~}"
+      }
+    }
+  }
+
+sample_privacy: |
+  {
+    "scopes": [
+      {
+        "name": "public",
+        "properties": {
+          "train_dataset": "/data/public/train",
+          "val_dataset": "/data/public/val"
+        },
+        "task_result_filters": [
+          {
+            "name": "AddNoiseToMinMax",
+            "args": {
+              "min_noise_level": 0.2,
+              "max_noise_level": 0.2
+            }
+          },
+          {
+            "name": "PercentilePrivacy",
+            "args": {
+              "percentile": 10,
+              "gamma": 0.02
+            }
+          }
+        ],
+        "task_data_filters": [
+          {
+            "name": "BadModelDetector"
+          }
+        ]
+      },
+      {
+        "name": "private",
+        "properties": {
+          "train_dataset": "/data/private/train",
+          "val_dataset": "/data/private/val"
+        },
+        "task_result_filters": [
+          {
+            "name": "AddNoiseToMinMax",
+            "args": {
+              "min_noise_level": 0.1,
+              "max_noise_level": 0.1
+            }
+          },
+          {
+            "name": "SVTPrivacy",
+            "args": {
+              "fraction": 0.1,
+              "epsilon": 0.2
+            }
+          }
+        ]
+      }
+    ],
+    "default_scope": "public"
+  }
+
+local_server_resources: |
+  {
+      "format_version": 2,
+      "servers": [
+          {
+              "admin_storage": "transfer",
+              "max_num_clients": 100,
+              "heart_beat_timeout": 600,
+              "download_job_url": "http://download.server.com/",
+              "admin_timeout": 10.0
+          }
+      ],
+      "snapshot_persistor": {
+          "path": "nvflare.app_common.state_persistors.storage_state_persistor.StorageStatePersistor",
+          "args": {
+              "uri_root": "/",
+              "storage": {
+                  "path": "nvflare.app_common.storages.filesystem_storage.FilesystemStorage",
+                  "args": {
+                      "root_dir": "/tmp/nvflare/snapshot-storage",
+                      "uri_root": "/"
+                  }
+              }
+          }
+      },
+      "components": [
+          {
+              "id": "job_scheduler",
+              "path": "nvflare.app_common.job_schedulers.job_scheduler.DefaultJobScheduler",
+              "args": {
+                  "max_jobs": 1
+              }
+          },
+          {
+              "id": "job_manager",
+              "path": "nvflare.apis.impl.job_def_manager.SimpleJobDefManager",
+              "args": {
+                  "uri_root": "/tmp/nvflare/jobs-storage",
+                  "job_store_id": "job_store"
+              }
+          },
+          {
+              "id": "job_store",
+              "path": "nvflare.app_common.storages.filesystem_storage.FilesystemStorage"
+          },
+          {
+              "id": "process_launcher",
+              "path": "nvflare.app_common.job_launcher.server_process_launcher.ServerProcessJobLauncher",
+              "args": {}
+          },
+          {
+              "id": "log_receiver",
+              "path": "nvflare.app_common.logging.log_receiver.LogReceiver",
+              "args": {}
+          }
+      ]
+  }
+
+comm_config: |
+  {
+    "allow_adhoc_conns": false,
+    "backbone_conn_gen": {~~conn_gen~~},
+    "internal": {
+      "scheme": "{~~scheme~~}",
+      "resources": {
+        "host": "{~~host~~}",
+        "port": {~~port~~},
+        "connection_security": "{~~conn_sec~~}"
+      }
+    }
+  }
+
+fed_server: |
+  {
+    "format_version": 2,
+    "servers": [
+        {
+            "name": "{~~name~~}",
+            "service": {
+                "target": "{~~target~~}",
+                "scheme": "{~~scheme~~}"
+            },
+            "admin_server": "{~~admin_server~~}",
+            "admin_port": {~~admin_port~~},
+            "ssl_private_key": "server.key",
+            "ssl_cert": "server.crt",
+            "ssl_root_cert": "rootCA.pem",
+            "connection_security": "{~~conn_sec~~}"
+        }
+    ],
+    "overseer_agent": {
+      "path": "nvflare.ha.dummy_overseer_agent.DummyOverseerAgent",
+      "args": {
+        "sp_end_point": "{~~sp_end_point~~}"
+      }
+    }
+  }
+
+fed_admin: |
+  {
+    "format_version": 1,
+    "admin": {
+      "project_name": "{~~project_name~~}",
+      "username": "{~~username~~}",
+      "server_identity": "{~~server_identity~~}",
+      "scheme": "{~~scheme~~}",
+      "host": "{~~host~~}",
+      "port": {~~port~~},
+      "connection_security": "{~~conn_sec~~}",
+      "uid_source": "{~~uid_source~~}",
+      "with_file_transfer": true,
+      "upload_dir": "transfer",
+      "download_dir": "transfer",
+      "client_key": "client.key",
+      "client_cert": "client.crt",
+      "ca_cert": "rootCA.pem"
+    }
+  }
+
+default_admin_resources: |
+  {
+    "format_version": 1,
+    "admin": {
+      "idle_timeout": 900.0,
+      "login_timeout": 10.0,
+      "with_debug": false,
+      "authenticate_msg_timeout": 2.0,
+      "prompt": "> "
+    }
+  }
+
+default_authz: |
+  {
+    "format_version": "1.0",
+    "permissions": {
+      "project_admin": "any",
+      "org_admin": {
+        "submit_job": "none",
+        "clone_job": "none",
+        "manage_job": "o:submitter",
+        "download_job": "o:submitter",
+        "view": "any",
+        "operate": "o:site",
+        "shell_commands": "o:site",
+        "byoc": "none"
+      },
+      "lead": {
+        "submit_job": "any",
+        "clone_job": "n:submitter",
+        "manage_job": "n:submitter",
+        "download_job": "n:submitter",
+        "view": "any",
+        "operate": "o:site",
+        "shell_commands": "o:site",
+        "byoc": "any"
+      },
+      "member": {
+        "view": "any"
+      }
+    }
+  }
+
+cc_authz: |
+  {
+    "format_version": "1.0",
+    "permissions": {
+      "project_admin": "any",
+      "org_admin": {
+        "submit_job": "none",
+        "clone_job": "none",
+        "manage_job": "o:submitter",
+        "download_job": "none",
+        "view": "any",
+        "operate": "none",
+        "shell_commands": "none",
+        "byoc": "none"
+      },
+      "lead": {
+        "submit_job": "any",
+        "clone_job": "n:submitter",
+        "manage_job": "n:submitter",
+        "download_job": "none",
+        "view": "any",
+        "operate": "none",
+        "shell_commands": "none",
+        "byoc": "none"
+      },
+      "member": {
+        "view": "any"
+      }
+    }
+  }
+
+
+fl_admin_sh: |
+  #!/usr/bin/env bash
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  mkdir -p $DIR/../transfer
+  python3 -m nvflare.fuel.hci.tools.admin -m $DIR/.. -s fed_admin.json
+
+log_config: |
+  {
+      "version": 1,
+      "disable_existing_loggers": false,
+      "formatters": {
+          "baseFormatter": {
+              "()": "nvflare.fuel.utils.log_utils.BaseFormatter",
+              "fmt": "%(asctime)s - %(name)s - %(levelname)s - %(fl_ctx)s - %(message)s"
+          },
+          "consoleFormatter": {
+              "()": "nvflare.fuel.utils.log_utils.ColorFormatter",
+              "fmt": "%(asctime)s - %(name)s - %(levelname)s - %(fl_ctx)s - %(message)s"
+          },
+          "jsonFormatter": {
+              "()": "nvflare.fuel.utils.log_utils.JsonFormatter",
+              "fmt": "%(asctime)s - %(name)s - %(fullName)s - %(levelname)s - %(fl_ctx)s - %(message)s"
+          }
+      },
+      "filters": {
+          "FLFilter": {
+              "()": "nvflare.fuel.utils.log_utils.LoggerNameFilter",
+              "logger_names": ["custom", "nvflare.app_common", "nvflare.app_opt"]
+          }
+      },
+      "handlers": {
+          "consoleHandler": {
+              "class": "logging.StreamHandler",
+              "level": "DEBUG",
+              "formatter": "consoleFormatter",
+              "filters": [],
+              "stream": "ext://sys.stdout"
+          },
+          "logFileHandler": {
+              "class": "logging.handlers.RotatingFileHandler",
+              "level": "DEBUG",
+              "formatter": "baseFormatter",
+              "filename": "log.txt",
+              "mode": "a",
+              "maxBytes": 20971520,
+              "backupCount": 10
+          },
+          "errorFileHandler": {
+              "class": "logging.handlers.RotatingFileHandler",
+              "level": "ERROR",
+              "formatter": "baseFormatter",
+              "filename": "log_error.txt",
+              "mode": "a",
+              "maxBytes": 20971520,
+              "backupCount": 10
+          },
+          "jsonFileHandler": {
+              "class": "logging.handlers.RotatingFileHandler",
+              "level": "DEBUG",
+              "formatter": "jsonFormatter",
+              "filename": "log.json",
+              "mode": "a",
+              "maxBytes": 20971520,
+              "backupCount": 10
+          },
+          "FLFileHandler": {
+              "class": "logging.handlers.RotatingFileHandler",
+              "level": "DEBUG",
+              "formatter": "baseFormatter",
+              "filters": ["FLFilter"],
+              "filename": "log_fl.txt",
+              "mode": "a",
+              "maxBytes": 20971520,
+              "backupCount": 10,
+              "delay": true
+          }
+      },
+      "loggers": {
+          "root": {
+              "level": "INFO",
+              "handlers": ["consoleHandler", "logFileHandler", "errorFileHandler", "jsonFileHandler", "FLFileHandler"]
+          }
+      }
+  }
+
+start_cln_sh: |
+  #!/usr/bin/env bash
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  all_arguments="${@}"
+  doCloud=false
+  # parse arguments
+  while [[ $# -gt 0 ]]
+  do
+      key="$1"
+      case $key in
+        --cloud)
+          doCloud=true
+          csp=$2
+          shift
+        ;;
+      esac
+      shift
+  done
+
+  if [ $doCloud == true ]
+  then
+    case $csp in
+      azure)
+        $DIR/azure_start.sh ${all_arguments}
+        ;;
+      aws)
+        $DIR/aws_start.sh ${all_arguments}
+        ;;
+      *)
+        echo "Only on-prem or azure or aws is currently supported."
+    esac
+  else
+    $DIR/sub_start.sh &
+  fi
+
+start_svr_sh: |
+  #!/usr/bin/env bash
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  all_arguments="${@}"
+  doCloud=false
+  ha_mode={~~ha_mode~~}
+  # parse arguments
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      --cloud)
+        if [ $ha_mode == false ]
+        then
+          doCloud=true
+          csp=$2
+          shift
+        else
+          echo "Cloud launch does not support NVFlare HA mode."
+          exit 1
+        fi
+      ;;
+    esac
+    shift
+  done
+
+  if [ $doCloud == true ]
+  then
+    case $csp in
+      azure)
+        $DIR/azure_start.sh ${all_arguments}
+        ;;
+      aws)
+        $DIR/aws_start.sh ${all_arguments}
+        ;;
+      *)
+        echo "Only on-prem or azure or aws is currently supported."
+    esac
+  else
+    $DIR/sub_start.sh &
+  fi
+
+stop_fl_sh: |
+  #!/usr/bin/env bash
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  echo "Please use FL admin console to issue shutdown client command to properly stop this client."
+  echo "This stop_fl.sh script can only be used as the last resort to stop this client."
+  echo "It will not properly deregister the client to the server."
+  echo "The client status on the server after this shell script will be incorrect."
+  read -n1 -p "Would you like to continue (y/N)? " answer
+  case $answer in
+    y|Y)
+      echo
+      echo "Shutdown request created.  Wait for local FL process to shutdown."
+      touch $DIR/../shutdown.fl
+      ;;
+    n|N|*)
+      echo
+      echo "Not continue"
+      ;;
+  esac
+
+sub_start_sh: |
+  #!/usr/bin/env bash
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  echo "WORKSPACE set to $DIR/.."
+  mkdir -p $DIR/../transfer
+  export PYTHONPATH=/local/custom:$PYTHONPATH
+  echo "PYTHONPATH is $PYTHONPATH"
+
+  # Memory management configuration
+  # Opt-in jemalloc preload for PyTorch workloads.
+  # Enable by setting NVFLARE_ENABLE_JEMALLOC_PRELOAD=true.
+  if [ "${NVFLARE_ENABLE_JEMALLOC_PRELOAD:-false}" = "true" ]; then
+    for JEMALLOC in /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+                    /usr/lib64/libjemalloc.so.2 \
+                    /usr/local/lib/libjemalloc.so; do
+        if [ -f "$JEMALLOC" ]; then
+            export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}$JEMALLOC"
+            export MALLOC_CONF="${MALLOC_CONF:-dirty_decay_ms:5000,muzzy_decay_ms:5000}"
+            echo "Using jemalloc: $JEMALLOC"
+            break
+        fi
+    done
+  fi
+
+  # Limit glibc memory arenas to reduce RSS fragmentation (ignored by jemalloc)
+  # Recommended: MALLOC_ARENA_MAX=2 for clients, MALLOC_ARENA_MAX=4 for servers
+  export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-4}
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      --verify)
+        doVerify=true
+      ;;
+      --once)
+        doOnce=true
+      ;;
+    esac
+    shift
+  done
+
+  SECONDS=0
+  lst=-400
+  restart_count=0
+
+  start_python() {
+    python3 -u -m nvflare.private.fed.app.{~~type~~}.{~~app_name~~} -m $DIR/.. -s fed_{~~type~~}.json --set secure_train=true {~~cln_uid~~} org={~~org_name~~} config_folder={~~config_folder~~}
+  }
+
+  start_fl() {
+    if [[ $(( $SECONDS - $lst )) -lt 300 ]]; then
+      ((restart_count++))
+    else
+      restart_count=0
+    fi
+    if [[ $(($SECONDS - $lst )) -lt 300 && $restart_count -ge 5 ]]; then
+      echo "System is in trouble and unable to start the task!!!!!"
+      rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl $DIR/../daemon_pid.fl
+      exit
+    fi
+    lst=$SECONDS
+    (start_python 2>&1 & echo $! >&3 ) 3>$DIR/../pid.fl
+    pid=`cat $DIR/../pid.fl`
+    echo "new pid ${pid}"
+  }
+
+  stop_fl() {
+    if [[ ! -f "$DIR/../pid.fl" ]]; then
+      echo "No pid.fl.  No need to kill process."
+      return
+    fi
+    pid=`cat $DIR/../pid.fl`
+    sleep 5
+    kill -0 ${pid} 2> /dev/null 1>&2
+    if [[ $? -ne 0 ]]; then
+      echo "Process already terminated"
+      return
+    fi
+    kill -9 $pid
+    rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl 2> /dev/null 1>&2
+  }
+
+  if [[ "$doVerify" == "true" ]]; then
+    python3 -m nvflare.tool.verify_startup_kits -f $DIR/../ -c $DIR/rootCA.pem
+    verification_status=$?
+    if [[ $verification_status -ne 0 ]]; then
+      echo "verification failed"
+      exit 1
+    fi
+  fi
+
+  if [[ "$doOnce" == "true" ]]; then
+    echo "Start NVFlare directly"
+    rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl 2> /dev/null 1>&2
+    start_python
+    exit $?
+  fi
+
+  if [[ -f "$DIR/../daemon_pid.fl" ]]; then
+    dpid=`cat $DIR/../daemon_pid.fl`
+    kill -0 ${dpid} 2> /dev/null 1>&2
+    if [[ $? -eq 0 ]]; then
+      echo "There seems to be one instance, pid=$dpid, running."
+      echo "If you are sure it's not the case, please kill process $dpid and then remove daemon_pid.fl in $DIR/.."
+      exit
+    fi
+    rm -f $DIR/../daemon_pid.fl
+  fi
+
+  echo $BASHPID > $DIR/../daemon_pid.fl
+
+  while true
+  do
+    sleep 5
+    if [[ ! -f "$DIR/../pid.fl" ]]; then
+      echo "start fl because of no pid.fl"
+      start_fl
+      continue
+    fi
+    pid=`cat $DIR/../pid.fl`
+    kill -0 ${pid} 2> /dev/null 1>&2
+    if [[ $? -ne 0 ]]; then
+      if [[ -f "$DIR/../shutdown.fl" ]]; then
+        echo "Gracefully shutdown."
+        break
+      fi
+      echo "start fl because process of ${pid} does not exist"
+      start_fl
+      continue
+    fi
+    if [[ -f "$DIR/../shutdown.fl" ]]; then
+      echo "About to shutdown."
+      stop_fl
+      break
+    fi
+    if [[ -f "$DIR/../restart.fl" ]]; then
+      echo "About to restart."
+      stop_fl
+    fi
+  done
+
+  rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl $DIR/../daemon_pid.fl
+
+docker_cln_sh: |
+  #!/usr/bin/env bash
+  # docker run script for FL client with proper env variable forwarding
+  # Auto disable TTY in non-interactive CI environments
+  if [ -t 1 ]; then
+      TTY_OPT="-it"
+  else
+      echo "[INFO] No interactive terminal detected, disabling TTY."
+      TTY_OPT=""
+  fi
+
+  # Parse command-line arguments
+  while [[ "$#" -gt 0 ]]; do
+      case $1 in
+          --data_dir)            MY_DATA_DIR="$2"; shift ;;
+          --scratch_dir)         MY_SCRATCH_DIR="$2"; shift ;;
+          --GPU)                 GPU2USE="$2"; shift ;;
+          --no_pull)             NOPULL="1" ;;
+          --dummy_training)      DUMMY_TRAINING="1" ;;
+          --preflight_check)     PREFLIGHT_CHECK="1" ;;
+          --local_training)      LOCAL_TRAINING="1" ;;
+          --start_client)        START_CLIENT="1" ;;
+          --list_licenses)       LIST_LICENSES="1";;
+          --interactive)         INTERACTIVE="1" ;;
+          --run_script)          SCRIPT_TO_RUN="$2"; shift ;;
+          --job)                 JOB_NAME="$2"; shift ;;
+          --log_dataset_details) LOG_DATASET_DETAILS="1";;
+          *) echo "Unknown parameter passed: $1"; exit 1 ;;
+      esac
+      shift
+  done
+
+  # Default job for preflight_check and local_training
+  : ${JOB_NAME:="STAMP_classification"}
+
+  # Prompt for parameters if missing
+  if [[ -z "$DUMMY_TRAINING" && -z "$LIST_LICENSES" && -z "$MY_DATA_DIR" ]]; then
+      read -p "Enter the path to your data directory (default: /home/flclient/data): " user_data_dir
+      : ${MY_DATA_DIR:="${user_data_dir:-/home/flclient/data}"}
+  fi
+
+  if [[ -z "$MY_SCRATCH_DIR" && -z "$LIST_LICENSES" ]]; then
+      read -p "Enter the path to your scratch directory (default: /mnt/scratch): " user_scratch_dir
+      : ${MY_SCRATCH_DIR:="${user_scratch_dir:-/mnt/scratch}"}
+  fi
+
+  if [[ -z "$GPU2USE" && -z "$LIST_LICENSES" ]]; then
+      read -p "Enter the GPU index to use or 'all' (default: device=0): " user_gpu
+      : ${GPU2USE:="${user_gpu:-device=0}"}
+  fi
+
+  # Resolve script directory
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+  if [ -n "$MY_SCRATCH_DIR" ]; then
+      mkdir -p "$MY_SCRATCH_DIR"
+      chmod -R 777 "$MY_SCRATCH_DIR"
+  fi
+
+  # Networking & Cleanup
+  NETARG="--net=host"
+  rm -rf ../pid.fl ../daemon_pid.fl
+
+  # Docker image and container name
+  DOCKER_IMAGE={~~docker_image~~}
+  if [[ -z "$NOPULL" ]]; then
+      echo "Updating docker image"
+      docker pull "$DOCKER_IMAGE"
+  fi
+
+  CONTAINER_NAME=stamp_swarm_client_{~~client_name~~}___REPLACED_BY_CONTAINER_VERSION_IDENTIFIER_WHEN_BUILDING_DOCKER_IMAGE__
+  DOCKER_OPTIONS_A="--name=$CONTAINER_NAME --gpus=$GPU2USE -u $(id -u):$(id -g)"
+  DOCKER_MOUNTS="-v /etc/passwd:/etc/passwd -v /etc/group:/etc/group -v $DIR/..:/startupkit/ -v $MY_SCRATCH_DIR:/scratch/"
+  if [ -n "$MY_DATA_DIR" ]; then
+      DOCKER_MOUNTS+=" -v $MY_DATA_DIR:/data/:ro"
+  fi
+  DOCKER_OPTIONS_B="-w /startupkit/startup/ --ipc=host $NETARG"
+  DOCKER_OPTIONS="${DOCKER_OPTIONS_A} ${DOCKER_MOUNTS} ${DOCKER_OPTIONS_B}"
+
+  # Common ENV vars
+  ENV_VARS="--env SITE_NAME={~~client_name~~} \
+            --env DATA_DIR=/data \
+            --env SCRATCH_DIR=/scratch \
+            --env TORCH_HOME=/torch_home \
+            --env GPU_DEVICE=$GPU2USE \
+            --env MEDISWARM_VERSION=__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_DOCKER_IMAGE__ \
+            --env NVFLARE_TENSOR_MIN_DOWNLOAD_TIMEOUT=1800"
+
+  if [ -n "$LOG_DATASET_DETAILS" ]; then
+     ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
+  fi
+
+  # Forward all STAMP_* environment variables into the container
+  for _var in $(env | grep '^STAMP_' | cut -d= -f1); do
+      ENV_VARS+=" --env ${_var}=${!_var}"
+  done
+
+  # ── Live Sync Integration ──────────────────────────────────────────
+  # live_sync.sh is co-located in the startup directory (injected by
+  # _injectLiveSyncIntoStartupKits.sh) and syncs training artifacts to
+  # the central monitoring server for --local_training and --start_client
+  # modes.  If live_sync.sh is not present the functions are a no-op.
+  KIT_ROOT="$(cd "$DIR/.." && pwd)"
+  SYNC_STATE_DIR="$DIR/.mediswarm_sync"
+  SITE_NAME_RESOLVED="{~~client_name~~}"
+
+  _start_live_sync() {
+    local mode="$1"
+    if [ ! -f "$DIR/live_sync.sh" ]; then return; fi
+    mkdir -p "$SYNC_STATE_DIR"
+
+    if [ "$mode" = "local" ]; then
+      "$DIR/live_sync.sh" \
+        --mode local \
+        --site-name "$SITE_NAME_RESOLVED" \
+        --kit-root "$KIT_ROOT" \
+        --startup-dir "$DIR" \
+        --scratch-dir "${MY_SCRATCH_DIR:-}" &
+      LIVE_SYNC_PID=$!
+    elif [ "$mode" = "swarm" ]; then
+      local pid_file="$SYNC_STATE_DIR/swarm_sync.pid"
+      if [ -f "$pid_file" ]; then
+        local old_pid
+        old_pid="$(cat "$pid_file" 2>/dev/null || true)"
+        if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+          echo "Live sync daemon already running (PID $old_pid)"
+          return 0
+        fi
+      fi
+      nohup "$DIR/live_sync.sh" \
+        --mode swarm \
+        --site-name "$SITE_NAME_RESOLVED" \
+        --kit-root "$KIT_ROOT" \
+        --startup-dir "$DIR" \
+        --scratch-dir "${MY_SCRATCH_DIR:-}" \
+        > "$SYNC_STATE_DIR/live_sync_daemon.log" 2>&1 < /dev/null &
+      echo $! > "$pid_file"
+      echo "Started live sync daemon (PID $(cat "$pid_file"))"
+    fi
+  }
+
+  _stop_live_sync() {
+    if [ -n "${LIVE_SYNC_PID:-}" ] && kill -0 "$LIVE_SYNC_PID" 2>/dev/null; then
+      kill "$LIVE_SYNC_PID" || true
+      wait "$LIVE_SYNC_PID" || true
+    fi
+  }
+
+  # Execution modes
+  if [ -n "$DUMMY_TRAINING" ]; then
+      docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training $DOCKER_IMAGE \
+      /bin/bash -c "/MediSwarm/application/jobs/minimal_training_pytorch_cnn/app/custom/main.py"
+
+  elif [ -n "$PREFLIGHT_CHECK" ]; then
+      echo "[INFO] Preflight check using job: $JOB_NAME"
+      docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=preflight_check $DOCKER_IMAGE \
+      /bin/bash -c "/MediSwarm/application/jobs/${JOB_NAME}/app/custom/main.py"
+
+  elif [ -n "$LOCAL_TRAINING" ]; then
+      echo "[INFO] Local training using job: $JOB_NAME"
+      trap _stop_live_sync EXIT INT TERM
+      _start_live_sync local
+      docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training $DOCKER_IMAGE \
+      /bin/bash -c "/MediSwarm/application/jobs/${JOB_NAME}/app/custom/main.py"
+
+  elif [ -n "$START_CLIENT" ]; then
+      _start_live_sync swarm
+      docker run -d -t --restart=on-failure:5 \
+      --health-cmd="nvidia-smi > /dev/null 2>&1 || exit 1" \
+      --health-interval=120s --health-start-period=180s --health-retries=3 \
+      $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=swarm $DOCKER_IMAGE \
+      /bin/bash -c "nohup ./start.sh >> nohup.out 2>&1 && /bin/bash"
+
+  elif [ -n "$LIST_LICENSES" ]; then
+      docker run --rm --name=$CONTAINER_NAME $DOCKER_IMAGE \
+      /bin/bash -c "/MediSwarm/scripts/_list_licenses.sh"
+
+  elif [ -n "$INTERACTIVE" ]; then
+      docker run --rm $TTY_OPT --detach-keys="ctrl-x" $DOCKER_OPTIONS $DOCKER_IMAGE /bin/bash
+
+  elif [ -n "$SCRIPT_TO_RUN" ]; then
+      docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS $DOCKER_IMAGE \
+      /bin/bash -c "$SCRIPT_TO_RUN"
+
+  else
+      echo "❗ One of the following options must be passed:"
+      echo "--dummy_training         minimal sanity check for Docker/GPU"
+      echo "--preflight_check        verify data access & local training (use --job to select model)"
+      echo "--local_training         train a local model (use --job to select model)"
+      echo "--start_client           launch FL client in swarm mode"
+      echo "--list_licenses          list licenses of installed packages"
+      echo "--interactive            drop into interactive container (for debugging)"
+      echo "--run_script             execute script in container (for testing)"
+      echo "--log_dataset_details    log detailed dataset information (UIDs, hashes)"
+      echo ""
+      echo "Optional:"
+      echo "--job <name>             select job/model for preflight_check or local_training"
+      echo "                         (default: STAMP_classification)"
+      echo "                         Available: STAMP_classification"
+      echo ""
+      echo "STAMP environment variables (set before calling docker.sh):"
+      echo "  All env vars prefixed with STAMP_ are forwarded into the container."
+      echo "  See STAMP documentation for the full list of supported variables."
+      exit 1
+  fi
+
+
+
+docker_svr_sh: |
+  #!/usr/bin/env bash
+  # docker run script for FL server
+
+  while [[ "$#" -gt 0 ]]; do
+      case $1 in
+          --no_pull)        NOPULL="1";;
+          --start_server)   START_SERVER="1";;
+          --list_licenses)  LIST_LICENSES="1";;
+          --interactive)    INTERACTIVE="1";;
+          --svr_name)       CLI_SVR_NAME="$2"; shift ;;
+          *) echo "Unknown parameter passed: $1"; exit 1 ;;
+      esac
+      shift
+  done
+
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+  # to use host network, use line below
+  NETARG="--net=host"
+  # or to expose specific ports, use line below
+  #NETARG="-p {~~admin_port~~}:{~~admin_port~~} -p {~~fed_learn_port~~}:{~~fed_learn_port~~}"
+
+  DOCKER_IMAGE={~~docker_image~~}
+  if [[ -z "$NOPULL" ]]; then
+      echo "Updating docker image"
+      docker pull $DOCKER_IMAGE
+  fi
+  # CLI flag --svr_name takes priority over env var SVR_NAME (survives sudo)
+  svr_name="${CLI_SVR_NAME:-${SVR_NAME:-flserver}}"
+  CONTAINER_NAME=stamp_swarm_server_${svr_name}___REPLACED_BY_CONTAINER_VERSION_IDENTIFIER_WHEN_BUILDING_DOCKER_IMAGE__
+
+  rm -rf ../pid.fl ../daemon_pid.fl  # clean up potential leftovers from previous run
+
+  echo "Starting docker with $DOCKER_IMAGE as $CONTAINER_NAME"
+  # Run docker with appropriate parameters
+  if [ -n "$START_SERVER" ]; then
+      docker run -d -t --restart=on-failure:5 --name=$CONTAINER_NAME \
+      -v $DIR/..:/startupkit/ -w /startupkit/startup/ \
+      --ipc=host $NETARG $DOCKER_IMAGE \
+      /bin/bash -c "nohup ./start.sh >> nohup.out 2>&1 && chmod a+r nohup.out && /bin/bash"
+  elif [ -n "$LIST_LICENSES" ]; then
+      docker run --rm --name=$CONTAINER_NAME \
+      $DOCKER_IMAGE \
+      /bin/bash -c "/MediSwarm/scripts/_list_licenses.sh"
+  elif [ -n "$INTERACTIVE" ]; then
+      docker run --rm -it --detach-keys="ctrl-x" --name=$CONTAINER_NAME \
+      -v $DIR/..:/startupkit/ -w /startupkit/startup/ \
+      --ipc=host $NETARG $DOCKER_IMAGE \
+      /bin/bash -c "/bin/bash"
+  else
+      echo "One of the following options must be passed:"
+      echo "--start_server     start the swarm learning server"
+      echo "--list_licenses    list licenses of installed packages"
+      echo "--interactive      start the container with an interactive shell (for debugging purposes)"
+  fi
+
+docker_adm_sh: |
+  #!/usr/bin/env bash
+
+  while [[ "$#" -gt 0 ]]; do
+      case $1 in
+          --no_pull)        NOPULL="1";;
+          --list_licenses)  LIST_LICENSES="1";;
+          *) echo "Unknown parameter passed: $1"; exit 1 ;;
+      esac
+      shift
+  done
+
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  # To use host network
+  NETARG="--net=host"
+
+  DOCKER_IMAGE={~~docker_image~~}
+  if [[ -z "$NOPULL" ]]; then
+      echo "Updating docker image"
+      docker pull $DOCKER_IMAGE
+  fi
+  CONTAINER_NAME=stamp_swarm_admin___REPLACED_BY_CONTAINER_VERSION_IDENTIFIER_WHEN_BUILDING_DOCKER_IMAGE__
+
+  if [ -n "$LIST_LICENSES" ]; then
+      docker run --rm --name=$CONTAINER_NAME $DOCKER_IMAGE \
+      /bin/bash -c "/MediSwarm/scripts/_list_licenses.sh"
+      exit 0
+  fi
+
+  echo "Starting docker with $DOCKER_IMAGE as $CONTAINER_NAME"
+  docker run --rm -it --name=$CONTAINER_NAME -v $DIR/../local/:/fl_admin/local/ -v $DIR/../startup/:/fl_admin/startup/ -w /fl_admin/startup/ $NETARG $DOCKER_IMAGE /bin/bash -c "./fl_admin.sh"
+
+compose_yaml: |
+  services:
+    __overseer__:
+      build: ./nvflare
+      image: ${IMAGE_NAME}
+      volumes:
+        - .:/workspace
+      command: ["${WORKSPACE}/startup/start.sh"]
+      ports:
+        - "8443:8443"
+
+    __flserver__:
+      image: ${IMAGE_NAME}
+      ports:
+        - "8002:8002"
+        - "8003:8003"
+      volumes:
+        - .:/workspace
+        - nvflare_svc_persist:/tmp/nvflare/
+      command: ["${PYTHON_EXECUTABLE}",
+            "-u",
+            "-m",
+            "nvflare.private.fed.app.server.server_train",
+            "-m",
+            "${WORKSPACE}",
+            "-s",
+            "fed_server.json",
+            "--set",
+            "secure_train=true",
+            "config_folder=config",
+            "org=__org_name__",
+          ]
+
+    __flclient__:
+      image: ${IMAGE_NAME}
+      volumes:
+        - .:/workspace
+      command: ["${PYTHON_EXECUTABLE}",
+            "-u",
+            "-m",
+            "nvflare.private.fed.app.client.client_train",
+            "-m",
+            "${WORKSPACE}",
+            "-s",
+            "fed_client.json",
+            "--set",
+            "secure_train=true",
+            "uid=__flclient__",
+            "org=__org_name__",
+            "config_folder=config",
+          ]
+
+  volumes:
+    nvflare_svc_persist:
+
+dockerfile: |
+  RUN pip install -U pip
+  RUN pip install nvflare
+  COPY requirements.txt requirements.txt
+  RUN pip install -r requirements.txt
+
+helm_chart_chart: |
+  apiVersion: v2
+  name: nvflare
+  description: A Helm chart for NVFlare overseer and servers
+  type: application
+  version: 0.1.0
+  appVersion: "2.2.0"
+
+helm_chart_service_overseer: |
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: overseer
+  spec:
+    selector:
+      system: overseer
+    ports:
+      - protocol: TCP
+        port: 8443
+        targetPort: overseer-port
+
+helm_chart_service_server: |
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: server
+    labels:
+      system: server
+  spec:
+    selector:
+      system: server
+    ports:
+      - name: fl-port
+        protocol: TCP
+        port: 8002
+        targetPort: fl-port
+      - name: admin-port
+        protocol: TCP
+        port: 8003
+        targetPort: admin-port
+
+helm_chart_deployment_overseer: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: overseer
+    labels:
+      system: overseer
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        system: overseer
+    template:
+      metadata:
+        labels:
+          system: overseer
+      spec:
+        volumes:
+          - name: workspace
+            hostPath:
+              path:
+              type: Directory
+        containers:
+          - name: overseer
+            image: nvflare-min:2.2.0
+            imagePullPolicy: IfNotPresent
+            volumeMounts:
+              - name: workspace
+                mountPath: /workspace
+            command: ["/workspace/overseer/startup/start.sh"]
+            ports:
+              - name: overseer-port
+                containerPort: 8443
+                protocol: TCP
+helm_chart_deployment_server: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: server
+    labels:
+      system: server
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        system: server
+    template:
+      metadata:
+        labels:
+          system: server
+      spec:
+        volumes:
+          - name: workspace
+            hostPath:
+              path:
+              type: Directory
+          - name: persist
+            hostPath:
+              path: /tmp/nvflare
+              type: Directory
+        containers:
+          - name: server1
+            image: nvflare-min:2.2.0
+            imagePullPolicy: IfNotPresent
+            volumeMounts:
+              - name: workspace
+                mountPath: /workspace
+              - name: persist
+                mountPath: /tmp/nvflare
+            command: ["/usr/local/bin/python3"]
+            args:
+              [
+                "-u",
+                "-m",
+                "nvflare.private.fed.app.server.server_train",
+                "-m",
+                "/workspace/server",
+                "-s",
+                "fed_server.json",
+                "--set",
+                "secure_train=true",
+                "config_folder=config",
+                "org=__org_name__",
+
+              ]
+            ports:
+              - containerPort: 8002
+                protocol: TCP
+              - containerPort: 8003
+                protocol: TCP
+helm_chart_values: |
+  workspace: /home/nvflare
+  persist: /home/nvflare
+
+
+cloud_script_header: |
+  #!/usr/bin/env bash
+
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  function report_status() {
+    status="$1"
+    if [ "${status}" -ne 0 ]
+    then
+      echo "$2 failed"
+      exit "${status}"
+    fi
+  }
+
+  function check_binary() {
+    echo -n "Checking if $1 exists. => "
+    if ! command -v $1 &> /dev/null
+    then
+      echo "not found. $2"
+      exit 1
+    else
+      echo "found"
+    fi
+  }
+
+  function prompt() {
+    # usage:  prompt NEW_VAR "Prompt message" ["${PROMPT_VALUE}"]
+    local __resultvar=$1
+    local __prompt=$2
+    local __default=${3:-}
+    local __result
+    if [[ ${BASH_VERSINFO[0]} -ge 4 && -n "$__default" ]]
+      then
+      read -e -i "$__default" -p "$__prompt: " __result
+    else
+      __default=${3:-${!__resultvar:-}}
+      if [[ -n $__default ]]
+        then
+        printf "%s [%s]: " "$__prompt" "$__default"
+      else
+        printf "%s: " "$__prompt"
+      fi
+      IFS= read -r __result
+      if [[ -z "$__result" && -n "$__default" ]]
+        then
+        __result="$__default"
+      fi
+    fi
+    eval $__resultvar="'$__result'"
+  }
+
+  function get_resources_file() {
+    local rfile="${DIR}/../local/resources.json"
+    if [ -f "${rfile}" ]
+      then
+      echo "${rfile}"
+    elif [ -f "${rfile}.default" ]
+      then
+      echo "${rfile}.default"
+    else
+      echo ""
+      exit 1
+    fi
+  }
+
+  # parse arguments
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      --config)
+        config_file=$2
+        shift
+      ;;
+      --image)
+        image_name=$2
+        shift
+      ;;
+      --vpc-id)
+        vpc_id=$2
+        shift
+      ;;
+      --subnet-id)
+        subnet_id=$2
+        shift
+      ;;
+    esac
+    shift
+  done
+
+adm_notebook: |
+  {
+  "cells": [
+    {
+    "cell_type": "markdown",
+    "id": "b758695b",
+    "metadata": {},
+    "source": [
+      "# System Info"
+    ]
+    },
+    {
+    "cell_type": "markdown",
+    "id": "9f7cd9e6",
+    "metadata": {},
+    "source": [
+      "In this notebook, System Info is checked with the FLARE API."
+    ]
+    },
+    {
+    "cell_type": "markdown",
+    "id": "ea50ba28",
+    "metadata": {},
+    "source": [
+      "#### 1. Connect to the FL System with the FLARE API\n",
+      "\n",
+      "Use `new_secure_session()` to initiate a session connecting to the FL Server with the FLARE API. The necessary arguments are the username of the admin user you are using and the corresponding startup kit location.\n",
+      "\n",
+      "In the code example below, we get the `admin_user_dir` by concatenating the workspace root with the default directories that are created if you provision a project with a given project name. You can change the values to what applies to your system if needed.\n",
+      "\n",
+      "Note that if debug mode is not enabled, there is no output after initiating a session successfully, so instead we print the output of `get_system_info()`. If you are unable to connect and initiate a session, make sure that your FL Server is running and that the configurations are correct with the right path to the admin startup kit directory."
+    ]
+    },
+    {
+    "cell_type": "code",
+    "execution_count": null,
+    "id": "0166942d",
+    "metadata": {
+      "collapsed": true
+    },
+    "outputs": [],
+    "source": [
+      "# Run this pip install if NVFlare is not installed in your Jupyter Notebook\n",
+      "\n",
+      "# !python3 -m pip install -U nvflare"
+    ]
+    },
+    {
+    "cell_type": "code",
+    "execution_count": null,
+    "id": "c3dbde69",
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "import os\n",
+      "from nvflare.fuel.flare_api.flare_api import new_secure_session\n",
+      "\n",
+      "username = \"{~~admin_name~~}\"  # change this to your own username\n",
+      "\n",
+      "sess = new_secure_session(\n",
+      "    username=username,\n",
+      "    startup_kit_location=os.getcwd()\n",
+      ")\n",
+      "print(sess.get_system_info())"
+    ]
+    },
+    {
+    "cell_type": "markdown",
+    "id": "31ccb6a6",
+    "metadata": {},
+    "source": [
+      "### 2. Shutting Down the FL System\n",
+      "\n",
+      "As of now, there is no specific FLARE API command for shutting down the FL system, but the FLARE API can use the `do_command()` function of the underlying AdminAPI to submit any commands that the FLARE Console supports including shutdown commands to the clients and server:"
+    ]
+    },
+    {
+    "cell_type": "code",
+    "execution_count": null,
+    "id": "b0d8aa9c",
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "print(sess.api.do_command(\"shutdown client\"))\n",
+      "print(sess.api.do_command(\"shutdown server\"))\n",
+      "\n",
+      "sess.close()"
+    ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+    "display_name": "Python 3 (ipykernel)",
+    "language": "python",
+    "name": "python3"
+    },
+    "language_info": {
+    "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+    },
+    "file_extension": ".py",
+    "mimetype": "text/x-python",
+    "name": "python",
+    "nbconvert_exporter": "python",
+    "pygments_lexer": "ipython3",
+    "version": "3.8.13"
+    },
+    "vscode": {
+    "interpreter": {
+      "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+    }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+  }
+
+relay_resources_json: |
+  {
+    "format_version": 2,
+    "relay_config": {
+      "scheme": "{~~scheme~~}",
+      "identity": "{~~identity~~}",
+      "address": "{~~address~~}",
+      "fqcn": "{~~fqcn~~}",
+      "connection_security": "{~~conn_sec~~}"
+    }
+  }
+
+fed_relay: |
+  {
+    "format_version": 2,
+    "project_name": "{~~project_name~~}",
+    "identity": "{~~identity~~}",
+    "server_identity": "{~~server_identity~~}",
+    "connect_to": {
+      "scheme": "{~~scheme~~}",
+      "identity": "{~~parent_identity~~}",
+      "address": "{~~address~~}",
+      "fqcn": "{~~fqcn~~}",
+      "connection_security": "{~~conn_sec~~}"
+    }
+  }

--- a/scripts/build/buildDockerImageAndStartupKits.sh
+++ b/scripts/build/buildDockerImageAndStartupKits.sh
@@ -60,6 +60,12 @@ chmod a+rX . -R
 sed -i 's#__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_DOCKER_IMAGE__#'$VERSION'#' docker_config/master_template.yml
 sed -i 's#__REPLACED_BY_CONTAINER_VERSION_IDENTIFIER_WHEN_BUILDING_DOCKER_IMAGE__#'$CONTAINER_VERSION_ID'#' docker_config/master_template.yml
 
+# Also patch STAMP template if it exists (separate template for STAMP builds)
+if [[ -f docker_config/master_template_STAMP.yml ]]; then
+    sed -i 's#__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_DOCKER_IMAGE__#'$VERSION'#' docker_config/master_template_STAMP.yml
+    sed -i 's#__REPLACED_BY_CONTAINER_VERSION_IDENTIFIER_WHEN_BUILDING_DOCKER_IMAGE__#'$CONTAINER_VERSION_ID'#' docker_config/master_template_STAMP.yml
+fi
+
 # Override num_rounds in all server configs if requested (CI/CD testing)
 if [[ -n "$NUM_ROUNDS_OVERRIDE" ]]; then
     echo "Overriding num_rounds to $NUM_ROUNDS_OVERRIDE in all config_fed_server.conf files"

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -127,10 +127,12 @@ JOB_NAME="${DEFAULT_JOB:-STAMP_classification}"
 
 setup_stamp_env() {
     local site_name="$1"
-    local data_dir="$2"
+    local data_dir="$2"   # host path — only used by caller for --data_dir flag
+    # Inside the container, --data_dir is mounted at /data/ (read-only).
+    # STAMP env vars must reference the container-internal path, not the host path.
     cat <<EOF
-export STAMP_CLINI_TABLE="${data_dir}/${site_name}/clini_table.csv"
-export STAMP_FEATURE_DIR="${data_dir}/${site_name}/features"
+export STAMP_CLINI_TABLE="/data/${site_name}/clini_table.csv"
+export STAMP_FEATURE_DIR="/data/${site_name}/features"
 export STAMP_GROUND_TRUTH_LABEL="Diagnosis"
 export STAMP_PATIENT_LABEL="PATIENT"
 export STAMP_TASK="classification"

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -1,0 +1,750 @@
+#!/usr/bin/env bash
+# ============================================================================
+# run_stamp_deploy_test.sh — Orchestrate 2-node STAMP deploy test
+#
+# Runs STAMP_classification through a full federated training cycle across
+# 2 physical machines connected via Tailscale VPN, with Cosmos as the
+# server/admin node (no training client on Cosmos).
+#
+# Architecture:
+#   Cosmos (localhost) — NVFlare server + admin only
+#   dl0                — RUMC_1 client
+#   dl2                — MHA_1 client
+#
+# Workflow:
+#   1. Stop any lingering containers (local + remote)
+#   2. Deploy startup kits to all sites
+#   3. Fix DNS on remote machines (dl3.tud.de → Cosmos Tailscale IP)
+#   4. Pre-pull Docker image on all remote machines
+#   5. Start NVFlare server on Cosmos
+#   6. Start NVFlare clients on DL0 + DL2 (with STAMP_* env vars)
+#   7. Wait for client registration
+#   8. Submit STAMP_classification job via admin
+#   9. Wait for training completion ("Server runner finished.")
+#  10. Record pass/fail result
+#
+# Unlike the ODELIA deploy test (run_deploy_test.sh), this script:
+#   - Runs ONE model only (STAMP_classification)
+#   - Exports STAMP_* environment variables on remote hosts before docker.sh
+#   - Uses stamp_swarm container name prefix (not odelia_swarm)
+#   - Has no evaluation step (STAMP has no predict.py equivalent yet)
+#   - Has no retry loop (simpler for initial testing)
+#
+# Usage:
+#   ./scripts/deploy/run_stamp_deploy_test.sh --conf deploy_sites_2node_stamp_test.conf
+#   ./scripts/deploy/run_stamp_deploy_test.sh --conf deploy_sites_2node_stamp_test.conf --timeout 60
+#
+# The Docker image and startup kits must be built BEFORE running this script:
+#   ./scripts/build/buildDockerImageAndStartupKits.sh \
+#       -p application/provision/project_deploy_test_2site.yml \
+#       -d docker_config/Dockerfile_STAMP --num-rounds 2
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Colors ─────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
+err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+step()  { echo -e "\n${BOLD}=== $* ===${NC}" >&2; }
+
+# ── Parse arguments ────────────────────────────────────────────────────────
+CONF_FILE=""
+TIMEOUT_MINUTES=120   # 2 hours for a quick 2-round test
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --conf)         CONF_FILE="$2"; shift ;;
+        --timeout)      TIMEOUT_MINUTES="$2"; shift ;;
+        -h|--help)
+            echo "Usage: $0 --conf CONF_FILE [--timeout MINUTES]"
+            echo ""
+            echo "  --conf      Path to site configuration file (required)"
+            echo "  --timeout   Per-model training timeout in minutes (default: 120)"
+            exit 0
+            ;;
+        *)
+            err "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Resolve conf file path
+if [[ -z "$CONF_FILE" ]]; then
+    err "Must specify --conf CONF_FILE"
+    exit 1
+fi
+if [[ ! -f "$CONF_FILE" ]]; then
+    if [[ -f "$REPO_ROOT/$CONF_FILE" ]]; then
+        CONF_FILE="$REPO_ROOT/$CONF_FILE"
+    else
+        err "Configuration file not found: $CONF_FILE"
+        exit 1
+    fi
+fi
+
+# ── Load configuration ─────────────────────────────────────────────────────
+# shellcheck source=/dev/null
+source "$CONF_FILE"
+
+VERSION=$("$REPO_ROOT/scripts/build/getVersionNumber.sh")
+DOCKER_IMAGE="jefftud/odelia:$VERSION"
+
+PROJECT_NAME=$(grep "^name: " "$REPO_ROOT/$PROJECT_FILE" \
+    | sed 's/^name: //' \
+    | sed "s/__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__/$VERSION/")
+WORKSPACE_DIR="$REPO_ROOT/workspace/$PROJECT_NAME"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+# Cosmos deploy dir (server + admin live here)
+DEPLOY_BASE="${COSMOS_DEPLOY_DIR:-/home/jeff/deploy_test_stamp}"
+
+# Results directory
+RESULTS_DIR="$REPO_ROOT/workspace/deploy_test_stamp_results"
+mkdir -p "$RESULTS_DIR"
+
+# Job to run
+JOB_NAME="${DEFAULT_JOB:-STAMP_classification}"
+
+# ── STAMP environment variables ──────────────────────────────────────────
+# These are exported on each remote host BEFORE calling docker.sh.
+# The STAMP master template's env var forwarding loop (for _var in STAMP_*)
+# picks them up and passes them into the Docker container.
+
+setup_stamp_env() {
+    local site_name="$1"
+    local data_dir="$2"
+    cat <<EOF
+export STAMP_CLINI_TABLE="${data_dir}/${site_name}/clini_table.csv"
+export STAMP_FEATURE_DIR="${data_dir}/${site_name}/features"
+export STAMP_GROUND_TRUTH_LABEL="Diagnosis"
+export STAMP_PATIENT_LABEL="PATIENT"
+export STAMP_TASK="classification"
+export STAMP_MODEL_NAME="vit"
+export STAMP_DIM_INPUT="1024"
+export STAMP_NUM_CLASSES="3"
+export STAMP_BAG_SIZE="64"
+export STAMP_BATCH_SIZE="8"
+export STAMP_MAX_EPOCHS="2"
+export STAMP_PATIENCE="2"
+export STAMP_NUM_WORKERS="0"
+export STAMP_SEED="42"
+export STAMP_NUM_ROUNDS="2"
+export STAMP_EPOCHS_PER_ROUND="2"
+export STAMP_EPOCHS_REFERENCE_DATASET_SIZE="15"
+export STAMP_EPOCHS_MAX_CAP="4"
+EOF
+}
+
+# ── Helper functions ──────────────────────────────────────────────────────
+
+site_var() {
+    local site=$1 var=$2
+    local full_var="${site}_${var}"
+    echo "${!full_var}"
+}
+
+remote_exec() {
+    local site=$1; shift
+    local host user pass
+    host=$(site_var "$site" HOST)
+    user=$(site_var "$site" USER)
+    pass=$(site_var "$site" PASS)
+
+    sshpass -p "$pass" ssh $SSH_OPTS "$user@$host" "$@"
+}
+
+remote_copy() {
+    local site=$1 src=$2 dst=$3
+    local host user pass
+    host=$(site_var "$site" HOST)
+    user=$(site_var "$site" USER)
+    pass=$(site_var "$site" PASS)
+
+    sshpass -p "$pass" scp $SSH_OPTS "$src" "$user@$host:$dst"
+}
+
+find_latest_prod() {
+    if [[ ! -d "$WORKSPACE_DIR" ]]; then
+        err "Workspace not found: $WORKSPACE_DIR"
+        err "Run buildDockerImageAndStartupKits.sh first."
+        exit 1
+    fi
+    ls -d "$WORKSPACE_DIR"/prod_* 2>/dev/null | sort -V | tail -n 1
+}
+
+# ── Resolve server startup directory ───────────────────────────────────
+_server_startup_dir=""
+
+resolve_server_startup_dir() {
+    local server_name="${SERVER_NAME:-dl3.tud.de}"
+    local candidate="$DEPLOY_BASE/$server_name/startup"
+    if [[ -d "$candidate" ]]; then
+        _server_startup_dir="$candidate"
+    else
+        local prod_dir
+        prod_dir=$(find_latest_prod)
+        candidate="$prod_dir/$server_name/startup"
+        if [[ -d "$candidate" ]]; then
+            _server_startup_dir="$candidate"
+        else
+            _server_startup_dir=""
+        fi
+    fi
+}
+
+# ── Fix DNS: ensure remote clients can reach the NVFlare server ──────────
+fix_remote_dns() {
+    local server_fqdn="${SERVER_NAME:-dl3.tud.de}"
+    local cosmos_ip
+    cosmos_ip=$(tailscale ip -4 2>/dev/null) || {
+        err "Cannot determine Cosmos Tailscale IP (is tailscale running?)"
+        return 1
+    }
+
+    step "Ensuring $server_fqdn resolves to $cosmos_ip on all remote machines"
+
+    local -A visited_hosts=()
+    for site in "${CLIENT_SITES[@]}"; do
+        local host
+        host=$(site_var "$site" HOST)
+        [[ -n "${visited_hosts[$host]:-}" ]] && continue
+        visited_hosts[$host]=1
+
+        # Skip if this machine IS Cosmos
+        [[ "$host" == "localhost" || "$host" == "127.0.0.1" || "$host" == "$cosmos_ip" ]] && continue
+
+        info "Checking /etc/hosts on $host for $server_fqdn ..."
+
+        local current_ip
+        current_ip=$(remote_exec "$site" \
+            "grep -E '\\b${server_fqdn}\\b' /etc/hosts 2>/dev/null | awk '{print \$1}' | head -1" \
+            2>/dev/null || true)
+
+        if [[ "$current_ip" == "$cosmos_ip" ]]; then
+            ok "  $host already maps $server_fqdn → $cosmos_ip"
+            continue
+        fi
+
+        if [[ -n "$current_ip" ]]; then
+            info "  $host maps $server_fqdn → $current_ip (wrong, updating to $cosmos_ip)"
+            remote_exec "$site" \
+                "echo '$(site_var "$site" PASS)' | sudo -S sed -i 's|^.*\\b${server_fqdn}\\b.*\$|${cosmos_ip} ${server_fqdn}|' /etc/hosts" \
+                2>/dev/null
+        else
+            info "  $host has no entry for $server_fqdn (adding)"
+            remote_exec "$site" \
+                "echo '$(site_var "$site" PASS)' | sudo -S bash -c 'echo \"${cosmos_ip} ${server_fqdn}\" >> /etc/hosts'" \
+                2>/dev/null
+        fi
+
+        # Verify
+        local verify_ip
+        verify_ip=$(remote_exec "$site" \
+            "grep -E '\\b${server_fqdn}\\b' /etc/hosts | awk '{print \$1}' | head -1" \
+            2>/dev/null || true)
+        if [[ "$verify_ip" == "$cosmos_ip" ]]; then
+            ok "  $host now maps $server_fqdn → $cosmos_ip"
+        else
+            err "  Failed to update /etc/hosts on $host (got: $verify_ip)"
+            return 1
+        fi
+    done
+
+    ok "DNS resolution verified on all remote machines"
+}
+
+# ── Stop all containers ───────────────────────────────────────────────────
+stop_all() {
+    info "Stopping all STAMP/NVFlare containers..."
+
+    # Stop local containers on Cosmos (server + admin)
+    local local_containers
+    local_containers=$(docker ps --format '{{.Names}}' | grep -E "stamp_swarm|nvflare" || true)
+    if [[ -n "$local_containers" ]]; then
+        echo "$local_containers" | xargs docker kill 2>/dev/null || true
+        echo "$local_containers" | xargs docker rm -f 2>/dev/null || true
+    fi
+
+    # Stop remote client containers
+    local -A visited_hosts=()
+    for site in "${CLIENT_SITES[@]}"; do
+        local host
+        host=$(site_var "$site" HOST)
+        if [[ -n "${visited_hosts[$host]:-}" ]]; then
+            continue
+        fi
+        visited_hosts[$host]=1
+        remote_exec "$site" \
+            "docker ps --format '{{.Names}}' | grep -E 'stamp_swarm|nvflare' | xargs -r docker kill 2>/dev/null; \
+             docker ps -a --format '{{.Names}}' | grep -E 'stamp_swarm|nvflare' | xargs -r docker rm -f 2>/dev/null" \
+            2>/dev/null || warn "  Could not stop containers on $host"
+    done
+
+    # Clean up root-owned files left by NVFlare server container
+    local server_name="${SERVER_NAME:-dl3.tud.de}"
+    local server_dir="$DEPLOY_BASE/$server_name"
+    if [[ -d "$server_dir" ]]; then
+        sudo rm -rf "$server_dir" 2>/dev/null \
+            || docker run --rm -v "$DEPLOY_BASE:/cleanup" alpine \
+                rm -rf "/cleanup/$server_name" 2>/dev/null \
+            || warn "Could not fully clean $server_dir (root-owned files may remain)"
+    fi
+
+    sleep 5
+    ok "All containers stopped"
+}
+
+# ── Pre-pull Docker image on all remote machines ─────────────────────────
+pre_pull_images() {
+    step "Pre-pulling Docker image on remote machines"
+    info "Image: $DOCKER_IMAGE"
+
+    local -A visited_hosts=()
+    for site in "${CLIENT_SITES[@]}"; do
+        local host
+        host=$(site_var "$site" HOST)
+        if [[ -n "${visited_hosts[$host]:-}" ]]; then
+            continue
+        fi
+        visited_hosts[$host]=1
+
+        info "Pulling $DOCKER_IMAGE on $host ..."
+        remote_exec "$site" "docker pull '$DOCKER_IMAGE'" || {
+            err "Failed to pull image on $host"
+            exit 1
+        }
+        ok "  Image pulled on $host"
+    done
+
+    ok "Docker image available on all remote machines"
+}
+
+# ── Deploy startup kits ───────────────────────────────────────────────────
+deploy_kits() {
+    local prod_dir
+    prod_dir=$(find_latest_prod)
+    info "Deploying startup kits from: $prod_dir"
+
+    # Deploy client kits to remote machines
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name host deploy_dir
+        site_name=$(site_var "$site" SITE_NAME)
+        host=$(site_var "$site" HOST)
+        deploy_dir=$(site_var "$site" DEPLOY_DIR)
+
+        local zip_file="$prod_dir/${site_name}_${VERSION}.zip"
+        if [[ ! -f "$zip_file" ]]; then
+            zip_file=$(ls "$prod_dir"/${site_name}*.zip 2>/dev/null | head -1 || true)
+            if [[ -z "$zip_file" ]]; then
+                err "Startup kit not found for $site_name in $prod_dir"
+                exit 1
+            fi
+        fi
+
+        remote_exec "$site" "mkdir -p '$deploy_dir'"
+        remote_copy "$site" "$zip_file" "$deploy_dir/"
+        remote_exec "$site" "cd '$deploy_dir' && rm -rf '${site_name}' && unzip -qo '$(basename "$zip_file")'"
+        ok "  Deployed $site_name to $host:$deploy_dir/"
+    done
+
+    # Deploy server kit locally (on Cosmos)
+    local server_name="${SERVER_NAME:-dl3.tud.de}"
+    local server_zip="$prod_dir/${server_name}_${VERSION}.zip"
+    if [[ ! -f "$server_zip" ]]; then
+        server_zip=$(ls "$prod_dir"/${server_name}*.zip 2>/dev/null | head -1 || true)
+    fi
+    if [[ -n "$server_zip" && -f "$server_zip" ]]; then
+        mkdir -p "$DEPLOY_BASE"
+        cp "$server_zip" "$DEPLOY_BASE/"
+        cd "$DEPLOY_BASE" && rm -rf "$server_name" && unzip -qo "$(basename "$server_zip")"
+        cd "$REPO_ROOT"
+        ok "  Deployed server kit ($server_name) locally on Cosmos"
+    fi
+
+    # Deploy admin kit locally (on Cosmos)
+    local admin_zip="$prod_dir/${ADMIN_USER}_${VERSION}.zip"
+    if [[ ! -f "$admin_zip" ]]; then
+        admin_zip=$(ls "$prod_dir"/${ADMIN_USER}*.zip 2>/dev/null | head -1 || true)
+    fi
+    if [[ -n "$admin_zip" && -f "$admin_zip" ]]; then
+        cp "$admin_zip" "$DEPLOY_BASE/"
+        cd "$DEPLOY_BASE" && rm -rf "$ADMIN_USER" && unzip -qo "$(basename "$admin_zip")"
+        cd "$REPO_ROOT"
+        ok "  Deployed admin kit ($ADMIN_USER) locally on Cosmos"
+    fi
+}
+
+# ── Start server (on Cosmos — always local) ──────────────────────────────
+start_server() {
+    local server_name="${SERVER_NAME:-dl3.tud.de}"
+    local server_startup="$DEPLOY_BASE/$server_name/startup"
+
+    if [[ ! -d "$server_startup" ]]; then
+        local prod_dir
+        prod_dir=$(find_latest_prod)
+        server_startup="$prod_dir/$server_name/startup"
+    fi
+
+    if [[ ! -d "$server_startup" ]]; then
+        err "Server startup kit not found at $server_startup"
+        exit 1
+    fi
+
+    _server_startup_dir="$server_startup"
+
+    info "Starting server from: $server_startup"
+    cd "$server_startup"
+    ./docker.sh --no_pull --start_server
+    cd "$REPO_ROOT"
+
+    info "Waiting 15s for server to initialize..."
+    sleep 15
+
+    if docker ps --format '{{.Names}}' | grep -qE "stamp_swarm|nvflare"; then
+        ok "Server container is running"
+    else
+        warn "Server container not detected — it may still be starting"
+    fi
+}
+
+# ── Start clients (all remote) ───────────────────────────────────────────
+# KEY DIFFERENCE from ODELIA: exports STAMP_* env vars on each remote host
+# before calling docker.sh.  The STAMP master template's forwarding loop
+# (for _var in $(env | grep '^STAMP_')) picks them up.
+start_clients() {
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name host deploy_dir datadir scratchdir gpu
+        site_name=$(site_var "$site" SITE_NAME)
+        host=$(site_var "$site" HOST)
+        deploy_dir=$(site_var "$site" DEPLOY_DIR)
+        datadir=$(site_var "$site" DATADIR)
+        scratchdir=$(site_var "$site" SCRATCHDIR)
+        gpu=$(site_var "$site" GPU)
+
+        info "Starting client: $site_name @ $host (with STAMP_* env vars)"
+
+        # Generate STAMP env exports for this site
+        local stamp_exports
+        stamp_exports=$(setup_stamp_env "$site_name" "$datadir")
+
+        remote_exec "$site" \
+            "$stamp_exports && \
+             cd '$deploy_dir/$site_name/startup' && \
+             ./docker.sh --no_pull --data_dir '$datadir' --scratch_dir '$scratchdir' --GPU '$gpu' --start_client"
+
+        ok "  Client started: $site_name"
+    done
+
+    ok "All clients started"
+}
+
+# ── Wait for all clients to register with the server ─────────────────────
+wait_for_client_registration() {
+    resolve_server_startup_dir
+    local server_log="${_server_startup_dir}/nohup.out"
+    local max_wait=600  # 10 minutes
+    local elapsed=0
+    local expected_clients=("${CLIENT_SITES[@]}")
+
+    info "Waiting for all ${#expected_clients[@]} clients to register (timeout: ${max_wait}s)"
+    info "Server log: $server_log"
+
+    while [[ $elapsed -lt $max_wait ]]; do
+        local all_registered=true
+        for site in "${expected_clients[@]}"; do
+            local site_name
+            site_name=$(site_var "$site" SITE_NAME)
+            if [[ -f "$server_log" ]] && grep -q "New client ${site_name}@" "$server_log" 2>/dev/null; then
+                :  # Client registered
+            else
+                all_registered=false
+                break
+            fi
+        done
+
+        if $all_registered; then
+            ok "All ${#expected_clients[@]} clients registered with the server"
+            sleep 5
+            return 0
+        fi
+
+        sleep 10
+        elapsed=$((elapsed + 10))
+
+        if (( elapsed % 60 == 0 )); then
+            local registered=0
+            for site in "${expected_clients[@]}"; do
+                local site_name
+                site_name=$(site_var "$site" SITE_NAME)
+                if [[ -f "$server_log" ]] && grep -q "New client ${site_name}@" "$server_log" 2>/dev/null; then
+                    registered=$((registered + 1))
+                fi
+            done
+            info "  ${registered}/${#expected_clients[@]} clients registered (${elapsed}s elapsed)"
+        fi
+    done
+
+    # Timeout: show which clients are missing
+    warn "Timed out waiting for client registration. Status:"
+    for site in "${expected_clients[@]}"; do
+        local site_name
+        site_name=$(site_var "$site" SITE_NAME)
+        if [[ -f "$server_log" ]] && grep -q "New client ${site_name}@" "$server_log" 2>/dev/null; then
+            ok "    $site_name — registered"
+        else
+            err "    $site_name — NOT registered"
+        fi
+    done
+
+    err "Not all clients registered within ${max_wait}s"
+    return 1
+}
+
+# ── Submit job (via admin on Cosmos — always local) ──────────────────────
+submit_job() {
+    local job_name="$1"
+    local admin_startup="$DEPLOY_BASE/$ADMIN_USER/startup"
+
+    if [[ ! -d "$admin_startup" ]]; then
+        local prod_dir
+        prod_dir=$(find_latest_prod)
+        admin_startup="$prod_dir/$ADMIN_USER/startup"
+    fi
+
+    if [[ ! -d "$admin_startup" ]]; then
+        err "Admin startup kit not found"
+        exit 1
+    fi
+
+    local job_path="MediSwarm/application/jobs/$job_name"
+    info "Submitting job: $job_name (path: $job_path)"
+
+    local expect_script
+    expect_script=$(mktemp /tmp/mediswarm_stamp_deploy_test_XXXXXX.exp)
+    cat > "$expect_script" <<EXPECT_EOF
+#!/usr/bin/env expect
+set timeout 120
+spawn ./docker.sh --no_pull
+expect "User Name: "
+send "$ADMIN_USER\r"
+expect "> "
+send "submit_job $job_path\r"
+expect "> "
+send "list_jobs\r"
+expect "> "
+send "bye\r"
+expect eof
+EXPECT_EOF
+    chmod +x "$expect_script"
+
+    cd "$admin_startup"
+    expect -f "$expect_script" || true
+    cd "$REPO_ROOT"
+
+    rm -f "$expect_script"
+    ok "Job submitted: $job_name"
+}
+
+# ── Wait for training completion ──────────────────────────────────────────
+wait_for_completion() {
+    local model_name="$1"
+    local timeout_minutes="${2:-$TIMEOUT_MINUTES}"
+    resolve_server_startup_dir
+    local server_log="${_server_startup_dir}/nohup.out"
+
+    # Record current line count so we only check NEW lines
+    local start_line=0
+    if [[ -f "$server_log" ]]; then
+        start_line=$(wc -l < "$server_log" 2>/dev/null || echo 0)
+    fi
+
+    local max_attempts=$(( timeout_minutes * 2 ))  # Check every 30 seconds
+    local attempt=0
+
+    info "Waiting for training to complete: $model_name (timeout: ${timeout_minutes}min, checking every 30s)"
+    info "Server log: $server_log (scanning from line $((start_line + 1)))"
+
+    while [[ $attempt -lt $max_attempts ]]; do
+        if [[ -f "$server_log" ]]; then
+            local new_lines
+            new_lines=$(tail -n +"$((start_line + 1))" "$server_log" 2>/dev/null || true)
+
+            # Check for clean completion
+            if echo "$new_lines" | grep -q 'Server runner finished\.' 2>/dev/null; then
+                # Check if it was a fatal finish
+                local finish_lineno
+                finish_lineno=$(echo "$new_lines" | grep -n 'Server runner finished\.' | tail -1 | cut -d: -f1)
+                local context_start=$(( finish_lineno - 50 ))
+                [[ $context_start -lt 1 ]] && context_start=1
+                local context
+                context=$(echo "$new_lines" | sed -n "${context_start},${finish_lineno}p")
+
+                if echo "$context" | grep -q 'FATAL_SYSTEM_ERROR\|ABORT_RUN\|EXECUTION_EXCEPTION.*abort' 2>/dev/null; then
+                    err "Training ABORTED for $model_name — fatal error detected (after $((attempt * 30))s)"
+                    echo "$new_lines" | grep -i 'FATAL\|ABORT\|EXCEPTION\|ERROR' | tail -20 >&2
+                    return 1
+                else
+                    ok "Training completed for $model_name! (after $((attempt * 30))s)"
+                    return 0
+                fi
+            fi
+        fi
+
+        # Check if the server container died
+        if ! docker ps --format '{{.Names}}' | grep -qE "stamp_swarm|nvflare"; then
+            if [[ -f "$server_log" ]]; then
+                local new_lines
+                new_lines=$(tail -n +"$((start_line + 1))" "$server_log" 2>/dev/null || true)
+                if echo "$new_lines" | grep -q 'Server runner finished\.' 2>/dev/null; then
+                    ok "Training completed for $model_name (container exited cleanly)"
+                    return 0
+                fi
+            fi
+            warn "Server container is no longer running — training may have failed"
+            return 1
+        fi
+
+        attempt=$((attempt + 1))
+        sleep 30
+
+        if (( attempt % 4 == 0 )); then
+            info "  Still waiting for $model_name... ($((attempt * 30))s elapsed)"
+        fi
+    done
+
+    err "Timeout after ${timeout_minutes}min waiting for $model_name training to complete"
+    return 1
+}
+
+# ── Record result ─────────────────────────────────────────────────────────
+record_result() {
+    local model_name="$1"
+    local job_name="$2"
+    local train_status="$3"   # pass or fail
+    local duration_seconds="$4"
+
+    local result_file="$RESULTS_DIR/deploy_test_stamp_${model_name}.json"
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    cat > "$result_file" <<EOF
+{
+    "model_name": "$model_name",
+    "job_name": "$job_name",
+    "training_status": "$train_status",
+    "duration_seconds": $duration_seconds,
+    "timestamp": "$timestamp",
+    "docker_image": "$DOCKER_IMAGE",
+    "version": "$VERSION",
+    "client_sites": $(printf '%s\n' "${CLIENT_SITES[@]}" | jq -R . | jq -s .)
+}
+EOF
+
+    info "Result recorded: $result_file"
+}
+
+# ── Run the deploy test ──────────────────────────────────────────────────
+run_single_model() {
+    local job_name="$1"
+    local model_name="$2"
+    local start_time
+    start_time=$(date +%s)
+
+    step "Running STAMP deploy test: $model_name (job: $job_name)"
+    echo ""
+    info "Docker image: $DOCKER_IMAGE"
+    info "Workspace: $WORKSPACE_DIR"
+    info "Server: Cosmos (localhost)"
+    info "Clients: ${CLIENT_SITES[*]}"
+    echo ""
+
+    local train_status="fail"
+
+    # 1. Stop any existing containers
+    stop_all
+
+    # 2. Start server on Cosmos
+    start_server
+
+    # 3. Start clients with STAMP_* env vars
+    start_clients
+
+    # 4. Wait for all clients to register
+    wait_for_client_registration
+
+    # 5. Submit job via admin
+    submit_job "$job_name"
+
+    # 6. Wait for training completion
+    if wait_for_completion "$model_name"; then
+        train_status="pass"
+    fi
+
+    # 7. Stop all containers
+    stop_all
+
+    # 8. Record result
+    local end_time
+    end_time=$(date +%s)
+    local duration=$(( end_time - start_time ))
+
+    record_result "$model_name" "$job_name" "$train_status" "$duration"
+
+    echo ""
+    if [[ "$train_status" == "pass" ]]; then
+        ok "PASSED: $model_name in ${duration}s"
+    else
+        err "FAILED: $model_name in ${duration}s"
+    fi
+
+    return 0
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+# Check dependencies
+for cmd in sshpass expect jq docker; do
+    if ! command -v "$cmd" &>/dev/null; then
+        err "Missing required tool: $cmd"
+        exit 1
+    fi
+done
+
+# Verify workspace exists
+if [[ ! -d "$WORKSPACE_DIR" ]]; then
+    err "Workspace not found: $WORKSPACE_DIR"
+    err "Build startup kits first:"
+    err "  ./scripts/build/buildDockerImageAndStartupKits.sh -p $PROJECT_FILE -d docker_config/Dockerfile_STAMP --num-rounds 2"
+    exit 1
+fi
+
+# Clean up any leftover containers from previous runs
+stop_all
+
+# Deploy startup kits to all sites
+step "Deploying startup kits to all sites"
+deploy_kits
+
+# Fix DNS on remote machines
+fix_remote_dns
+
+# Pre-pull Docker image on all remote machines
+pre_pull_images
+
+# Run the STAMP deploy test
+run_single_model "$JOB_NAME" "vit"


### PR DESCRIPTION
## Summary

- **STAMP deploy test infrastructure**: Separate STAMP-specific Docker template (`master_template_STAMP.yml`), Dockerfile update, build script changes, and a standalone deploy test orchestrator (`run_stamp_deploy_test.sh`) for 2-node real swarm training on DL0 + DL2
- **STAMP participant README**: New `assets/readme/README.participant.STAMP.md` — participant-facing guide covering data format (H5 features + clinical CSV), STAMP environment variable configuration, docker.sh usage, and STAMP-specific troubleshooting
- **Deploy test path fix**: Corrected `STAMP_CLINI_TABLE` and `STAMP_FEATURE_DIR` to use container-internal `/data/` paths instead of host paths

Successfully validated with a 2-round swarm training run (VIT model, 2 clients) — both rounds completed with proper model aggregation and weight sharing between nodes.

## Test plan

- [x] STAMP deploy test passed: 2-round VIT swarm training on DL0 (RUMC_1) + DL2 (MHA_1) with synthetic data
- [x] Both clients registered and contributed updates at each round
- [x] DXOAggregator confirmed "aggregating 2 update(s)" at rounds 0 and 1
- [x] Training metrics improved (AUROC 0.222 → 1.0, loss ~0.55 → ~0.07)
- [ ] Verify STAMP participant README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)