### PR TITLE
[codex] Add retry loop to STAMP deploy test

### DIFF
--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -660,22 +660,10 @@ EOF
     info "Result recorded: $result_file"
 }
 
-# ── Run the deploy test ──────────────────────────────────────────────────
-run_single_model() {
+# ── Run one training attempt ─────────────────────────────────────────────
+_run_training_attempt() {
     local job_name="$1"
     local model_name="$2"
-    local start_time
-    start_time=$(date +%s)
-
-    step "Running STAMP deploy test: $model_name (job: $job_name)"
-    echo ""
-    info "Docker image: $DOCKER_IMAGE"
-    info "Workspace: $WORKSPACE_DIR"
-    info "Server: Cosmos (localhost)"
-    info "Clients: ${CLIENT_SITES[*]}"
-    echo ""
-
-    local train_status="fail"
 
     # 1. Stop any existing containers
     stop_all
@@ -694,8 +682,48 @@ run_single_model() {
 
     # 6. Wait for training completion
     if wait_for_completion "$model_name"; then
-        train_status="pass"
+        return 0
+    else
+        return 1
     fi
+}
+
+# ── Run the deploy test ──────────────────────────────────────────────────
+MAX_RETRIES=2  # Total attempts = 1 + MAX_RETRIES
+
+run_single_model() {
+    local job_name="$1"
+    local model_name="$2"
+    local start_time
+    start_time=$(date +%s)
+
+    step "Running STAMP deploy test: $model_name (job: $job_name)"
+    echo ""
+    info "Docker image: $DOCKER_IMAGE"
+    info "Workspace: $WORKSPACE_DIR"
+    info "Server: Cosmos (localhost)"
+    info "Clients: ${CLIENT_SITES[*]}"
+    echo ""
+
+    local train_status="fail"
+
+    local attempt=1
+    while [[ $attempt -le $((MAX_RETRIES + 1)) ]]; do
+        if [[ $attempt -gt 1 ]]; then
+            warn "Retry $((attempt - 1))/$MAX_RETRIES for $model_name"
+        fi
+
+        if _run_training_attempt "$job_name" "$model_name"; then
+            train_status="pass"
+            break
+        fi
+
+        attempt=$((attempt + 1))
+        if [[ $attempt -le $((MAX_RETRIES + 1)) ]]; then
+            info "Waiting 30s before next attempt for $model_name"
+            sleep 30
+        fi
+    done
 
     # 7. Stop all containers
     stop_all


### PR DESCRIPTION
## Summary
- add an internal single-attempt helper for the STAMP deploy test
- wrap the STAMP run in the same fixed retry pattern used by the ODELIA deploy test
- keep the existing result JSON format unchanged

## Why
Issue #273 notes that `run_stamp_deploy_test.sh` currently treats a single transient failure as final, even though the ODELIA deploy test already retries flaky startup or network failures.

## Impact
The STAMP deploy test now retries failed runs up to 2 times with a 30-second cooldown between attempts, which should make transient infrastructure failures less likely to fail the full deploy test.

## Validation
- `bash -n scripts/deploy/run_stamp_deploy_test.sh`

Closes #273