### PR TITLE
Bump version to 1.4.3

### DIFF
--- a/odelia_image.version
+++ b/odelia_image.version
@@ -1,2 +1,2 @@
 # version of the ODELIA Docker image, read by different scripts
-1.4.2
+1.4.3


### PR DESCRIPTION
Bumps `odelia_image.version` from 1.4.2 → 1.4.3.

v1.4.2 shipped with all 6 ODELIA challenge models passing the 2-node swarm deploy test (PR #299).

🤖 Generated with [Claude Code](https://claude.com/claude-code)