### PR TITLE
Fix --job flag ignoring challenge model & live_sync SSH hanging

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -741,6 +741,16 @@ docker_cln_sh: |
   # Default job for preflight_check and local_training
   : ${JOB_NAME:="ODELIA_ternary_classification"}
 
+  # Auto-derive MODEL_NAME from challenge job names.
+  # Challenge jobs (challenge_1DivideAndConquer, etc.) share identical code
+  # via symlinks, so the model is selected entirely by MODEL_NAME.
+  # When --job specifies a challenge job and --model_name was NOT given,
+  # derive MODEL_NAME automatically so participants don't need to set both.
+  if [[ -z "${CLI_MODEL_NAME:-}" && "$JOB_NAME" == challenge_* ]]; then
+      CLI_MODEL_NAME="${JOB_NAME#challenge_}"
+      echo "[INFO] Auto-derived MODEL_NAME='$CLI_MODEL_NAME' from --job '$JOB_NAME'"
+  fi
+
   # Prompt for parameters if missing
   if [[ -z "$DUMMY_TRAINING" && -z "$LIST_LICENSES" && -z "$MY_DATA_DIR" ]]; then
       read -p "Enter the path to your data directory (default: /home/flclient/data): " user_data_dir

--- a/kit_live_sync/live_sync.sh
+++ b/kit_live_sync/live_sync.sh
@@ -27,6 +27,30 @@ done
 [ -n "$KIT_ROOT" ] || { echo "KIT_ROOT missing" >&2; exit 1; }
 [ -n "$STARTUP_DIR" ] || { echo "STARTUP_DIR missing" >&2; exit 1; }
 
+# ── SSH connectivity check ──────────────────────────────────────────
+# Verify we can reach the monitoring server before entering the sync
+# loop.  With BatchMode=yes the connection will fail immediately if
+# key-based auth is not set up instead of prompting for a password.
+if ! ssh ${SSH_OPTS} "${REMOTE_USER}@${REMOTE_HOST}" true 2>/dev/null; then
+    echo ""
+    echo "============================================================"
+    echo "[WARN] Live-sync: cannot connect to ${REMOTE_USER}@${REMOTE_HOST}"
+    echo ""
+    echo "  Training will continue normally, but training artifacts"
+    echo "  will NOT be synced to the monitoring server."
+    echo ""
+    echo "  To enable live sync, share your SSH public key with your"
+    echo "  swarm operator.  Generate one (if you haven't already) with:"
+    echo ""
+    echo "    ssh-keygen -t ed25519 -C \"\$(hostname)@mediswarm\""
+    echo ""
+    echo "  Then send the contents of ~/.ssh/id_ed25519.pub to your"
+    echo "  swarm operator so they can add it to the server."
+    echo "============================================================"
+    echo ""
+    exit 0
+fi
+
 STATE_DIR="$STARTUP_DIR/.mediswarm_sync"
 mkdir -p "$STATE_DIR"
 LAST_CKPT_SYNC_FILE="$STATE_DIR/${MODE}_last_ckpt_sync_ts"

--- a/kit_live_sync/sync.conf
+++ b/kit_live_sync/sync.conf
@@ -7,4 +7,4 @@ REMOTE_BASE="/srv/mediswarm/live"
 LOG_SYNC_INTERVAL=30
 CKPT_SYNC_INTERVAL=180
 
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes"


### PR DESCRIPTION
## Summary

- **Bug 1:** `--job challenge_1DivideAndConquer` now auto-derives `MODEL_NAME=1DivideAndConquer` when `--model_name` is not explicitly given. Previously the `--job` flag only selected the NVFlare job directory but did not affect `MODEL_NAME`, so any leftover `MODEL_NAME` env var from a previous experiment would silently override the intended model.
- **Bug 2:** `live_sync.sh` no longer hangs on SSH password prompts when the site's SSH key isn't authorized on the monitoring server. Added `BatchMode=yes` to `SSH_OPTS` and an upfront connectivity check that prints a clear message instructing users to generate and share their SSH public key with the swarm operator.

Both bugs were reported by the Cambridge site (Zhongying) while preparing for the April 16 challenge_1DivideAndConquer swarm training.

## Test plan

- [x] Unit tests pass (108 passed, 1 skipped, 1 pre-existing STAMP failure unrelated to changes)
- [ ] Verify `--job challenge_1DivideAndConquer` sets `MODEL_NAME=1DivideAndConquer` in generated docker.sh
- [ ] Verify `--job challenge_1DivideAndConquer --model_name 5Pimed` still uses `5Pimed` (explicit flag wins)
- [ ] Verify live_sync exits gracefully with instructive message when SSH key auth fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)