### PR TITLE
Fix challenge model selection (#284) and live-sync UX (#285)

### DIFF
--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -80,7 +80,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "MODEL_NAME=1DivideAndConquer python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -80,7 +80,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "MODEL_NAME=2BCN_AIM python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -80,7 +80,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "MODEL_NAME=3agaldran python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -80,7 +80,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "MODEL_NAME=4LME_ABMIL python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -80,7 +80,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "MODEL_NAME=5Pimed python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -747,7 +747,12 @@ docker_cln_sh: |
   # When --job specifies a challenge job and --model_name was NOT given,
   # derive MODEL_NAME automatically so participants don't need to set both.
   if [[ -z "${CLI_MODEL_NAME:-}" && "$JOB_NAME" == challenge_* ]]; then
-      CLI_MODEL_NAME="${JOB_NAME#challenge_}"
+      _derived="${JOB_NAME#challenge_}"
+      case "$_derived" in
+          4abmil) CLI_MODEL_NAME="4LME_ABMIL" ;;  # job dir name differs from model name
+          5pimed) CLI_MODEL_NAME="5Pimed" ;;        # job dir name differs from model name
+          *)      CLI_MODEL_NAME="$_derived" ;;
+      esac
       echo "[INFO] Auto-derived MODEL_NAME='$CLI_MODEL_NAME' from --job '$JOB_NAME'"
   fi
 

--- a/kit_live_sync/live_sync.sh
+++ b/kit_live_sync/live_sync.sh
@@ -4,21 +4,24 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SYNC_CONF="$SCRIPT_DIR/sync.conf"
 
+_ask_continue_without_sync() {
+    # In non-interactive environments (no TTY), default to continuing without sync
+    if [ ! -t 0 ]; then
+        echo "[INFO] Non-interactive mode — continuing without live sync."
+        return 0
+    fi
+    read -r -p "Continue training without live sync? [y/N] " ans
+    case "$ans" in
+        [yY]*) return 0 ;;
+        *) echo "Aborted."; return 1 ;;
+    esac
+}
+
 if [ ! -f "$SYNC_CONF" ]; then
     echo ""
-    echo "============================================================"
-    echo "[WARN] Live-sync: missing $SYNC_CONF"
+    echo "[WARN] Live-sync: sync.conf not found — training artifacts will not be synced."
     echo ""
-    echo "  Training will continue normally, but training artifacts"
-    echo "  will NOT be synced to the monitoring server."
-    echo ""
-    echo "  To enable live sync, create a local config from the example:"
-    echo ""
-    echo "    cp \"$SCRIPT_DIR/sync.conf.example\" \"$SYNC_CONF\""
-    echo ""
-    echo "============================================================"
-    echo ""
-    exit 0
+    _ask_continue_without_sync && exit 0 || exit 1
 fi
 
 # shellcheck source=/dev/null
@@ -50,24 +53,25 @@ done
 # Verify we can reach the monitoring server before entering the sync
 # loop.  With BatchMode=yes the connection will fail immediately if
 # key-based auth is not set up instead of prompting for a password.
-if ! ssh ${SSH_OPTS} "${REMOTE_USER}@${REMOTE_HOST}" true 2>/dev/null; then
+echo "Testing SSH connectivity to ${REMOTE_USER}@${REMOTE_HOST}..."
+if ssh ${SSH_OPTS} "${REMOTE_USER}@${REMOTE_HOST}" 'echo ok' >/dev/null 2>&1; then
+    echo "SSH OK — live sync enabled."
+else
     echo ""
     echo "============================================================"
     echo "[WARN] Live-sync: cannot connect to ${REMOTE_USER}@${REMOTE_HOST}"
-    echo ""
-    echo "  Training will continue normally, but training artifacts"
-    echo "  will NOT be synced to the monitoring server."
     echo ""
     echo "  To enable live sync, share your SSH public key with your"
     echo "  swarm operator.  Generate one (if you haven't already) with:"
     echo ""
     echo "    ssh-keygen -t ed25519 -C \"\$(hostname)@mediswarm\""
+    echo "    cat ~/.ssh/id_ed25519.pub  # send this to the swarm operator"
     echo ""
-    echo "  Then send the contents of ~/.ssh/id_ed25519.pub to your"
-    echo "  swarm operator so they can add it to the server."
+    echo "  Test connectivity manually with:"
+    echo "    ssh ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} 'echo ok'"
     echo "============================================================"
     echo ""
-    exit 0
+    _ask_continue_without_sync && exit 0 || exit 1
 fi
 
 STATE_DIR="$STARTUP_DIR/.mediswarm_sync"

--- a/kit_live_sync/sync.conf.example
+++ b/kit_live_sync/sync.conf.example
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-REMOTE_HOST="monitor.example.internal"
+REMOTE_HOST="172.24.4.65"
 REMOTE_USER="mediswarm-upload"
 REMOTE_BASE="/srv/mediswarm/live"
 
 LOG_SYNC_INTERVAL=30
 CKPT_SYNC_INTERVAL=180
 
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=5"

--- a/scripts/build/_injectLiveSyncIntoStartupKits.sh
+++ b/scripts/build/_injectLiveSyncIntoStartupKits.sh
@@ -31,7 +31,11 @@ find "$TARGET_FOLDER" -mindepth 1 -maxdepth 1 -type d | while read -r KIT_DIR; d
     continue
   fi
 
-  cp "$HELPER_SOURCE_DIR/sync.conf" "$STARTUP_DIR/sync.conf"
+  if [ -f "$HELPER_SOURCE_DIR/sync.conf" ]; then
+    cp "$HELPER_SOURCE_DIR/sync.conf" "$STARTUP_DIR/sync.conf"
+  else
+    cp "$HELPER_SOURCE_DIR/sync.conf.example" "$STARTUP_DIR/sync.conf"
+  fi
   cp "$HELPER_SOURCE_DIR/build_heartbeat.sh" "$STARTUP_DIR/build_heartbeat.sh"
   cp "$HELPER_SOURCE_DIR/live_sync.sh" "$STARTUP_DIR/live_sync.sh"
 


### PR DESCRIPTION
## Summary

- **Fixes #284** — `--job challenge_4abmil` and `--job challenge_5pimed` failed with `ValueError: Unsupported model name` because the auto-derive logic in `master_template.yml` produced `4abmil`/`5pimed` instead of the registry keys `4LME_ABMIL`/`5Pimed`. Fixed with a `case` statement mapping and by hardcoding the correct `MODEL_NAME=` in each challenge job's `SubprocessLauncher` script (covers admin-submitted jobs too).
- **Fixes #285** — Two live-sync UX issues:
  1. `sync.conf.example` had a placeholder IP (`monitor.example.internal`). Updated to the real server (`172.24.4.65`) + `ConnectTimeout=5`. Injection script now falls back to `.example` if no local `sync.conf` exists, so startup kits always arrive pre-configured.
  2. SSH connectivity failure previously exited silently with `exit 0`. Now shows the SSH command to test manually, key-sharing instructions, and interactively asks "Continue training without live sync? [y/N]". Non-interactive (no TTY) defaults to continue.

## Changes

| File | Change |
|------|--------|
| `docker_config/master_template.yml` | Case statement for `4abmil→4LME_ABMIL`, `5pimed→5Pimed` in auto-derive block |
| `application/jobs/challenge_*/app/config/config_fed_client.conf` (×5) | Hardcode correct `MODEL_NAME=` in `SubprocessLauncher` script |
| `kit_live_sync/sync.conf.example` | Real server IP, `ConnectTimeout=5` |
| `scripts/build/_injectLiveSyncIntoStartupKits.sh` | Fall back to `.example` if no `sync.conf` present |
| `kit_live_sync/live_sync.sh` | `_ask_continue_without_sync` helper, interactive SSH check, remove misleading "copy the example" instructions |

## Test plan

- [ ] `--preflight_check --job challenge_4abmil` — expect model `4LME_ABMIL` loads, no `ValueError`
- [ ] `--preflight_check --job challenge_5pimed` — expect model `5Pimed` loads, no `ValueError`
- [ ] Build startup kits — confirm `sync.conf` in each kit has `REMOTE_HOST=172.24.4.65`
- [ ] Run `--local_training` with SSH key NOT authorized → interactive prompt appears, `y` continues training, `n` exits cleanly
- [ ] Run without TTY (piped input) → defaults to continue without sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)