### PR TITLE
Improve ODELIA dataset plausibility checking

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/scripts/create_synthetic_dataset/create_synthetic_dataset.py
+++ b/application/jobs/ODELIA_ternary_classification/app/scripts/create_synthetic_dataset/create_synthetic_dataset.py
@@ -33,15 +33,25 @@ def create_folder_structure(output_folder) -> None:
 
 
 def get_image(i: int, j: int, lesion_class: int):
-    # create three different types of images depending on the class
-    array = np.random.randint(-10, 10, size=size, dtype=np.int16)
-    if lesion_class == 0:
-        array[:, i, j] = -50
-    elif lesion_class == 1:
-        array[:, i, j] = 200
-    else:
-        array[:size[2] // 2, i, j] = 200
-        array[size[2] // 2:, i, j] = 50
+    def _get_partially_random_array():
+        rng = np.random.Generator(np.random.SFC64())
+        small_size = (size[0], size[1]//4, size[2]//4)
+        random_array = rng.integers(low=-10, high=10, size=small_size, dtype=np.int16)
+        array = np.pad(random_array, ((0, 0), ((size[1]-small_size[1])//2, (size[1]-small_size[1])//2), ((size[2]-small_size[2])//2, (size[2]-small_size[2])//2)) )
+        return array
+
+    def _set_to_class(image, i: int, j: int):
+        if lesion_class == 0:
+            array[:, i, j] = -50
+        elif lesion_class == 1:
+            array[:, i, j] = 200
+        else:
+            array[:size[2] // 2, i, j] = 200
+            array[size[2] // 2:, i, j] = 50
+        return array
+
+    array = _get_partially_random_array()
+    array = _set_to_class(array, i, j)
     image = sitk.GetImageFromArray(array)
     return image
 

--- a/application/jobs/ODELIA_ternary_classification/app/scripts/create_synthetic_dataset/create_synthetic_dataset.py
+++ b/application/jobs/ODELIA_ternary_classification/app/scripts/create_synthetic_dataset/create_synthetic_dataset.py
@@ -122,6 +122,10 @@ if __name__ == '__main__':
                             {'UID': uid, 'PatientID': patientid, 'Lesion': lesion_class, 'Age': some_age + i + j, 'Fold': f,
                              'Split': get_split(j, f)})
 
+        folder = output_folder/site/data_folder/'SomeUID_both'
+        os.mkdir(folder)
+        shutil.copyfile(output_folder/site/data_folder/'ID_000_left'/'Sub_1.nii.gz', folder/'Sub_1.nii.gz')
+
         # one table entry per fold without image that is a duplicate in two parts of the split
         for f in range(num_folds):
             j = num_images_per_site + 1
@@ -131,5 +135,6 @@ if __name__ == '__main__':
                 table_data.append({'UID': uid, 'PatientID': patientid, 'Lesion': 0, 'Age': 0, 'Fold': f, 'Split': 'train'})
                 table_data.append({'UID': uid, 'PatientID': patientid, 'Lesion': 0, 'Age': 0, 'Fold': f, 'Split': 'val'})
                 table_data.append({'UID': uid, 'PatientID': patientid, 'Lesion': 0, 'Age': 0, 'Fold': f, 'Split': 'test'})
+            table_data.append({'UID': 'SomeUID_both', 'PatientID': 'SomeUID', 'Lesion': 0, 'Age': 0, 'Fold': f, 'Split': 'train'}) # one entry not ending in _left or _right
 
         save_table(output_folder, site, table_data)

--- a/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
+++ b/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
@@ -243,6 +243,18 @@ class ODELIA_Dataset3D(data.Dataset):
             _log_neither_left_nor_right(uids, where, logger, log_dataset_details)
             _log_one_side_only(uids, where, logger, log_dataset_details)
 
+        def _log_left_right_overlap(uids_a: List[str], uids_b: List[str], where_a: str, where_b: str, logger, log_dataset_details) -> None:
+            exam_ids_left  = {u[:-5] for u in uids if u.endswith('_left') }
+            exam_ids_right = {u[:-6] for u in uids if u.endswith('_right')}
+
+            joint_exam_ids = exam_ids_left.intersection(exam_ids_right)
+            if joint_exam_ids:
+                logger.error(f'UIDs for the same exam found in {where_a} and {where_b}, this should not happen.')
+                if log_dataset_details:
+                    joint_exam_ids = list(joint_exam_ids)
+                    joint_exam_ids.sort()
+                    logger.error(f'The following exams are present in {where_a} and {where_b}: ' + ', '.join(joint_exam_ids))
+
 
         config = 'unilateral'
         path_root = Path(cls.PATH_ROOT if path_root is None else path_root)
@@ -278,3 +290,7 @@ class ODELIA_Dataset3D(data.Dataset):
             _log_left_right_discrepancies(uids_in_split['train'], 'training',   logger, log_dataset_details)
             _log_left_right_discrepancies(uids_in_split['val'],   'validation', logger, log_dataset_details)
             _log_left_right_discrepancies(uids_in_split['test'],  'test',       logger, log_dataset_details)
+
+            _log_left_right_overlap(uids_in_split['train'], uids_in_split['val'],  'training',   'validation', logger, log_dataset_details)
+            _log_left_right_overlap(uids_in_split['train'], uids_in_split['test'], 'training',   'test',       logger, log_dataset_details)
+            _log_left_right_overlap(uids_in_split['val'],   uids_in_split['test'], 'validation', 'test',       logger, log_dataset_details)

--- a/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
+++ b/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
@@ -215,6 +215,35 @@ class ODELIA_Dataset3D(data.Dataset):
                     intersection.sort()
                     logger.error(f'Entries in {where_a}∩{where_b}: ' + ', '.join(intersection))
 
+        def _log_left_right_discrepancies(uids: List[str], where: str, logger, log_dataset_details) -> None:
+            def _log_neither_left_nor_right(uids: List[str], where: str, logger, log_dataset_details) -> None:
+                neither_left_right = [u for u in uids if ( not u.endswith('_left') and not u.endswith('_right') )]
+                if neither_left_right:
+                    logger.error(f'UIDs among {where} data present that do not end in _left or _right, this should not happen.')
+                    if log_dataset_details:
+                        neither_left_right.sort()
+                        logger.error('The following UIDs among {where} data do not end in _left or _right: ' + ', '.join(neither_left_nor_right))
+
+            def _log_one_side_only(uids: List[str], where: str, logger, log_dataset_details) -> None:
+                def _report(discrepancies: List[str], present: str, absent: str, where: str, logger, log_dataset_details) -> None:
+                    if discrepancies:
+                        logger.warning(f'UIDs with among {where} data _left present and _right missing detected, make sure this was intended.')
+                        if log_dataset_details:
+                            discrepancies = list(discrepancies)
+                            discrepancies.sort()
+                            logger.warning(f'For the following UIDs among {where} data, {present} is present and {absent} is missing: ' + ', '.join(discrepancies))
+
+                left  = [u for u in uids if u.endswith('_left') ]
+                right = [u for u in uids if u.endswith('_right')]
+                left_not_right = set(left).difference(set(right))
+                right_not_left = set(right).difference(set(left))
+                _report(left_not_right, '_left', '_right', where, logger, log_dataset_details)
+                _report(right_not_left, '_right', '_left', where, logger, log_dataset_details)
+
+            _log_neither_left_nor_right(uids, where, logger, log_dataset_details)
+            _log_one_side_only(uids, where, logger, log_dataset_details)
+
+
         config = 'unilateral'
         path_root = Path(cls.PATH_ROOT if path_root is None else path_root)
         meta_dir = cls.META_DIR[config]
@@ -242,6 +271,10 @@ class ODELIA_Dataset3D(data.Dataset):
             _log_differences(uids_in_split[None], uids_in_images,'split', 'images', logger, log_dataset_details)
             _log_differences(uids_in_annotation, uids_in_images, 'annotation', 'images', logger, log_dataset_details)
 
-            _log_intersection(uids_in_split['train'], uids_in_split['val'], 'training', 'validation', logger, log_dataset_details)
-            _log_intersection(uids_in_split['train'], uids_in_split['test'], 'training', 'test', logger, log_dataset_details)
-            _log_intersection(uids_in_split['val'], uids_in_split['test'], 'validation', 'test', logger, log_dataset_details)
+            _log_intersection(uids_in_split['train'], uids_in_split['val'],  'training',   'validation', logger, log_dataset_details)
+            _log_intersection(uids_in_split['train'], uids_in_split['test'], 'training',   'test',       logger, log_dataset_details)
+            _log_intersection(uids_in_split['val'],   uids_in_split['test'], 'validation', 'test',       logger, log_dataset_details)
+
+            _log_left_right_discrepancies(uids_in_split['train'], 'training',   logger, log_dataset_details)
+            _log_left_right_discrepancies(uids_in_split['val'],   'validation', logger, log_dataset_details)
+            _log_left_right_discrepancies(uids_in_split['test'],  'test',       logger, log_dataset_details)

--- a/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
+++ b/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
@@ -222,7 +222,7 @@ class ODELIA_Dataset3D(data.Dataset):
                     logger.error(f'UIDs among {where} data present that do not end in _left or _right, this should not happen.')
                     if log_dataset_details:
                         neither_left_right.sort()
-                        logger.error('The following UIDs among {where} data do not end in _left or _right: ' + ', '.join(neither_left_nor_right))
+                        logger.error(f'The following UIDs among {where} data do not end in _left or _right: ' + ', '.join(neither_left_right))
 
             def _log_one_side_only(uids: List[str], where: str, logger, log_dataset_details) -> None:
                 def _report(discrepancies: List[str], present: str, absent: str, where: str, logger, log_dataset_details) -> None:

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -128,7 +128,7 @@ def log_data_hash(dm: DataModule, logger, log_dataset_details: bool = False) -> 
 
                         for hsh, uids in uids_for_hash.items():
                             if uids:
-                                message += f'Image data with hash {hsh} appears {count} times: ' + ', '.join(uids) + '\n'
+                                message += f'Image data with hash {hsh} appears {len(uids)} times: ' + ', '.join(uids) + '\n'
                     logger.info(message)
 
         _check_separately_for_duplicates(uids_with_hashes_train, where, 'training', log_dataset_details)

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -129,7 +129,7 @@ def log_data_hash(dm: DataModule, logger, log_dataset_details: bool = False) -> 
                         for hsh, uids in uids_for_hash.items():
                             if uids:
                                 message += f'Image data with hash {hsh} appears {len(uids)} times: ' + ', '.join(uids) + '\n'
-                    logger.info(message)
+                    logger.warning(message)
 
         _check_separately_for_duplicates(uids_with_hashes_train, where, 'training', log_dataset_details)
         _check_separately_for_duplicates(uids_with_hashes_valid, where, 'validation', log_dataset_details)

--- a/assets/readme/README.participant.md
+++ b/assets/readme/README.participant.md
@@ -105,12 +105,14 @@ The dataset must be in the following format.
       ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --job challenge_5pimed
       ```
     * Available jobs: `ODELIA_ternary_classification` (default), `challenge_1DivideAndConquer`, `challenge_2BCN_AIM`, `challenge_3agaldran`, `challenge_4abmil`, `challenge_5pimed`
-5. Check your local dataset for discrepancies.
+5. Check your local dataset for discrepancies between expected data and data actually found for training.
    * Check `preflight_check_console_output.txt` for errors and warnings about the dataset.
+       * Generally, errors indicate that something is wrong, whereas warnings may indicate properties that may or may not be intended in your dataset.
        * There should be no duplicate UIDs.
        * If there are discrepancies between UIDs listed in `split.csv` and `annotation.csv` and the image files present, make sure this is intended and not an error.
        * There should be no UIDs present in more than one split (training, validation, test).
-       * If duplicate image data is reported, make sure this is intended and not a mix-up of patients, failure in preprocessing etc.
+       * There should be no duplicate image data.
+       * If there are discrepancies between left and right images present, make sure this is intended for your dataset and not an error.
    * You can run
        ```bash
        ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --log_dataset_details

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -326,7 +326,8 @@ run_data_access_preflight_check () {
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩test detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
        grep -q  "WARNING:threedcnn_ptl:UIDs with among training data _left present and _right missing detected, make sure this was intended." "$CONSOLE_OUTPUT" && \
-       grep -q  "ERROR:threedcnn_ptl:UIDs among training data present that do not end in _left or _right, this should not happen." "$CONSOLE_OUTPUT" ;
+       grep -q  "ERROR:threedcnn_ptl:UIDs among training data present that do not end in _left or _right, this should not happen." "$CONSOLE_OUTPUT" && \
+       grep -q  "ERROR:threedcnn_ptl:UIDs for the same exam found in training and validation, this should not happen." "$CONSOLE_OUTPUT" ;
     then
         echo "✅ Expected output (including expected warnings and errors) of data access preflight check found"
     else
@@ -367,7 +368,8 @@ run_data_access_preflight_check_log_details () {
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩test: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
        grep -q  "WARNING:threedcnn_ptl:For the following UIDs among training data, _left is present and _right is missing: ID_000_left" "$CONSOLE_OUTPUT" &&
-       grep -q  "ERROR:threedcnn_ptl:The following UIDs among training data do not end in _left or _right: SomeUID_both" "$CONSOLE_OUTPUT" ;
+       grep -q  "ERROR:threedcnn_ptl:The following UIDs among training data do not end in _left or _right: SomeUID_both" "$CONSOLE_OUTPUT" &&
+       grep -q  "ERROR:threedcnn_ptl:The following exams are present in training and validation: ID_000," "$CONSOLE_OUTPUT" ;
     then
         echo "✅ Expected output (including expected warnings and errors) of data access preflight check found"
     else

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -306,7 +306,7 @@ run_data_access_preflight_check () {
     # also check that it finishes the single round within one minute
     timeout --signal=kill 1m ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --preflight_check --no_pull 2>&1 | tee $CONSOLE_OUTPUT
 
-    if grep -q  "Train set: 18, Val set: 6" "$CONSOLE_OUTPUT" && \
+    if grep -q  "Train set: 19, Val set: 6" "$CONSOLE_OUTPUT" && \
        grep -q  "Epoch 0: 100%" "$CONSOLE_OUTPUT" && \
        grep -q  "INFO:threedcnn_ptl:Run directory" "$CONSOLE_OUTPUT" && \
        grep -q  "INFO:threedcnn_ptl:Run name" "$CONSOLE_OUTPUT" && \
@@ -325,7 +325,8 @@ run_data_access_preflight_check () {
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩validation detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩test detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
-       grep -q  "WARNING:threedcnn_ptl:UIDs with among training data _left present and _right missing detected, make sure this was intended." "$CONSOLE_OUTPUT" ;
+       grep -q  "WARNING:threedcnn_ptl:UIDs with among training data _left present and _right missing detected, make sure this was intended." "$CONSOLE_OUTPUT" && \
+       grep -q  "ERROR:threedcnn_ptl:UIDs among training data present that do not end in _left or _right, this should not happen." "$CONSOLE_OUTPUT" ;
     then
         echo "✅ Expected output (including expected warnings and errors) of data access preflight check found"
     else
@@ -365,7 +366,8 @@ run_data_access_preflight_check_log_details () {
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩validation: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩test: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
-       grep -q  "WARNING:threedcnn_ptl:For the following UIDs among training data, _left is present and _right is missing: ID_000_left" "$CONSOLE_OUTPUT" ;
+       grep -q  "WARNING:threedcnn_ptl:For the following UIDs among training data, _left is present and _right is missing: ID_000_left" "$CONSOLE_OUTPUT" &&
+       grep -q  "ERROR:threedcnn_ptl:The following UIDs among training data do not end in _left or _right: SomeUID_both" "$CONSOLE_OUTPUT" ;
     then
         echo "✅ Expected output (including expected warnings and errors) of data access preflight check found"
     else

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -324,7 +324,9 @@ run_data_access_preflight_check () {
        grep -q  "WARNING:threedcnn_ptl:UIDs in images but not in annotation detected, make sure this was intended." "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩validation detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩test detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
-       grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test detected, they should be in one set only." "$CONSOLE_OUTPUT" ; then
+       grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test detected, they should be in one set only." "$CONSOLE_OUTPUT" && \
+       grep -q  "WARNING:threedcnn_ptl:UIDs with among training data _left present and _right missing detected, make sure this was intended." "$CONSOLE_OUTPUT" ;
+    then
         echo "✅ Expected output (including expected warnings and errors) of data access preflight check found"
     else
         echo "❌ Missing expected output of data access preflight check"
@@ -362,7 +364,9 @@ run_data_access_preflight_check_log_details () {
        grep -qx "WARNING:threedcnn_ptl:Difference images.annotation: ID_014_left, ID_014_right" "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩validation: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
        grep -q  "ERROR:threedcnn_ptl:Entries in training∩test: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
-       grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" ; then
+       grep -q  "ERROR:threedcnn_ptl:Entries in validation∩test: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
+       grep -q  "WARNING:threedcnn_ptl:For the following UIDs among training data, _left is present and _right is missing: ID_000_left" "$CONSOLE_OUTPUT" ;
+    then
         echo "✅ Expected output (including expected warnings and errors) of data access preflight check found"
     else
         echo "❌ Missing expected output of data access preflight check"


### PR DESCRIPTION
Extend the plausibility check by 
- reporting discrepancies between left and right images, to be compared against expectation for respective dataset
- checking that left and right images (if present) are in the same split

Also,
- fix incorrectly printed count of duplicate image data
- speed up generating the synthetic dataset