### PR TITLE
Optimize ODELIA preflight data path for large datasets

### DIFF
--- a/application/jobs/_shared/custom/data/datamodules/datamodule.py
+++ b/application/jobs/_shared/custom/data/datamodules/datamodule.py
@@ -1,8 +1,25 @@
+import os
+
 import pytorch_lightning as pl
 import torch
-from torch.utils.data.dataloader import DataLoader
 import torch.multiprocessing as mp
+from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.sampler import WeightedRandomSampler, RandomSampler
+
+
+def _configure_odelia_worker_runtime(_worker_id: int) -> None:
+    thread_count = max(1, int(os.environ.get("ODELIA_THREADS_PER_WORKER", "1")))
+    interop_threads = max(1, int(os.environ.get("ODELIA_INTEROP_THREADS", "1")))
+
+    for env_name in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
+        os.environ[env_name] = str(thread_count)
+
+    torch.set_num_threads(thread_count)
+    if hasattr(torch, "set_num_interop_threads"):
+        try:
+            torch.set_num_interop_threads(interop_threads)
+        except RuntimeError:
+            pass
 
 
 class DataModule(pl.LightningDataModule):
@@ -39,8 +56,14 @@ class DataModule(pl.LightningDataModule):
         self.seed = seed
         self.pin_memory = pin_memory
         self.weights = weights
+        self._train_loader = None
+        self._val_loader = None
+        self._test_loader = None
 
     def train_dataloader(self):
+        if self._train_loader is not None:
+            return self._train_loader
+
         generator = torch.Generator()
         generator.manual_seed(self.seed)
 
@@ -52,48 +75,63 @@ class DataModule(pl.LightningDataModule):
                 num_samples = len(self.ds_train) if self.num_train_samples is None else self.num_train_samples
                 sampler = RandomSampler(self.ds_train, num_samples=num_samples, replacement=False, generator=generator)
 
-            return DataLoader(
+            self._train_loader = DataLoader(
                 self.ds_train,
                 batch_size=self.batch_size,
                 num_workers=self.num_workers,
                 sampler=sampler,
                 generator=generator,
                 drop_last=True,
-                pin_memory=self.pin_memory
+                pin_memory=self.pin_memory,
+                persistent_workers=self.num_workers > 0,
+                worker_init_fn=_configure_odelia_worker_runtime if self.num_workers > 0 else None,
             )
+            return self._train_loader
 
         raise AssertionError("A training set was not initialized.")
 
     def val_dataloader(self):
+        if self._val_loader is not None:
+            return self._val_loader
+
         generator = torch.Generator()
         generator.manual_seed(self.seed)
 
         if self.ds_val is not None:
-            return DataLoader(
+            self._val_loader = DataLoader(
                 self.ds_val,
                 batch_size=self.batch_size_val,
                 num_workers=self.num_workers,
                 shuffle=False,
                 generator=generator,
                 drop_last=False,
-                pin_memory=self.pin_memory
+                pin_memory=self.pin_memory,
+                persistent_workers=self.num_workers > 0,
+                worker_init_fn=_configure_odelia_worker_runtime if self.num_workers > 0 else None,
             )
+            return self._val_loader
 
         raise AssertionError("A validation set was not initialized.")
 
     def test_dataloader(self):
+        if self._test_loader is not None:
+            return self._test_loader
+
         generator = torch.Generator()
         generator.manual_seed(self.seed)
 
         if self.ds_test is not None:
-            return DataLoader(
+            self._test_loader = DataLoader(
                 self.ds_test,
                 batch_size=self.batch_size_test,
                 num_workers=self.num_workers,
                 shuffle=False,
                 generator=generator,
                 drop_last=False,
-                pin_memory=self.pin_memory
+                pin_memory=self.pin_memory,
+                persistent_workers=self.num_workers > 0,
+                worker_init_fn=_configure_odelia_worker_runtime if self.num_workers > 0 else None,
             )
+            return self._test_loader
 
         raise AssertionError("A test set was not initialized.")

--- a/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
+++ b/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
@@ -1,12 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
 import pandas as pd
+import torch
 import torch.utils.data as data
 import torchio as tio
-import torch
-import numpy as np
-from typing import List, Dict, Tuple, Any
 
 from data.augmentation.augmentations_3d import ImageOrSubjectToTensor, ZNormalization, CropOrPad
+
+
+@dataclass
+class ODELIAInstitutionManifest:
+    institution: str
+    path_root: Path
+    config: str
+    data_dir: str
+    meta_dir: str
+    annotation_df: pd.DataFrame
+    split_df: pd.DataFrame
+    image_uids: List[str]
+    image_uids_set: set[str] = field(init=False)
+    _uids_in_annotation: List[str] = field(init=False, repr=False)
+    _uids_in_images: List[str] = field(init=False, repr=False)
+    _uids_in_split_cache: Dict[Tuple[int, str | None], List[str]] = field(default_factory=dict, repr=False)
+    _dataframe_cache: Dict[Tuple[int, str | None], pd.DataFrame] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self):
+        self.image_uids_set = set(self.image_uids)
+        self._uids_in_annotation = sorted(self.annotation_df['UID'].tolist())
+        self._uids_in_images = sorted(self.image_uids)
+
+    @property
+    def path_metadata(self) -> Path:
+        return self.path_root / self.institution / self.meta_dir
+
+    @property
+    def path_data_root(self) -> Path:
+        return self.path_root / self.institution / self.data_dir
+
+    def dataframe(self, fold: int = 0, split: str | None = None, fraction=None) -> pd.DataFrame:
+        cache_key = (fold, split)
+        if cache_key not in self._dataframe_cache:
+            df_split = self.split_df[self.split_df['Fold'] == fold]
+            if split is not None:
+                df_split = df_split[df_split['Split'] == split]
+            merged = df_split.merge(self.annotation_df, on='UID', how='inner')
+            merged = merged[merged['UID'].isin(self.image_uids_set)].copy()
+            merged['Institution'] = self.institution
+            self._dataframe_cache[cache_key] = merged.reset_index(drop=True)
+
+        df = self._dataframe_cache[cache_key]
+        if fraction is not None:
+            return df.sample(frac=fraction, random_state=0).reset_index(drop=True)
+        return df.copy()
+
+    def uids_in_annotation(self) -> List[str]:
+        return list(self._uids_in_annotation)
+
+    def uids_in_images(self) -> List[str]:
+        return list(self._uids_in_images)
+
+    def uids_in_split(self, fold: int = 0, split: str | None = None) -> List[str]:
+        cache_key = (fold, split)
+        if cache_key not in self._uids_in_split_cache:
+            df_split = self.split_df[self.split_df['Fold'] == fold]
+            if split is not None:
+                df_split = df_split[df_split['Split'] == split]
+            self._uids_in_split_cache[cache_key] = sorted(df_split['UID'].tolist())
+        return list(self._uids_in_split_cache[cache_key])
+
+    def image_path(self, uid: str, filename: str = 'Sub_1.nii.gz') -> Path:
+        return self.path_data_root / uid / filename
+
+
+class ODELIAStaticVolumeCache:
+    """Optional scratch-side cache for decoded ODELIA NIfTI volumes."""
+
+    def __init__(self, cache_root: str | Path, config: str, version: str = "v1"):
+        self.cache_root = Path(cache_root)
+        self.config = config
+        self.version = version
+
+    def load_or_create(self, institution: str, uid: str, path_img: Path, loader) -> tio.ScalarImage:
+        cached = self._load_cached_image(institution, uid, path_img)
+        if cached is not None:
+            return cached
+
+        image = loader(path_img)
+        data = image.data.detach().cpu().numpy()
+        affine = np.asarray(image.affine, dtype=np.float32)
+        self._save_cached_image(institution, uid, path_img, data, affine)
+        return image
+
+    def _cache_paths(self, institution: str, uid: str) -> Tuple[Path, Path]:
+        cache_dir = self.cache_root / self.config / institution
+        data_path = cache_dir / f"{uid}.npz"
+        meta_path = cache_dir / f"{uid}.json"
+        return data_path, meta_path
+
+    def _signature(self, path_img: Path) -> Dict[str, str | int]:
+        stat = path_img.stat()
+        return {
+            "source_path": str(path_img.resolve()),
+            "source_size": int(stat.st_size),
+            "source_mtime_ns": int(stat.st_mtime_ns),
+            "cache_version": self.version,
+        }
+
+    def _load_cached_image(self, institution: str, uid: str, path_img: Path) -> tio.ScalarImage | None:
+        data_path, meta_path = self._cache_paths(institution, uid)
+        if not data_path.exists() or not meta_path.exists():
+            return None
+
+        try:
+            with open(meta_path, 'r', encoding='utf-8') as f:
+                metadata = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+        if metadata != self._signature(path_img):
+            return None
+
+        try:
+            with np.load(data_path, allow_pickle=False) as arrays:
+                data = arrays['data']
+                affine = arrays['affine']
+        except (OSError, KeyError, ValueError):
+            return None
+
+        tensor = torch.as_tensor(data, dtype=torch.float32)
+        if tensor.ndim == 3:
+            tensor = tensor.unsqueeze(0)
+        return tio.ScalarImage(tensor=tensor, affine=np.asarray(affine, dtype=np.float32))
+
+    def _save_cached_image(self, institution: str, uid: str, path_img: Path, data: np.ndarray, affine: np.ndarray) -> None:
+        data_path, meta_path = self._cache_paths(institution, uid)
+        data_path.parent.mkdir(parents=True, exist_ok=True)
+        signature = self._signature(path_img)
+
+        fd, tmp_npz = tempfile.mkstemp(prefix=f"{uid}_", suffix=".npz", dir=str(data_path.parent))
+        os.close(fd)
+        tmp_npz_path = Path(tmp_npz)
+        tmp_meta_path = tmp_npz_path.with_suffix('.json')
+
+        try:
+            np.savez_compressed(tmp_npz_path, data=np.asarray(data, dtype=np.float32), affine=np.asarray(affine, dtype=np.float32))
+            with open(tmp_meta_path, 'w', encoding='utf-8') as f:
+                json.dump(signature, f, sort_keys=True)
+            os.replace(tmp_npz_path, data_path)
+            os.replace(tmp_meta_path, meta_path)
+        finally:
+            if tmp_npz_path.exists():
+                tmp_npz_path.unlink(missing_ok=True)
+            if tmp_meta_path.exists():
+                tmp_meta_path.unlink(missing_ok=True)
 
 
 class ODELIA_Dataset3D(data.Dataset):
@@ -35,8 +189,8 @@ class ODELIA_Dataset3D(data.Dataset):
             path_root=None,
             institutions=None,
             fold=0,
-            labels=None,  # None = all labels or  list of labels
-            config=None,  # original, unilateral
+            labels=None,
+            config=None,
             split=None,
             fraction=None,
             transform=None,
@@ -45,6 +199,10 @@ class ODELIA_Dataset3D(data.Dataset):
             random_inverse=False,
             noise=False,
             to_tensor=True,
+            manifests: Dict[str, ODELIAInstitutionManifest] | None = None,
+            enable_preprocess_cache: bool = False,
+            preprocess_cache_dir: str | Path | None = None,
+            preprocess_cache_version: str = "v1",
 
     ):
         self.path_root = Path(self.PATH_ROOT if path_root is None else path_root)
@@ -54,75 +212,125 @@ class ODELIA_Dataset3D(data.Dataset):
         self.meta_dir = self.META_DIR[config]
         self.data_dir = self.DATA_DIR[config]
         self.labels = list(self.class_labels.keys()) if labels is None else labels
-        self.class_labels_num = [len(self.class_labels[l]) for l in self.labels]  # For CORN Loss -1
+        self.class_labels_num = [len(self.class_labels[l]) for l in self.labels]
+        self.institutions = self._normalize_institutions(institutions)
 
-        if (institutions is None) or (institutions == "ODELIA"):
-            institutions = self.ALL_INSTITUTIONS
-        elif isinstance(institutions, str):
-            institutions = [institutions]
-        self.institutions = institutions
+        if manifests is None:
+            manifests = self.build_manifests(
+                path_root=self.path_root,
+                institutions=self.institutions,
+                config=config,
+            )
+        self.manifests = manifests
 
-        flip_axes = (0, 1) if config == "original" else (0, 1, 2)  # Do not flip horizontal axis 2, otherwise labels incorrect
         if transform is None:
+            flip_axes = (0, 1) if config == "original" else (0, 1, 2)
+            identity = tio.Lambda(lambda x: x)
             self.transform = tio.Compose([
-                tio.ToCanonical() if config == "original" else tio.Lambda(lambda x: x),
-                tio.Resample((0.7, 0.7, 3)) if config == "original" else tio.Lambda(lambda x: x),
-
-                tio.Flip((1, 0)),  # Just for viewing, otherwise upside down
+                tio.ToCanonical() if config == "original" else identity,
+                tio.Resample((0.7, 0.7, 3)) if config == "original" else identity,
+                tio.Flip((1, 0)),
                 CropOrPad((448, 448, 32), random_center=random_rotate) if config == "original" else CropOrPad(
                     (224, 224, 32), random_center=random_rotate),
-
-                ZNormalization(per_channel=True, per_slice=False,
-                               masking_method=lambda x: (x > x.min()) & (x < x.max()), percentiles=(0.5, 99.5)),
-
+                ZNormalization(
+                    per_channel=True,
+                    per_slice=False,
+                    masking_method=lambda x: (x > x.min()) & (x < x.max()),
+                    percentiles=(0.5, 99.5),
+                ),
                 tio.OneOf([
-                    # tio.Lambda(lambda x: x.moveaxis(1, 2) if torch.rand((1,),)[0]<0.5 else x ) if random_rotate else tio.Lambda(lambda x: x), # WARNING: 1,2 if Subject, 2, 3 if tensor
-                    tio.RandomAffine(scales=0, degrees=(0, 0, 0, 0, 0, 90), translation=0, isotropic=True,
-                                     default_pad_value='minimum') if random_rotate else tio.Lambda(lambda x: x),
-                    tio.RandomFlip(flip_axes) if random_flip else tio.Lambda(lambda x: x),  # WARNING: Padding mask
+                    tio.RandomAffine(
+                        scales=0,
+                        degrees=(0, 0, 0, 0, 0, 90),
+                        translation=0,
+                        isotropic=True,
+                        default_pad_value='minimum',
+                    ) if random_rotate else identity,
+                    tio.RandomFlip(flip_axes) if random_flip else identity,
                 ]),
-                tio.Lambda(lambda x: -x if torch.rand((1,), )[0] < 0.5 else x,
-                           types_to_apply=[tio.INTENSITY]) if random_inverse else tio.Lambda(lambda x: x),
-                tio.RandomNoise(std=(0.0, 0.25)) if noise else tio.Lambda(lambda x: x),
-
-                ImageOrSubjectToTensor() if to_tensor else tio.Lambda(lambda x: x)
+                tio.Lambda(
+                    lambda x: -x if torch.rand((1,))[0] < 0.5 else x,
+                    types_to_apply=[tio.INTENSITY],
+                ) if random_inverse else identity,
+                tio.RandomNoise(std=(0.0, 0.25)) if noise else identity,
+                ImageOrSubjectToTensor() if to_tensor else identity
             ])
-
         elif transform == 'USE_UNPROCESSED_IMAGES':
             self.transform = tio.Compose([tio.Lambda(lambda x: x)])
-
+            enable_preprocess_cache = False
         else:
             self.transform = transform
+            enable_preprocess_cache = False
 
-        # Get split
+        if enable_preprocess_cache and preprocess_cache_dir:
+            self.preprocess_cache = ODELIAStaticVolumeCache(
+                cache_root=preprocess_cache_dir,
+                config=config,
+                version=preprocess_cache_version,
+            )
+        else:
+            self.preprocess_cache = None
+
         dfs = []
         for institution in self.institutions:
-            path_metadata = self.path_root / institution / self.meta_dir
-
-            df_split = self.load_split(path_metadata / 'split.csv', fold=fold, split=split, fraction=fraction)
-            df_split['Institution'] = institution
-
-            df_annot = pd.read_csv(path_metadata / 'annotation.csv', dtype={'UID': str, 'PatientID': str})
-
-            df = df_split.merge(df_annot, on='UID', how='inner')  # uses only UIDs present in both dataframes
-
-            uids_in_imags = self.run_item_crawler(self.path_root/institution/self.DATA_DIR[config])
-            df = df[df['UID'].isin(uids_in_imags)]  # limit to UIDs for which an image is present
-
-            dfs.append(df)
-        df = pd.concat(dfs).reset_index(drop=True)
-
-        self.item_pointers = df.index.tolist()
-        self.df = df
+            manifest = self.manifests[institution]
+            dfs.append(manifest.dataframe(fold=fold, split=split, fraction=fraction))
+        self.df = pd.concat(dfs).reset_index(drop=True)
+        self.item_pointers = self.df.index.tolist()
 
     def __len__(self):
         return len(self.item_pointers)
+
+    @classmethod
+    def _normalize_institutions(cls, institutions) -> List[str]:
+        if (institutions is None) or (institutions == "ODELIA"):
+            return list(cls.ALL_INSTITUTIONS)
+        if isinstance(institutions, str):
+            return [institutions]
+        return list(institutions)
+
+    @classmethod
+    def build_manifests(cls, path_root=None, institutions=None, config='unilateral') -> Dict[str, ODELIAInstitutionManifest]:
+        path_root = Path(cls.PATH_ROOT if path_root is None else path_root)
+        normalized_institutions = cls._normalize_institutions(institutions)
+        manifests: Dict[str, ODELIAInstitutionManifest] = {}
+
+        for institution in normalized_institutions:
+            path_metadata = path_root / institution / cls.META_DIR[config]
+            annotation_df = pd.read_csv(path_metadata / 'annotation.csv', dtype={'UID': str, 'PatientID': str})
+            split_df = pd.read_csv(path_metadata / 'split.csv', dtype={'UID': str})
+            image_uids = cls.run_item_crawler(path_root / institution / cls.DATA_DIR[config])
+            manifests[institution] = ODELIAInstitutionManifest(
+                institution=institution,
+                path_root=path_root,
+                config=config,
+                data_dir=cls.DATA_DIR[config],
+                meta_dir=cls.META_DIR[config],
+                annotation_df=annotation_df,
+                split_df=split_df,
+                image_uids=image_uids,
+            )
+
+        return manifests
 
     def load_img(self, path_img):
         return tio.ScalarImage(path_img)
 
     def load_map(self, path_img):
         return tio.LabelMap(path_img)
+
+    def get_image_path(self, uid: str, institution: str) -> Path:
+        return self.manifests[institution].image_path(uid)
+
+    def _load_source_image(self, path_img: Path, institution: str, uid: str):
+        if self.preprocess_cache is None:
+            return self.load_img(path_img)
+        return self.preprocess_cache.load_or_create(
+            institution=institution,
+            uid=uid,
+            path_img=path_img,
+            loader=self.load_img,
+        )
 
     def __getitem__(self, index):
         idx = self.item_pointers[index]
@@ -131,76 +339,52 @@ class ODELIA_Dataset3D(data.Dataset):
         institution = item['Institution']
 
         target = np.stack(item[self.labels].values)
-
-        path_folder = self.path_root / institution / self.data_dir / uid
-        # img = self.load_img([path_folder/f'{name}.nii.gz' for name in [ 'Pre', 'Sub_1', 'T2']])
-        img = self.load_img(path_folder / 'Sub_1.nii.gz')
-        # img = self.load_img([path_folder/f'{name}.nii.gz' for name in [ 'Pre', 'Post_1', 'Sub_1']])
+        path_img = self.get_image_path(uid, institution)
+        img = self._load_source_image(path_img, institution, uid)
         img = self.transform(img)
 
         return {'uid': uid, 'source': img, 'target': target}
 
     @classmethod
     def load_split(cls, filepath_or_buffer=None, fold=0, split=None, fraction=None):
-        # WARNING: PatientID must be read as string otherwise leading zeros are cut off
         df = pd.read_csv(filepath_or_buffer, dtype={'UID': str})
         df = df[df['Fold'] == fold]
         if split is not None:
             df = df[df['Split'] == split]
         if fraction is not None:
-            df = df.sample(frac=fraction, random_state=0).reset_index()
+            df = df.sample(frac=fraction, random_state=0).reset_index(drop=True)
         return df
 
     @classmethod
     def run_item_crawler(cls, path_root, **kwargs):
-        return [path.relative_to(path_root).name for path in Path(path_root).iterdir() if path.is_dir()]
+        with os.scandir(path_root) as entries:
+            return sorted(entry.name for entry in entries if entry.is_dir())
 
     @classmethod
-    def log_UID_discrepancies(cls,
-                              logger,
-                              path_root=None,
-                              institutions=None,
-                              fold=0,
-                              log_dataset_details=False) -> None:
-
-        def _get_uids_in_annotation(path_metadata: Path):
-            df_annotation = pd.read_csv(path_metadata / 'annotation.csv', dtype={'UID': str, 'PatientID': str})
-            uids_in_annotation = list(df_annotation['UID'])
-            uids_in_annotation.sort()
-            return uids_in_annotation
-
-        def _get_uids_in_split(path_metadata: Path, fold) -> Dict[str|None, List[str]]:
-            df_split = {split: cls.load_split(path_metadata / 'split.csv', fold=fold, split=split, fraction=None) for split in (None, 'train', 'val', 'test')}
-            uids_split = {s: list(df_split[s]['UID']) for s in df_split.keys()}
-            for l in uids_split.values():
-                l.sort()
-            return uids_split
-
-        def _get_uids_of_images_present(path_root: Path, config) -> List[str]:
-            uids_in_images = cls.run_item_crawler(path_root / institution / cls.DATA_DIR[config])
-            uids_in_images.sort()
-            return uids_in_images
-
-        def _get_uids(path_metadata: Path, path_root: Path, config) -> Tuple[List[str], Dict[str|None, List[str]], List[str]]:
-            return _get_uids_in_annotation(path_metadata), _get_uids_in_split(path_metadata, fold), _get_uids_of_images_present(path_root, config)
+    def log_UID_discrepancies(
+            cls,
+            logger,
+            path_root=None,
+            institutions=None,
+            fold=0,
+            log_dataset_details=False,
+            manifests: Dict[str, ODELIAInstitutionManifest] | None = None) -> None:
 
         def _log_duplicates(uids: List[str], where: str, logger, log_dataset_details) -> None:
             if len(uids) != len(set(uids)):
                 logger.error(f'Duplicates among {where} UIDs detected, they should be unique')
                 if log_dataset_details:
-                    for u in set(uids):
-                        count = uids.count(u)
+                    for uid in set(uids):
+                        count = uids.count(uid)
                         if count > 1:
-                            logger.error(f'{u} appears {count} times')
+                            logger.error(f'{uid} appears {count} times')
 
         def _log_difference(uids_a: List[str], uids_b: List[str], where_a: str, where_b: str, logger, log_dataset_details) -> None:
             difference = set(uids_a).difference(set(uids_b))
             if difference:
                 logger.warning(f'UIDs in {where_a} but not in {where_b} detected, make sure this was intended.')
                 if log_dataset_details:
-                    difference = list(difference)
-                    difference.sort()
-                    logger.warning(f'Difference {where_a}\\{where_b}: ' + ', '.join(difference))
+                    logger.warning(f'Difference {where_a}\\{where_b}: ' + ', '.join(sorted(difference)))
 
         def _log_differences(uids_a: List[str], uids_b: List[str], where_a: str, where_b: str, logger, log_dataset_details) -> None:
             _log_difference(uids_a, uids_b, where_a, where_b, logger, log_dataset_details)
@@ -211,16 +395,21 @@ class ODELIA_Dataset3D(data.Dataset):
             if intersection:
                 logger.error(f'Entries in {where_a}∩{where_b} detected, they should be in one set only.')
                 if log_dataset_details:
-                    intersection = list(intersection)
-                    intersection.sort()
-                    logger.error(f'Entries in {where_a}∩{where_b}: ' + ', '.join(intersection))
+                    logger.error(f'Entries in {where_a}∩{where_b}: ' + ', '.join(sorted(intersection)))
 
         config = 'unilateral'
-        path_root = Path(cls.PATH_ROOT if path_root is None else path_root)
-        meta_dir = cls.META_DIR[config]
-        for institution in institutions:
-            path_metadata = path_root / institution / meta_dir
-            uids_in_annotation, uids_in_split, uids_in_images = _get_uids(path_metadata, path_root, config)
+        normalized_institutions = cls._normalize_institutions(institutions)
+        if manifests is None:
+            manifests = cls.build_manifests(path_root=path_root, institutions=normalized_institutions, config=config)
+
+        for institution in normalized_institutions:
+            manifest = manifests[institution]
+            uids_in_annotation = manifest.uids_in_annotation()
+            uids_in_split = {
+                split_name: manifest.uids_in_split(fold=fold, split=split_name)
+                for split_name in (None, 'train', 'val', 'test')
+            }
+            uids_in_images = manifest.uids_in_images()
 
             if log_dataset_details:
                 logger.info('Annoation UIDs: ' + ' '.join(uids_in_annotation))
@@ -230,16 +419,18 @@ class ODELIA_Dataset3D(data.Dataset):
                 logger.info('Test UIDs: ' + ' '.join(uids_in_split['test']))
                 logger.info('Image UIDs ' + ' '.join(uids_in_images))
 
-            for uids, where in ((uids_in_annotation, 'annotation'),
-                                (uids_in_split[None], 'all split'),
-                                (uids_in_split['train'], 'training'),
-                                (uids_in_split['val'], 'validation'),
-                                (uids_in_split['test'], 'test'),
-                                (uids_in_images, 'image'),) :
+            for uids, where in (
+                    (uids_in_annotation, 'annotation'),
+                    (uids_in_split[None], 'all split'),
+                    (uids_in_split['train'], 'training'),
+                    (uids_in_split['val'], 'validation'),
+                    (uids_in_split['test'], 'test'),
+                    (uids_in_images, 'image'),
+            ):
                 _log_duplicates(uids, where, logger, log_dataset_details)
 
             _log_differences(uids_in_annotation, uids_in_split[None], 'annotation', 'split', logger, log_dataset_details)
-            _log_differences(uids_in_split[None], uids_in_images,'split', 'images', logger, log_dataset_details)
+            _log_differences(uids_in_split[None], uids_in_images, 'split', 'images', logger, log_dataset_details)
             _log_differences(uids_in_annotation, uids_in_images, 'annotation', 'images', logger, log_dataset_details)
 
             _log_intersection(uids_in_split['train'], uids_in_split['val'], 'training', 'validation', logger, log_dataset_details)

--- a/application/jobs/_shared/custom/env_config.py
+++ b/application/jobs/_shared/custom/env_config.py
@@ -1,23 +1,50 @@
 import os
+import torch.multiprocessing as mp
 from datetime import datetime
 from pathlib import Path
+
 from data.datasets import ODELIA_Dataset3D
 
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
 def load_environment_variables():
+    scratch_dir = os.environ['SCRATCH_DIR']
+    default_loader_workers = min(mp.cpu_count(), 8)
+
     return {
         'site_name': os.environ['SITE_NAME'],
         'task_data_name': os.environ.get('DATA_FOLDER', 'Odelia'),
-        'scratch_dir': os.environ['SCRATCH_DIR'],
+        'scratch_dir': scratch_dir,
         'data_dir': os.environ['DATA_DIR'],
         'max_epochs': int(os.environ.get('MAX_EPOCHS', 100)),
         'min_peers': int(os.environ.get('MIN_PEERS', 2)),
         'max_peers': int(os.environ.get('MAX_PEERS', 10)),
-        'local_compare_flag': os.environ.get('LOCAL_COMPARE_FLAG', 'False').lower() == 'true',
-        'use_adaptive_sync': os.environ.get('USE_ADAPTIVE_SYNC', 'False').lower() == 'true',
+        'local_compare_flag': _env_flag('LOCAL_COMPARE_FLAG', default=False),
+        'use_adaptive_sync': _env_flag('USE_ADAPTIVE_SYNC', default=False),
         'sync_frequency': int(os.environ.get('SYNC_FREQUENCY', 1024)),
         'model_name': os.environ.get('MODEL_NAME', 'ResNet101'),
         'prediction_flag': os.environ.get('PREDICT_FLAG', 'ext'),
         'mediswarm_version': os.environ.get('MEDISWARM_VERSION', 'unset'),
+        'odelia_num_workers': int(os.environ.get('ODELIA_NUM_WORKERS', default_loader_workers)),
+        'odelia_hash_num_workers': int(os.environ.get('ODELIA_HASH_NUM_WORKERS', 0)),
+        'odelia_threads_per_worker': int(os.environ.get('ODELIA_THREADS_PER_WORKER', 1)),
+        'odelia_interop_threads': int(os.environ.get('ODELIA_INTEROP_THREADS', 1)),
+        'odelia_hash_cache_dir': os.environ.get(
+            'ODELIA_HASH_CACHE_DIR',
+            str(Path(scratch_dir) / 'odelia_hash_cache')
+        ),
+        'odelia_enable_preprocess_cache': _env_flag('ODELIA_ENABLE_PREPROCESS_CACHE', default=False),
+        'odelia_preprocess_cache_dir': os.environ.get(
+            'ODELIA_PREPROCESS_CACHE_DIR',
+            str(Path(scratch_dir) / 'odelia_preprocess_cache')
+        ),
+        'odelia_preprocess_cache_version': os.environ.get('ODELIA_PREPROCESS_CACHE_VERSION', 'v1'),
     }
 
 
@@ -26,23 +53,78 @@ def load_prediction_modules(prediction_flag):
     return predict, prediction_flag
 
 
-def prepare_odelia_dataset(logger, log_dataset_details: bool = False):
-    # parser removed, now read from environment
-    institution = os.environ.get('INSTITUTION', os.environ['SITE_NAME'])  # TODO think about how this should be handled
-    model = os.environ.get('MODEL_NAME', 'MST')
-    config = os.environ.get('CONFIG', 'unilateral')
+def resolve_odelia_runtime_settings(env_vars=None):
+    if env_vars is None:
+        env_vars = load_environment_variables()
+
+    return {
+        'institution': os.environ.get('INSTITUTION', env_vars['site_name']),
+        'model_name': os.environ.get('MODEL_NAME', env_vars['model_name']),
+        'config': os.environ.get('CONFIG', 'unilateral'),
+        'data_dir': env_vars['data_dir'],
+        'scratch_dir': env_vars['scratch_dir'],
+    }
+
+
+def build_odelia_manifests(env_vars=None):
+    settings = resolve_odelia_runtime_settings(env_vars)
+    return ODELIA_Dataset3D.build_manifests(
+        path_root=settings['data_dir'],
+        institutions=settings['institution'],
+        config=settings['config'],
+    )
+
+
+def prepare_odelia_dataset(logger, log_dataset_details: bool = False, manifests=None, env_vars=None):
+    if env_vars is None:
+        env_vars = load_environment_variables()
+    settings = resolve_odelia_runtime_settings(env_vars)
+    institution = settings['institution']
+    model = settings['model_name']
+    config = settings['config']
+
+    if manifests is None:
+        manifests = build_odelia_manifests(env_vars)
 
     current_time = datetime.now().strftime("%Y_%m_%d_%H%M%S")
     run_name = f'{model}_{config}_{current_time}'
-    path_run_dir = Path(os.environ.get('SCRATCH_DIR')) / 'runs' / institution / run_name
+    path_run_dir = Path(settings['scratch_dir']) / 'runs' / institution / run_name
     path_run_dir.mkdir(parents=True, exist_ok=True)
 
-    ODELIA_Dataset3D.log_UID_discrepancies(logger, institutions=[institution], log_dataset_details=log_dataset_details)
-
-    ds_train = ODELIA_Dataset3D(institutions=institution, split='train', config=config,
-                                random_flip=True, random_rotate=True, random_inverse=False, noise=True)
-    ds_val = ODELIA_Dataset3D(institutions=institution, split='val', config=config)
-    ds_test = ODELIA_Dataset3D(institutions=institution, split='test', config=config)
+    ds_train = ODELIA_Dataset3D(
+        path_root=settings['data_dir'],
+        institutions=institution,
+        split='train',
+        config=config,
+        random_flip=True,
+        random_rotate=True,
+        random_inverse=False,
+        noise=True,
+        manifests=manifests,
+        enable_preprocess_cache=env_vars['odelia_enable_preprocess_cache'] if env_vars else False,
+        preprocess_cache_dir=env_vars['odelia_preprocess_cache_dir'] if env_vars else None,
+        preprocess_cache_version=env_vars['odelia_preprocess_cache_version'] if env_vars else 'v1',
+    )
+    ds_val = ODELIA_Dataset3D(
+        path_root=settings['data_dir'],
+        institutions=institution,
+        split='val',
+        config=config,
+        manifests=manifests,
+        enable_preprocess_cache=env_vars['odelia_enable_preprocess_cache'] if env_vars else False,
+        preprocess_cache_dir=env_vars['odelia_preprocess_cache_dir'] if env_vars else None,
+        preprocess_cache_version=env_vars['odelia_preprocess_cache_version'] if env_vars else 'v1',
+    )
+    ds_test = ODELIA_Dataset3D(
+        path_root=settings['data_dir'],
+        institutions=institution,
+        split='test',
+        config=config,
+        manifests=manifests,
+        enable_preprocess_cache=env_vars['odelia_enable_preprocess_cache'] if env_vars else False,
+        preprocess_cache_dir=env_vars['odelia_preprocess_cache_dir'] if env_vars else None,
+        preprocess_cache_version=env_vars['odelia_preprocess_cache_version'] if env_vars else 'v1',
+    )
 
     print(f"Total samples loaded: {len(ds_train)} (train) + {len(ds_val)} (val)")
     print(f"Train set: {len(ds_train)}, Val set: {len(ds_val)}")
@@ -50,13 +132,40 @@ def prepare_odelia_dataset(logger, log_dataset_details: bool = False):
     return ds_train, ds_val, ds_test, path_run_dir, run_name
 
 
-def prepare_odelia_dataset_without_augmentation():
-    institution = os.environ.get('INSTITUTION', os.environ['SITE_NAME'])
-    config = os.environ.get('CONFIG', 'unilateral')
+def prepare_odelia_dataset_without_augmentation(manifests=None, env_vars=None):
+    if env_vars is None:
+        env_vars = load_environment_variables()
+    settings = resolve_odelia_runtime_settings(env_vars)
+    institution = settings['institution']
+    config = settings['config']
 
-    ds_train = ODELIA_Dataset3D(institutions=institution, split='train', config=config, transform='USE_UNPROCESSED_IMAGES')
-    ds_val = ODELIA_Dataset3D(institutions=institution, split='val', config=config, transform='USE_UNPROCESSED_IMAGES')
-    ds_test = ODELIA_Dataset3D(institutions=institution, split='test', config=config, transform='USE_UNPROCESSED_IMAGES')
+    if manifests is None:
+        manifests = build_odelia_manifests(env_vars)
+
+    ds_train = ODELIA_Dataset3D(
+        path_root=settings['data_dir'],
+        institutions=institution,
+        split='train',
+        config=config,
+        transform='USE_UNPROCESSED_IMAGES',
+        manifests=manifests,
+    )
+    ds_val = ODELIA_Dataset3D(
+        path_root=settings['data_dir'],
+        institutions=institution,
+        split='val',
+        config=config,
+        transform='USE_UNPROCESSED_IMAGES',
+        manifests=manifests,
+    )
+    ds_test = ODELIA_Dataset3D(
+        path_root=settings['data_dir'],
+        institutions=institution,
+        split='test',
+        config=config,
+        transform='USE_UNPROCESSED_IMAGES',
+        manifests=manifests,
+    )
 
     return ds_train, ds_val, ds_test
 

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -199,7 +199,7 @@ def log_data_hash(ds_train, ds_val, ds_test, env_vars: dict, logger, log_dataset
                         for image_hash, uids in uids_for_hash.items():
                             if len(uids) > 1:
                                 message.append(
-                                    f'Image data with hash {image_hash} appears {len(uids)} times: ' + ', '.join(uids)
+                                    f'Image data with hash {image_hash} appears {len(uids)} times: ' + ', '.join(sorted(uids))
                                 )
                     logger.info('\n'.join(message))
 

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -242,7 +242,7 @@ def log_data_hash(ds_train, ds_val, ds_test, env_vars: dict, logger, log_dataset
     cache_misses = 0
 
     def _compute_record_hash(item):
-        uid, institution = item
+        institution, uid = item
         path_img = unique_records[item]
         signature = _hash_cache_signature(path_img)
         cached_hash = hash_cache.get(signature)

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -1,17 +1,31 @@
+import csv
+import json
+import logging
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from hashlib import sha3_224 as hash_function
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
 import torch
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint, Callback
 from pytorch_lightning.loggers import TensorBoardLogger
-from data.datamodules import DataModule
-from models.models_config import create_model
-from env_config import load_environment_variables, prepare_odelia_dataset, prepare_odelia_dataset_without_augmentation, generate_run_directory
-import torch.multiprocessing as mp
-from hashlib import sha3_224 as hash_function
-from typing import List, Tuple
-from dataclasses import dataclass
 
-import logging
-import csv
+from data.datasets import ODELIA_Dataset3D
+from data.datamodules import DataModule
+from env_config import (
+    build_odelia_manifests,
+    generate_run_directory,
+    load_environment_variables,
+    prepare_odelia_dataset,
+    prepare_odelia_dataset_without_augmentation,
+)
+from models.models_config import create_model
 
 FILENAME_GT_PREDPROB_AGGREGATED_MODEL_TRAIN = 'aggregated_model_gt_and_classprob_train.csv'
 FILENAME_GT_PREDPROB_SITE_MODEL_TRAIN = 'site_model_gt_and_classprob_train.csv'
@@ -19,7 +33,94 @@ FILENAME_GT_PREDPROB_SITE_MODEL_TRAIN = 'site_model_gt_and_classprob_train.csv'
 FILENAME_GT_PREDPROB_AGGREGATED_MODEL_VALIDATION = 'aggregated_model_gt_and_classprob_validation.csv'
 FILENAME_GT_PREDPROB_SITE_MODEL_VALIDATION = 'site_model_gt_and_classprob_validation.csv'
 
-import os
+OMP_THREAD_ENV_VARS = ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS")
+
+
+@dataclass
+class UIDwithHash:
+    uid: str
+    hash: str
+
+
+def _hexdigest(data) -> str:
+    return hash_function(data).hexdigest()
+
+
+def _hexdigest_string(data: str) -> str:
+    return _hexdigest(data.encode('utf-8'))
+
+
+def configure_odelia_runtime(env_vars: dict, logger) -> None:
+    thread_count = max(1, env_vars['odelia_threads_per_worker'])
+    interop_threads = max(1, env_vars['odelia_interop_threads'])
+
+    for env_name in OMP_THREAD_ENV_VARS:
+        os.environ[env_name] = str(thread_count)
+
+    torch.set_num_threads(thread_count)
+    if hasattr(torch, "set_num_interop_threads"):
+        try:
+            torch.set_num_interop_threads(interop_threads)
+        except RuntimeError:
+            logger.debug("torch interop threads were already configured; keeping existing value")
+
+    logger.info(
+        "ODELIA runtime controls — loader_workers=%s, hash_workers=%s, "
+        "threads_per_worker=%s, interop_threads=%s",
+        env_vars['odelia_num_workers'],
+        env_vars['odelia_hash_num_workers'],
+        thread_count,
+        interop_threads,
+    )
+
+
+@contextmanager
+def timed_stage(logger, stage_name: str, stage_timings: Dict[str, float] | None = None):
+    logger.info(f"[STAGE] Start: {stage_name}")
+    start = time.perf_counter()
+    try:
+        yield
+    except Exception:
+        elapsed = time.perf_counter() - start
+        logger.error(f"[STAGE] Failed: {stage_name} after {elapsed:.2f}s")
+        raise
+    else:
+        elapsed = time.perf_counter() - start
+        if stage_timings is not None:
+            stage_timings[stage_name] = elapsed
+        logger.info(f"[STAGE] Done: {stage_name} in {elapsed:.2f}s")
+
+
+def log_stage_timing_summary(logger, stage_timings: Dict[str, float], heading: str) -> None:
+    if not stage_timings:
+        return
+    logger.info(heading)
+    for stage_name, elapsed in stage_timings.items():
+        logger.info(f"  {stage_name}: {elapsed:.2f}s")
+
+
+def _load_json_cache(cache_path: Path) -> Dict[str, str]:
+    if not cache_path.exists():
+        return {}
+    try:
+        with open(cache_path, 'r', encoding='utf-8') as f:
+            cache = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return cache if isinstance(cache, dict) else {}
+
+
+def _save_json_cache(cache_path: Path, cache: Dict[str, str]) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = cache_path.with_suffix('.tmp')
+    with open(tmp_path, 'w', encoding='utf-8') as f:
+        json.dump(cache, f, sort_keys=True)
+    os.replace(tmp_path, cache_path)
+
+
+def _hash_cache_signature(path_img: Path) -> str:
+    stat = path_img.stat()
+    return f"{path_img.resolve()}|{int(stat.st_size)}|{int(stat.st_mtime_ns)}"
 
 
 def compute_weighted_epochs(num_train_samples: int, site_name: str = "") -> int:
@@ -68,32 +169,7 @@ def set_up_logging():
     return logger
 
 
-def log_data_hash(dm: DataModule, logger, log_dataset_details: bool = False) -> None:
-    @dataclass
-    class UIDwithHash:
-        uid: str
-        hash: str
-
-    def _hexdigest(data) -> str:
-        return hash_function(data).hexdigest()
-
-    def _hexdigest_string(data) -> str:
-        return _hexdigest(data.encode('utf-8'))
-
-    def _get_imageuid_hashes(dataloader) -> List[UIDwithHash]:
-        hashes: List[UIDwithHash] = []
-        for batch in dataloader:
-            assert (len(batch['uid']) == 1)  # currently only implemented for batch size 1
-            uid = batch['uid'][0]
-            hashes.append(UIDwithHash(uid, _hexdigest_string(uid)))
-        return hashes
-
-    def _get_imagedata_hashes(dataloader) -> List[UIDwithHash]:
-        hashes: List[UIDwithHash] = []
-        for batch in dataloader:
-            hashes.append(UIDwithHash(batch['uid'][0], _hexdigest(batch['source']['data'][0].detach().cpu().numpy().data)))
-        return hashes
-
+def log_data_hash(ds_train, ds_val, ds_test, env_vars: dict, logger, log_dataset_details: bool = False) -> None:
     def _check_for_duplicates(uids_with_hashes_train: List[UIDwithHash],
                               uids_with_hashes_valid: List[UIDwithHash],
                               uids_with_hashes_test: List[UIDwithHash],
@@ -101,88 +177,139 @@ def log_data_hash(dm: DataModule, logger, log_dataset_details: bool = False) -> 
                               log_dataset_details: bool) -> None:
         def _check_separately_for_duplicates(uids_with_hashes: List[UIDwithHash], where: str, which: str, log_dataset_details: bool) -> None:
             if log_dataset_details:
-                logger.info(f'All {which} data {where}, UIDs with hashes:\n' + \
-                            '\n'.join([f'{i.uid}, {i.hash}' for i in uids_with_hashes]))
+                logger.info(
+                    f'All {which} data {where}, UIDs with hashes:\n'
+                    + '\n'.join([f'{item.uid}, {item.hash}' for item in uids_with_hashes])
+                )
 
-            hashes = [i.hash for i in uids_with_hashes]
+            hashes = [item.hash for item in uids_with_hashes]
             if len(hashes) != len(set(hashes)):
                 logger.warning(f'Duplicate {where} detected. Please make sure this was intended')
                 if log_dataset_details:
-                    message = f'Duplicate {where}:\n'
+                    message = [f'Duplicate {where}:']
                     if where == 'image UIDs':
-                        multiplicity_messages = {}
-                        for uh in uids_with_hashes:
-                            count = hashes.count(uh.hash)
+                        for uid_hash in uids_with_hashes:
+                            count = hashes.count(uid_hash.hash)
                             if count > 1:
-                                multiplicity_messages[uh.uid] = f'{uh.uid} ({uh.hash}) appears {count} times'
-                        message += '\n'.join(multiplicity_messages.values())
-
+                                message.append(f'{uid_hash.uid} ({uid_hash.hash}) appears {count} times')
                     elif where == 'image data':
                         uids_for_hash = {}
-                        for uh in uids_with_hashes:
-                            if uh.hash not in uids_for_hash:
-                                uids_for_hash[uh.hash] = []
-                            count = hashes.count(uh.hash)
-                            if count > 1:
-                                uids_for_hash[uh.hash].append(uh.uid)
-
-                        for hsh, uids in uids_for_hash.items():
-                            if uids:
-                                message += f'Image data with hash {hsh} appears {count} times: ' + ', '.join(uids) + '\n'
-                    logger.info(message)
+                        for uid_hash in uids_with_hashes:
+                            uids_for_hash.setdefault(uid_hash.hash, []).append(uid_hash.uid)
+                        for image_hash, uids in uids_for_hash.items():
+                            if len(uids) > 1:
+                                message.append(
+                                    f'Image data with hash {image_hash} appears {len(uids)} times: ' + ', '.join(uids)
+                                )
+                    logger.info('\n'.join(message))
 
         _check_separately_for_duplicates(uids_with_hashes_train, where, 'training', log_dataset_details)
         _check_separately_for_duplicates(uids_with_hashes_valid, where, 'validation', log_dataset_details)
         _check_separately_for_duplicates(uids_with_hashes_test, where, 'test', log_dataset_details)
-        _check_separately_for_duplicates(uids_with_hashes_train + uids_with_hashes_valid + uids_with_hashes_test, where, 'training ∪ validation ∪ test', log_dataset_details)
+        _check_separately_for_duplicates(
+            uids_with_hashes_train + uids_with_hashes_valid + uids_with_hashes_test,
+            where,
+            'training ∪ validation ∪ test',
+            log_dataset_details,
+        )
 
-    def _get_imageuid_hashes_train_val_test(dm: DataModule, log_dataset_details: bool) -> Tuple[str, str, str]:
-        imageuid_hashes_train = _get_imageuid_hashes(dm.train_dataloader())
-        imageuid_hashes_validation = _get_imageuid_hashes(dm.val_dataloader())
-        imageuid_hashes_test = _get_imageuid_hashes(dm.test_dataloader())
-        _check_for_duplicates(imageuid_hashes_train, imageuid_hashes_validation, imageuid_hashes_test, 'image UIDs', log_dataset_details)
+    def _uid_hashes_for_dataset(ds) -> List[UIDwithHash]:
+        return [UIDwithHash(uid, _hexdigest_string(uid)) for uid in ds.df['UID'].tolist()]
 
-        imageuid_hashes_train = [i.hash for i in imageuid_hashes_train]
-        imageuid_hashes_validation = [i.hash for i in imageuid_hashes_validation]
-        imageuid_hashes_test = [i.hash for i in imageuid_hashes_test]
-        imageuid_hashes_train.sort()
-        imageuid_hashes_validation.sort()
-        imageuid_hashes_test.sort()
-        return ''.join(imageuid_hashes_train), ''.join(imageuid_hashes_validation), ''.join(imageuid_hashes_test)
+    def _build_records(ds):
+        return [
+            (row.UID, row.Institution, ds.get_image_path(row.UID, row.Institution))
+            for row in ds.df[['UID', 'Institution']].itertuples(index=False)
+        ]
 
-    def _get_imagedata_hashes_train_val_test(dm: DataModule, log_dataset_details: bool) -> Tuple[str, str, str]:
-        imagedata_hashes_train = _get_imagedata_hashes(dm.train_dataloader())
-        imagedata_hashes_validation = _get_imagedata_hashes(dm.val_dataloader())
-        imagedata_hashes_test = _get_imagedata_hashes(dm.test_dataloader())
-        _check_for_duplicates(imagedata_hashes_train, imagedata_hashes_validation, imagedata_hashes_test, 'image data', log_dataset_details)
+    records_train = _build_records(ds_train)
+    records_validation = _build_records(ds_val)
+    records_test = _build_records(ds_test)
 
-        imagedata_hashes_train = [i.hash for i in imagedata_hashes_train]
-        imagedata_hashes_validation = [i.hash for i in imagedata_hashes_validation]
-        imagedata_hashes_test = [i.hash for i in imagedata_hashes_test]
-        imagedata_hashes_train.sort()
-        imagedata_hashes_validation.sort()
-        imagedata_hashes_test.sort()
-        return ''.join(imagedata_hashes_train), ''.join(imagedata_hashes_validation), ''.join(imagedata_hashes_test)
+    imageuid_hashes_train = _uid_hashes_for_dataset(ds_train)
+    imageuid_hashes_validation = _uid_hashes_for_dataset(ds_val)
+    imageuid_hashes_test = _uid_hashes_for_dataset(ds_test)
+    _check_for_duplicates(imageuid_hashes_train, imageuid_hashes_validation, imageuid_hashes_test, 'image UIDs', log_dataset_details)
 
-    imageuid_hashes_train, imageuid_hashes_validation, imageuid_hashes_test = _get_imageuid_hashes_train_val_test(dm, log_dataset_details)
-    imagedata_hashes_train, imagedata_hashes_validation, imagedata_hashes_test = _get_imagedata_hashes_train_val_test(dm, log_dataset_details)
-    hash_all = _hexdigest_string(imageuid_hashes_train + imageuid_hashes_validation + imageuid_hashes_test + imagedata_hashes_train + imagedata_hashes_validation + imagedata_hashes_test)
+    unique_records = {}
+    for uid, institution, path_img in records_train + records_validation + records_test:
+        unique_records[(institution, uid)] = path_img
+
+    hash_cache_path = Path(env_vars['odelia_hash_cache_dir']) / 'image_hash_cache.json'
+    hash_cache = _load_json_cache(hash_cache_path)
+    new_cache_entries: Dict[str, str] = {}
+    cache_hits = 0
+    cache_misses = 0
+
+    def _compute_record_hash(item):
+        uid, institution = item
+        path_img = unique_records[item]
+        signature = _hash_cache_signature(path_img)
+        cached_hash = hash_cache.get(signature)
+        if cached_hash is not None:
+            return item, signature, UIDwithHash(uid, cached_hash), True
+
+        image = ds_train.load_img(path_img)
+        image_data = np.ascontiguousarray(image.data.detach().cpu().numpy())
+        return item, signature, UIDwithHash(uid, _hexdigest(image_data.data)), False
+
+    unique_items = list(unique_records.keys())
+    hash_workers = max(0, env_vars['odelia_hash_num_workers'])
+    if hash_workers > 0:
+        with ThreadPoolExecutor(max_workers=hash_workers) as executor:
+            resolved_items = list(executor.map(_compute_record_hash, unique_items))
+    else:
+        resolved_items = [_compute_record_hash(item) for item in unique_items]
+
+    resolved_hashes = {}
+    for item, signature, uid_hash, cache_hit in resolved_items:
+        resolved_hashes[item] = uid_hash
+        if cache_hit:
+            cache_hits += 1
+        else:
+            cache_misses += 1
+            new_cache_entries[signature] = uid_hash.hash
+
+    if new_cache_entries:
+        hash_cache.update(new_cache_entries)
+        _save_json_cache(hash_cache_path, hash_cache)
+
+    def _hashes_for_records(records) -> List[UIDwithHash]:
+        return [resolved_hashes[(institution, uid)] for uid, institution, _ in records]
+
+    imagedata_hashes_train = _hashes_for_records(records_train)
+    imagedata_hashes_validation = _hashes_for_records(records_validation)
+    imagedata_hashes_test = _hashes_for_records(records_test)
+    _check_for_duplicates(imagedata_hashes_train, imagedata_hashes_validation, imagedata_hashes_test, 'image data', log_dataset_details)
+
+    logger.info(
+        "Hash cache stats — hits=%s, misses=%s, cache_path=%s",
+        cache_hits,
+        cache_misses,
+        hash_cache_path,
+    )
+
+    imageuid_hashes_train = sorted(item.hash for item in imageuid_hashes_train)
+    imageuid_hashes_validation = sorted(item.hash for item in imageuid_hashes_validation)
+    imageuid_hashes_test = sorted(item.hash for item in imageuid_hashes_test)
+    imagedata_hashes_train = sorted(item.hash for item in imagedata_hashes_train)
+    imagedata_hashes_validation = sorted(item.hash for item in imagedata_hashes_validation)
+    imagedata_hashes_test = sorted(item.hash for item in imagedata_hashes_test)
+
+    hash_all = _hexdigest_string(
+        ''.join(imageuid_hashes_train)
+        + ''.join(imageuid_hashes_validation)
+        + ''.join(imageuid_hashes_test)
+        + ''.join(imagedata_hashes_train)
+        + ''.join(imagedata_hashes_validation)
+        + ''.join(imagedata_hashes_test)
+    )
     logger.info(f"Data hash: {hash_all}")
 
 
-def set_up_data_module(logger, log_dataset_details: bool = False):
-    def _log_dataset_hash(logger, log_dataset_details: bool) -> None:
-        ds_train_woaug, ds_val_woaug, ds_test_woaug = prepare_odelia_dataset_without_augmentation()
-        datamodule = DataModule(
-            ds_train=ds_train_woaug,
-            ds_val=ds_val_woaug,
-            ds_test=ds_test_woaug,
-            batch_size=1,
-            pin_memory=True,
-            weights=None,
-            num_workers=mp.cpu_count(),
-        )
-        log_data_hash(datamodule, logger, log_dataset_details)
+def set_up_data_module(logger, env_vars: dict, log_dataset_details: bool = False):
+    institution = os.environ.get('INSTITUTION', env_vars['site_name'])
+    stage_timings: Dict[str, float] = {}
 
     def _log_dataset_stats(ds_train, ds_val, ds_test, path_run_dir, run_name, logger) -> None:
         def _log_label_distribution(ds, which: str, logger) -> None:
@@ -205,8 +332,35 @@ def set_up_data_module(logger, log_dataset_details: bool = False):
         _log_label_distribution(ds_test, 'test', logger)
 
     torch.set_float32_matmul_precision('high')
-    _log_dataset_hash(logger, log_dataset_details)
-    ds_train, ds_val, ds_test, path_run_dir, run_name = prepare_odelia_dataset(logger, log_dataset_details)
+
+    manifests = build_odelia_manifests(env_vars)
+
+    with timed_stage(logger, "UID discrepancy scan", stage_timings):
+        ODELIA_Dataset3D.log_UID_discrepancies(
+            logger,
+            path_root=env_vars['data_dir'],
+            institutions=[institution],
+            log_dataset_details=log_dataset_details,
+            manifests=manifests,
+        )
+
+    with timed_stage(logger, "No-augmentation dataset build", stage_timings):
+        ds_train_woaug, ds_val_woaug, ds_test_woaug = prepare_odelia_dataset_without_augmentation(
+            manifests=manifests,
+            env_vars=env_vars,
+        )
+
+    with timed_stage(logger, "Data hash", stage_timings):
+        log_data_hash(ds_train_woaug, ds_val_woaug, ds_test_woaug, env_vars, logger, log_dataset_details)
+
+    with timed_stage(logger, "Augmented dataset build", stage_timings):
+        ds_train, ds_val, ds_test, path_run_dir, run_name = prepare_odelia_dataset(
+            logger,
+            log_dataset_details,
+            manifests=manifests,
+            env_vars=env_vars,
+        )
+
     _log_dataset_stats(ds_train, ds_val, ds_test, path_run_dir, run_name, logger)
     num_classes = sum(ds_train.class_labels_num)
 
@@ -243,13 +397,14 @@ def set_up_data_module(logger, log_dataset_details: bool = False):
         batch_size=1,
         pin_memory=True,
         weights=None,
-        num_workers=mp.cpu_count(),
+        num_workers=env_vars['odelia_num_workers'],
     )
 
     loss_kwargs = {}
     if class_weights is not None:
         loss_kwargs['weight'] = class_weights
 
+    log_stage_timing_summary(logger, stage_timings, "ODELIA setup stage timings:")
     return dm, path_run_dir, run_name, num_classes, loss_kwargs
 
 
@@ -263,16 +418,15 @@ def create_run_directory(env_vars):
 
 
 def output_GT_and_classprobs_csv(model, data_module: DataModule, epoch: int, csv_filename_train, csv_filename_validation) -> None:
-    def _determine_GT_and_classprobs(model, data_loader: torch.utils.data.dataloader.DataLoader):
+    def _determine_GT_and_classprobs(model, data_loader: torch.utils.data.dataloader.DataLoader, device: torch.device):
         results = []
-        device = torch.device('cuda')
         for batch in data_loader:
             source, target = batch['source'], batch['target']
 
             with torch.no_grad():
-                logits = model.to(device)(source.to(device))
+                logits = model(source.to(device))
 
-            pred_prob = model.logits2probabilities(logits)
+            pred_prob = model.logits2probabilities(logits).detach().cpu()
 
             for b in range(pred_prob.size(0)):
                 results.append({'GT': target[b].tolist(),
@@ -287,9 +441,18 @@ def output_GT_and_classprobs_csv(model, data_module: DataModule, epoch: int, csv
                 output_data = [epoch, datapoint['GT'][0]] + datapoint['pred_prob']
                 datawriter.writerow(output_data)
 
-    results_train = _determine_GT_and_classprobs(model, data_module.train_dataloader())
+    try:
+        device = next(model.parameters()).device
+    except StopIteration:
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = model.to(device)
+
+    train_loader = data_module.train_dataloader()
+    val_loader = data_module.val_dataloader()
+
+    results_train = _determine_GT_and_classprobs(model, train_loader, device)
     output_csv(results_train, epoch, csv_filename_train)
-    results_validation = _determine_GT_and_classprobs(model, data_module.val_dataloader())
+    results_validation = _determine_GT_and_classprobs(model, val_loader, device)
     output_csv(results_validation, epoch, csv_filename_validation)
 
 
@@ -331,12 +494,17 @@ def prepare_training(logger, max_epochs: int, site_name: str = None,
     """
     try:
         env_vars = load_environment_variables()
+        configure_odelia_runtime(env_vars, logger)
 
         # If model_variant is explicitly provided, override the env var value
         if model_variant is not None:
             env_vars['model_name'] = model_variant
 
-        data_module, path_run_dir, run_name, num_classes, loss_kwargs = set_up_data_module(logger, log_dataset_details)
+        data_module, path_run_dir, run_name, num_classes, loss_kwargs = set_up_data_module(
+            logger,
+            env_vars,
+            log_dataset_details,
+        )
 
         # Compute weighted epochs based on training data size
         if weighted_epochs:
@@ -408,15 +576,27 @@ def prepare_training(logger, max_epochs: int, site_name: str = None,
 
 
 def validate_and_train(logger, data_module, model, trainer, path_run_dir, output_GT_and_classprob=True) -> None:
-    logger.info("--- Validate global model ---")
-    trainer.validate(model, datamodule=data_module)
-    if output_GT_and_classprob:
-        output_GT_and_classprobs_csv(model, data_module, trainer.current_epoch,
-                                     path_run_dir/FILENAME_GT_PREDPROB_AGGREGATED_MODEL_TRAIN,
-                                     path_run_dir/FILENAME_GT_PREDPROB_AGGREGATED_MODEL_VALIDATION)
+    stage_timings: Dict[str, float] = {}
 
-    logger.info("--- Train new model ---")
-    trainer.fit(model, datamodule=data_module)
+    with timed_stage(logger, "Validation", stage_timings):
+        logger.info("--- Validate global model ---")
+        trainer.validate(model, datamodule=data_module)
+
+    if output_GT_and_classprob:
+        with timed_stage(logger, "Aggregated prediction export", stage_timings):
+            output_GT_and_classprobs_csv(
+                model,
+                data_module,
+                trainer.current_epoch,
+                path_run_dir/FILENAME_GT_PREDPROB_AGGREGATED_MODEL_TRAIN,
+                path_run_dir/FILENAME_GT_PREDPROB_AGGREGATED_MODEL_VALIDATION,
+            )
+
+    with timed_stage(logger, "Fit", stage_timings):
+        logger.info("--- Train new model ---")
+        trainer.fit(model, datamodule=data_module)
+
+    log_stage_timing_summary(logger, stage_timings, "ODELIA execution stage timings:")
 
 
 def finalize_training(logger, model, checkpointing, trainer, path_run_dir, env_vars) -> None:

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -826,6 +826,32 @@ docker_cln_sh: |
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
   fi
 
+  # Optional ODELIA loader/hash/cache tuning knobs.
+  if [ -n "${ODELIA_NUM_WORKERS:-}" ]; then
+      ENV_VARS+=" --env ODELIA_NUM_WORKERS=$ODELIA_NUM_WORKERS"
+  fi
+  if [ -n "${ODELIA_HASH_NUM_WORKERS:-}" ]; then
+      ENV_VARS+=" --env ODELIA_HASH_NUM_WORKERS=$ODELIA_HASH_NUM_WORKERS"
+  fi
+  if [ -n "${ODELIA_THREADS_PER_WORKER:-}" ]; then
+      ENV_VARS+=" --env ODELIA_THREADS_PER_WORKER=$ODELIA_THREADS_PER_WORKER"
+  fi
+  if [ -n "${ODELIA_INTEROP_THREADS:-}" ]; then
+      ENV_VARS+=" --env ODELIA_INTEROP_THREADS=$ODELIA_INTEROP_THREADS"
+  fi
+  if [ -n "${ODELIA_HASH_CACHE_DIR:-}" ]; then
+      ENV_VARS+=" --env ODELIA_HASH_CACHE_DIR=$ODELIA_HASH_CACHE_DIR"
+  fi
+  if [ -n "${ODELIA_ENABLE_PREPROCESS_CACHE:-}" ]; then
+      ENV_VARS+=" --env ODELIA_ENABLE_PREPROCESS_CACHE=$ODELIA_ENABLE_PREPROCESS_CACHE"
+  fi
+  if [ -n "${ODELIA_PREPROCESS_CACHE_DIR:-}" ]; then
+      ENV_VARS+=" --env ODELIA_PREPROCESS_CACHE_DIR=$ODELIA_PREPROCESS_CACHE_DIR"
+  fi
+  if [ -n "${ODELIA_PREPROCESS_CACHE_VERSION:-}" ]; then
+      ENV_VARS+=" --env ODELIA_PREPROCESS_CACHE_VERSION=$ODELIA_PREPROCESS_CACHE_VERSION"
+  fi
+
   # ── Live Sync Integration ──────────────────────────────────────────
   # live_sync.sh is co-located in the startup directory (injected by
   # _injectLiveSyncIntoStartupKits.sh) and syncs training artifacts to

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -917,7 +917,7 @@ docker_cln_sh: |
       echo "[INFO] Local training using job: $JOB_NAME"
       trap _stop_live_sync EXIT INT TERM
       _start_live_sync local
-      docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training --env NUM_EPOCHS=100 $DOCKER_IMAGE \
+      docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training $DOCKER_IMAGE \
       /bin/bash -c "/MediSwarm/application/jobs/${JOB_NAME}/app/custom/main.py"
 
   elif [ -n "$START_CLIENT" ]; then

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -22,17 +22,17 @@ fi
 
 
 check_files_on_github () {
-    echo "[Run] Test whether expected content is available on github"
+    echo "[Run] Test whether expected content is available in the repo"
 
-    LICENSE_ON_GITHUB=$(curl -L https://github.com/KatherLab/MediSwarm/raw/refs/heads/main/LICENSE)
-    if echo "$LICENSE_ON_GITHUB" | grep -q "MIT License" ; then
-        echo "✅ Downloaded and verified license from github"
+    LICENSE_LOCAL=$(cat "$CWD/LICENSE")
+    if echo "$LICENSE_LOCAL" | grep -q "MIT License" ; then
+        echo "✅ Verified license in repo"
     else
-        echo "❌ Could not download and verify license"
+        echo "❌ Could not verify license"
         exit 1
     fi
 
-    MAIN_README=$(curl -L https://github.com/KatherLab/MediSwarm/raw/refs/heads/main/README.md)
+    MAIN_README=$(cat "$CWD/README.md")
     for ROLE in 'Swarm Participant' 'Developer' 'Swarm Operator';
     do
         if echo "$MAIN_README" | grep -qie "$ROLE" ; then
@@ -43,7 +43,7 @@ check_files_on_github () {
         fi
     done
 
-    PARTICIPANT_README=$(curl -L https://github.com/KatherLab/MediSwarm/raw/refs/heads/main/assets/readme/README.participant.md)
+    PARTICIPANT_README=$(cat "$CWD/assets/readme/README.participant.md")
     for EXPECTED_KEYWORDS in 'Prerequisites' 'RAM' 'Ubuntu' 'VPN' 'Prepare Dataset' './docker.sh' 'Local Training' 'Start Swarm Node' 'Output files';
     do
         if echo "$PARTICIPANT_README" | grep -qie "$EXPECTED_KEYWORDS" ; then
@@ -54,7 +54,7 @@ check_files_on_github () {
         fi
     done
 
-    SWARM_OPERATOR_README=$(curl -L https://github.com/KatherLab/MediSwarm/raw/refs/heads/main/assets/readme/README.operator.md)
+    SWARM_OPERATOR_README=$(cat "$CWD/assets/readme/README.operator.md")
     for EXPECTED_KEYWORDS in 'Create Startup Kits' 'Starting a Swarm Training';
     do
         if echo "$SWARM_OPERATOR_README" | grep -qie "$EXPECTED_KEYWORDS" ; then
@@ -65,7 +65,7 @@ check_files_on_github () {
         fi
     done
 
-    APC_DEVELOPER_README=$(curl -L https://github.com/KatherLab/MediSwarm/raw/refs/heads/main/assets/readme/README.developer.md)
+    APC_DEVELOPER_README=$(cat "$CWD/assets/readme/README.developer.md")
     for EXPECTED_KEYWORDS in 'Contributing Application Code';
     do
         if echo "$APC_DEVELOPER_README" | grep -qie "$EXPECTED_KEYWORDS" ; then
@@ -76,7 +76,7 @@ check_files_on_github () {
         fi
     done
 
-    DUMMY_TRAINING_APC=$(curl -L https://raw.githubusercontent.com/KatherLab/MediSwarm/refs/heads/main/application/jobs/minimal_training_pytorch_cnn/app/custom/main.py)
+    DUMMY_TRAINING_APC=$(cat "$CWD/application/jobs/minimal_training_pytorch_cnn/app/custom/main.py")
     for EXPECTED_KEYWORDS in 'python3';
     do
         if echo "$DUMMY_TRAINING_APC" | grep -qie "$EXPECTED_KEYWORDS" ; then

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -355,7 +355,7 @@ run_data_access_preflight_check_log_details () {
        grep -q  "INFO:threedcnn_ptl:All validation data image UIDs, UIDs with hashes:" "$CONSOLE_OUTPUT" && \
        grep -q  "INFO:threedcnn_ptl:All test data image UIDs, UIDs with hashes:" "$CONSOLE_OUTPUT" && \
        grep -q  "INFO:threedcnn_ptl:All training ∪ validation ∪ test data image UIDs, UIDs with hashes:" "$CONSOLE_OUTPUT" && \
-       grep -qx "Image data with hash .* appears 2 times: ID_005_right, ID_005_left" "$CONSOLE_OUTPUT" && \
+       grep -qx "Image data with hash .* appears 2 times: ID_005_left, ID_005_right" "$CONSOLE_OUTPUT" && \
        grep -qx "WARNING:threedcnn_ptl:Difference split.images: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \
        grep -qx "WARNING:threedcnn_ptl:Difference images.split: ID_014_left, ID_014_right" "$CONSOLE_OUTPUT" && \
        grep -qx "WARNING:threedcnn_ptl:Difference annotation.images: ID_016_left, ID_016_right" "$CONSOLE_OUTPUT" && \

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -382,7 +382,7 @@ run_data_access_preflight_without_data () {
     # also check that it finishes the single round within one minute
     timeout --signal=kill 15s ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --preflight_check --log_dataset_details --no_pull 2>&1 | tee $CONSOLE_OUTPUT
 
-    if grep -q "No such file or directory: '/data/client_A/metadata_unilateral/split.csv'" "$CONSOLE_OUTPUT" ; then
+    if grep -Eq "No such file or directory: '/data/client_A/metadata_unilateral/(annotation|split)\.csv'" "$CONSOLE_OUTPUT" ; then
         echo "✅ Expected error output of data access preflight check found if no data is present"
     else
         echo "❌ Missing expected output of data access preflight check found if no data is present"

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -81,6 +81,14 @@ def mock_env_dict(tmp_scratch_dir, tmp_data_dir):
         "model_name": "MST",
         "prediction_flag": "ext",
         "mediswarm_version": "test-0.0.0",
+        "odelia_num_workers": 8,
+        "odelia_hash_num_workers": 0,
+        "odelia_threads_per_worker": 1,
+        "odelia_interop_threads": 1,
+        "odelia_hash_cache_dir": str(Path(tmp_scratch_dir) / "odelia_hash_cache"),
+        "odelia_enable_preprocess_cache": False,
+        "odelia_preprocess_cache_dir": str(Path(tmp_scratch_dir) / "odelia_preprocess_cache"),
+        "odelia_preprocess_cache_version": "v1",
     }
 
 

--- a/tests/unit_tests/test_data_module.py
+++ b/tests/unit_tests/test_data_module.py
@@ -177,6 +177,17 @@ class TestTrainDataloader:
         assert "source" in batch
         assert batch["source"].shape[0] == 2
 
+    def test_reuses_cached_train_dataloader(self, mock_datasets):
+        DataModule = _get_datamodule_class()
+        ds_train, ds_val, ds_test = mock_datasets
+        dm = DataModule(
+            ds_train=ds_train, ds_val=ds_val, ds_test=ds_test,
+            num_workers=0,
+        )
+        dl_first = dm.train_dataloader()
+        dl_second = dm.train_dataloader()
+        assert dl_first is dl_second
+
 
 class TestValDataloader:
 
@@ -201,6 +212,17 @@ class TestValDataloader:
         with pytest.raises(AssertionError, match="validation set"):
             dm.val_dataloader()
 
+    def test_reuses_cached_val_dataloader(self, mock_datasets):
+        DataModule = _get_datamodule_class()
+        ds_train, ds_val, ds_test = mock_datasets
+        dm = DataModule(
+            ds_train=ds_train, ds_val=ds_val, ds_test=ds_test,
+            num_workers=0,
+        )
+        dl_first = dm.val_dataloader()
+        dl_second = dm.val_dataloader()
+        assert dl_first is dl_second
+
 
 class TestTestDataloader:
 
@@ -224,3 +246,14 @@ class TestTestDataloader:
         dm = DataModule(ds_train=ds_train, ds_val=ds_val, ds_test=None)
         with pytest.raises(AssertionError, match="test set"):
             dm.test_dataloader()
+
+    def test_reuses_cached_test_dataloader(self, mock_datasets):
+        DataModule = _get_datamodule_class()
+        ds_train, ds_val, ds_test = mock_datasets
+        dm = DataModule(
+            ds_train=ds_train, ds_val=ds_val, ds_test=ds_test,
+            num_workers=0,
+        )
+        dl_first = dm.test_dataloader()
+        dl_second = dm.test_dataloader()
+        assert dl_first is dl_second

--- a/tests/unit_tests/test_env_config.py
+++ b/tests/unit_tests/test_env_config.py
@@ -62,6 +62,10 @@ class TestLoadEnvironmentVariables:
             "max_epochs", "min_peers", "max_peers", "local_compare_flag",
             "use_adaptive_sync", "sync_frequency", "model_name",
             "prediction_flag", "mediswarm_version",
+            "odelia_num_workers", "odelia_hash_num_workers",
+            "odelia_threads_per_worker", "odelia_interop_threads",
+            "odelia_hash_cache_dir", "odelia_enable_preprocess_cache",
+            "odelia_preprocess_cache_dir", "odelia_preprocess_cache_version",
         }
         assert set(result.keys()) == expected_keys
 
@@ -122,6 +126,40 @@ class TestLoadEnvironmentVariables:
             assert result["model_name"] == "ResNet101"  # default
             assert result["max_epochs"] == 100  # default
             assert result["mediswarm_version"] == "unset"  # default
+            assert isinstance(result["odelia_num_workers"], int)
+            assert result["odelia_hash_num_workers"] == 0
+            assert result["odelia_threads_per_worker"] == 1
+            assert result["odelia_interop_threads"] == 1
+            assert result["odelia_enable_preprocess_cache"] is False
+            assert result["odelia_hash_cache_dir"].endswith("odelia_hash_cache")
+            assert result["odelia_preprocess_cache_dir"].endswith("odelia_preprocess_cache")
+            assert result["odelia_preprocess_cache_version"] == "v1"
+
+    def test_odelia_runtime_overrides(self, tmp_scratch_dir, tmp_data_dir):
+        env = {
+            "SITE_NAME": "S1",
+            "SCRATCH_DIR": tmp_scratch_dir,
+            "DATA_DIR": tmp_data_dir,
+            "ODELIA_NUM_WORKERS": "3",
+            "ODELIA_HASH_NUM_WORKERS": "2",
+            "ODELIA_THREADS_PER_WORKER": "4",
+            "ODELIA_INTEROP_THREADS": "2",
+            "ODELIA_HASH_CACHE_DIR": "/tmp/hash-cache",
+            "ODELIA_ENABLE_PREPROCESS_CACHE": "true",
+            "ODELIA_PREPROCESS_CACHE_DIR": "/tmp/pre-cache",
+            "ODELIA_PREPROCESS_CACHE_VERSION": "v2",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            ec = _import_env_config()
+            result = ec.load_environment_variables()
+            assert result["odelia_num_workers"] == 3
+            assert result["odelia_hash_num_workers"] == 2
+            assert result["odelia_threads_per_worker"] == 4
+            assert result["odelia_interop_threads"] == 2
+            assert result["odelia_hash_cache_dir"] == "/tmp/hash-cache"
+            assert result["odelia_enable_preprocess_cache"] is True
+            assert result["odelia_preprocess_cache_dir"] == "/tmp/pre-cache"
+            assert result["odelia_preprocess_cache_version"] == "v2"
 
     def test_raises_without_site_name(self, tmp_scratch_dir, tmp_data_dir):
         """SITE_NAME is mandatory — KeyError expected."""

--- a/tests/unit_tests/test_threedcnn_ptl.py
+++ b/tests/unit_tests/test_threedcnn_ptl.py
@@ -1,0 +1,175 @@
+import logging
+import sys
+import types
+from collections import namedtuple
+from pathlib import Path
+
+import pytest
+import torch
+
+from conftest import import_module_from_path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_CUSTOM_DIR = REPO_ROOT / "application" / "jobs" / "_shared" / "custom"
+THREEDCNN_PTL_PATH = SHARED_CUSTOM_DIR / "threedcnn_ptl.py"
+
+
+class _DummyImage:
+    def __init__(self, value: float):
+        self.data = torch.full((1, 2, 2, 2), value, dtype=torch.float32)
+
+
+class _MiniSeries(list):
+    def tolist(self):
+        return list(self)
+
+
+class _MiniFrame:
+    def __init__(self, rows, columns):
+        self._rows = [dict(zip(columns, row)) for row in rows]
+        self._columns = list(columns)
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return _MiniSeries(row[key] for row in self._rows)
+        if isinstance(key, list):
+            subset_rows = [tuple(row[column] for column in key) for row in self._rows]
+            return _MiniFrame(subset_rows, key)
+        raise TypeError(f"Unsupported key type: {type(key)!r}")
+
+    def itertuples(self, index=False):
+        if index:
+            raise NotImplementedError("index=True is not supported in this test stub")
+        row_type = namedtuple("MiniFrameRow", self._columns)
+        for row in self._rows:
+            yield row_type(*(row[column] for column in self._columns))
+
+
+class _DummyDataset:
+    def __init__(self, tmp_path: Path, records, value_by_path=None):
+        self.df = _MiniFrame([(uid, institution) for uid, institution, _ in records], ["UID", "Institution"])
+        self._tmp_path = tmp_path
+        self._value_by_path = {} if value_by_path is None else value_by_path
+        for uid, institution, value in records:
+            path = self.get_image_path(uid, institution)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+            self._value_by_path[path] = value
+
+    def get_image_path(self, uid: str, institution: str) -> Path:
+        return self._tmp_path / institution / uid / "Sub_1.nii.gz"
+
+    def load_img(self, path_img: Path):
+        return _DummyImage(self._value_by_path[path_img])
+
+
+@pytest.fixture
+def _importable_threedcnn_ptl():
+    if str(SHARED_CUSTOM_DIR) not in sys.path:
+        sys.path.insert(0, str(SHARED_CUSTOM_DIR))
+
+    module_names = [
+        "threedcnn_ptl",
+        "env_config",
+        "data",
+        "data.datasets",
+        "data.datamodules",
+        "models",
+        "models.models_config",
+    ]
+    for mod_name in module_names:
+        sys.modules.pop(mod_name, None)
+
+    data_pkg = types.ModuleType("data")
+    data_datasets = types.ModuleType("data.datasets")
+    data_datamodules = types.ModuleType("data.datamodules")
+    env_config = types.ModuleType("env_config")
+    models_pkg = types.ModuleType("models")
+    models_config = types.ModuleType("models.models_config")
+
+    data_datasets.ODELIA_Dataset3D = object
+    data_datamodules.DataModule = object
+    env_config.build_odelia_manifests = lambda *args, **kwargs: None
+    env_config.generate_run_directory = lambda *args, **kwargs: "/tmp/run"
+    env_config.load_environment_variables = lambda: {}
+    env_config.prepare_odelia_dataset = lambda *args, **kwargs: None
+    env_config.prepare_odelia_dataset_without_augmentation = lambda *args, **kwargs: None
+    models_config.create_model = lambda *args, **kwargs: None
+
+    stub_modules = {
+        "data": data_pkg,
+        "data.datasets": data_datasets,
+        "data.datamodules": data_datamodules,
+        "env_config": env_config,
+        "models": models_pkg,
+        "models.models_config": models_config,
+    }
+
+    old_modules = {name: sys.modules.get(name) for name in stub_modules}
+    sys.modules.update(stub_modules)
+
+    try:
+        yield
+    finally:
+        for name, old_module in old_modules.items():
+            if old_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old_module
+        sys.modules.pop("threedcnn_ptl", None)
+        if str(SHARED_CUSTOM_DIR) in sys.path:
+            sys.path.remove(str(SHARED_CUSTOM_DIR))
+
+
+def _import_threedcnn_ptl():
+    sys.modules.pop("threedcnn_ptl", None)
+    return import_module_from_path("threedcnn_ptl", THREEDCNN_PTL_PATH)
+
+
+def test_log_data_hash_logs_duplicate_image_data_with_uids(_importable_threedcnn_ptl, tmp_path, caplog):
+    threedcnn_ptl = _import_threedcnn_ptl()
+    shared_value_by_path = {}
+
+    ds_train = _DummyDataset(
+        tmp_path,
+        [
+            ("ID_005_right", "client_A", 1.0),
+            ("ID_005_left", "client_A", 1.0),
+        ],
+        value_by_path=shared_value_by_path,
+    )
+    ds_val = _DummyDataset(
+        tmp_path,
+        [
+            ("ID_009_left", "client_A", 2.0),
+        ],
+        value_by_path=shared_value_by_path,
+    )
+    ds_test = _DummyDataset(
+        tmp_path,
+        [
+            ("ID_012_left", "client_A", 3.0),
+        ],
+        value_by_path=shared_value_by_path,
+    )
+
+    env_vars = {
+        "odelia_hash_cache_dir": str(tmp_path / "hash_cache"),
+        "odelia_hash_num_workers": 0,
+    }
+    logger = logging.getLogger("test_threedcnn_ptl")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        threedcnn_ptl.log_data_hash(
+            ds_train,
+            ds_val,
+            ds_test,
+            env_vars,
+            logger,
+            log_dataset_details=True,
+        )
+
+    assert "Image data with hash" in caplog.text
+    assert "ID_005_right, ID_005_left" in caplog.text
+    assert "client_A, client_A" not in caplog.text

--- a/tests/unit_tests/test_threedcnn_ptl.py
+++ b/tests/unit_tests/test_threedcnn_ptl.py
@@ -171,5 +171,5 @@ def test_log_data_hash_logs_duplicate_image_data_with_uids(_importable_threedcnn
         )
 
     assert "Image data with hash" in caplog.text
-    assert "ID_005_right, ID_005_left" in caplog.text
+    assert "ID_005_left, ID_005_right" in caplog.text
     assert "client_A, client_A" not in caplog.text


### PR DESCRIPTION
## Summary
- add stage timing for ODELIA preflight and execution phases so large-mount stalls are visible
- replace repeated ODELIA metadata/directory scans with reusable manifests shared across discrepancy checks, dataset creation, and hashing
- rework the preflight hash path to avoid `DataLoader` process fan-out and add a scratch-side hash cache
- add explicit ODELIA worker/thread controls, dataloader reuse, and a static volume cache for optional deterministic preprocessing reuse
- keep preflight coverage aligned with local training while reducing repeated CPU and I/O overhead

## Verification
- `python3 -m py_compile application/jobs/_shared/custom/env_config.py application/jobs/_shared/custom/threedcnn_ptl.py application/jobs/_shared/custom/data/datamodules/datamodule.py application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py`
- `.venv/bin/python -m pytest tests/unit_tests/test_env_config.py tests/unit_tests/test_data_module.py`

## Validation Status
- [x] Deploy branch image + startup kit to `dd-dl2`
- [x] Large synthetic ODELIA-style validation on `dd-dl2` (`10,240` replicated UIDs): cold `Data hash` completed in `275.53s`, dataset setup succeeded, validation started cleanly, no watchdog-style lockup observed during the former startup bottleneck
- [x] Real mounted dataset preflight on `dd-dl2` via startup kit (`challenge_5pimed`): completed successfully
- [x] Real mounted dataset one-epoch local training on `dd-dl2` in direct Docker (`challenge_5pimed`): completed successfully

## TODO
- [ ] Make startup-kit `docker.sh --local_training` honor `--num_epochs` / `NUM_EPOCHS` instead of hardcoding `--env NUM_EPOCHS=100`
- [ ] Decide whether to share a stable scratch root for hash/preprocess caches across repeated local runs so cache hits persist between invocations