### PR TITLE
[codex] Add PR301 startup-kit deploy validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ deploy_sites_2node_test.conf
 deploy_sites_2node_stamp_test.conf
 deploy_sites_4node_test.conf
 deploy_sites_3node_test.conf
+deploy_sites_duke_iid.conf
 kit_live_sync/sync.conf
 scripts/deploy/distribute_data.conf
 

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 import torch
+import torch.multiprocessing as torch_mp
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint, Callback
 from pytorch_lightning.loggers import TensorBoardLogger
@@ -53,9 +54,16 @@ def _hexdigest_string(data: str) -> str:
 def configure_odelia_runtime(env_vars: dict, logger) -> None:
     thread_count = max(1, env_vars['odelia_threads_per_worker'])
     interop_threads = max(1, env_vars['odelia_interop_threads'])
+    sharing_strategy = os.environ.get("TORCH_MULTIPROCESSING_SHARING_STRATEGY", "file_system")
 
     for env_name in OMP_THREAD_ENV_VARS:
         os.environ[env_name] = str(thread_count)
+
+    if sharing_strategy:
+        try:
+            torch_mp.set_sharing_strategy(sharing_strategy)
+        except RuntimeError as exc:
+            logger.warning("Could not set torch multiprocessing sharing strategy to %s: %s", sharing_strategy, exc)
 
     torch.set_num_threads(thread_count)
     if hasattr(torch, "set_num_interop_threads"):
@@ -66,11 +74,12 @@ def configure_odelia_runtime(env_vars: dict, logger) -> None:
 
     logger.info(
         "ODELIA runtime controls — loader_workers=%s, hash_workers=%s, "
-        "threads_per_worker=%s, interop_threads=%s",
+        "threads_per_worker=%s, interop_threads=%s, torch_sharing_strategy=%s",
         env_vars['odelia_num_workers'],
         env_vars['odelia_hash_num_workers'],
         thread_count,
         interop_threads,
+        torch_mp.get_sharing_strategy(),
     )
 
 

--- a/application/provision/project_duke_iid_3site.yml
+++ b/application/provision/project_duke_iid_3site.yml
@@ -1,0 +1,41 @@
+api_version: 3
+name: odelia_duke_iid___REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS___model_test
+description: Duke IID 3-site swarm training (Cosmos server + admin; dl0=node_A, dl2=node_B, dl3=node_C)
+
+participants:
+  - name: dl3.tud.de
+    type: server
+    org: TUD
+    fed_learn_port: 8002
+    admin_port: 8003
+  - name: node_A
+    type: client
+    org: TUD
+  - name: node_B
+    type: client
+    org: TUD
+  - name: node_C
+    type: client
+    org: TUD
+  - name: jiefu.zhu@tu-dresden.de
+    type: admin
+    org: TUD
+    role: project_admin
+
+builders:
+  - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
+    args:
+      template_file: master_template.yml
+  - path: nvflare.lighter.impl.template.TemplateBuilder
+  - path: nvflare.lighter.impl.static_file.StaticFileBuilder
+    args:
+      config_folder: config
+      scheme: http
+      docker_image: jefftud/odelia:__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__
+      overseer_agent:
+        path: nvflare.ha.dummy_overseer_agent.DummyOverseerAgent
+        overseer_exists: false
+        args:
+          sp_end_point: dl3.tud.de:8002:8003
+  - path: nvflare.lighter.impl.cert.CertBuilder
+  - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -916,6 +916,7 @@ docker_cln_sh: |
   elif [ -n "$LOCAL_TRAINING" ]; then
       echo "[INFO] Local training using job: $JOB_NAME"
       trap _stop_live_sync EXIT INT TERM
+      export MEDISWARM_LOCAL_SYNC_START_TS="$(date +%s)"
       _start_live_sync local
       LOCAL_TRAINING_CONSOLE_LOG="$DIR/local_training_console_output.txt"
       : > "$LOCAL_TRAINING_CONSOLE_LOG"

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -917,8 +917,14 @@ docker_cln_sh: |
       echo "[INFO] Local training using job: $JOB_NAME"
       trap _stop_live_sync EXIT INT TERM
       _start_live_sync local
+      LOCAL_TRAINING_CONSOLE_LOG="$DIR/local_training_console_output.txt"
+      : > "$LOCAL_TRAINING_CONSOLE_LOG"
+      set +e
       docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training $DOCKER_IMAGE \
-      /bin/bash -c "/MediSwarm/application/jobs/${JOB_NAME}/app/custom/main.py"
+      /bin/bash -c "/MediSwarm/application/jobs/${JOB_NAME}/app/custom/main.py" 2>&1 | tee "$LOCAL_TRAINING_CONSOLE_LOG"
+      LOCAL_TRAINING_STATUS=${PIPESTATUS[0]}
+      set -e
+      exit "$LOCAL_TRAINING_STATUS"
 
   elif [ -n "$START_CLIENT" ]; then
       _start_live_sync swarm

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -796,7 +796,8 @@ docker_cln_sh: |
   fi
 
   CONTAINER_NAME=odelia_swarm_client_{~~client_name~~}___REPLACED_BY_CONTAINER_VERSION_IDENTIFIER_WHEN_BUILDING_DOCKER_IMAGE__
-  DOCKER_OPTIONS_A="--name=$CONTAINER_NAME --gpus=$GPU2USE -u $(id -u):$(id -g)"
+  DOCKER_NOFILE_LIMIT="${DOCKER_NOFILE_LIMIT:-65536}"
+  DOCKER_OPTIONS_A="--name=$CONTAINER_NAME --gpus=$GPU2USE --ulimit nofile=${DOCKER_NOFILE_LIMIT}:${DOCKER_NOFILE_LIMIT} -u $(id -u):$(id -g)"
   DOCKER_MOUNTS="-v /etc/passwd:/etc/passwd -v /etc/group:/etc/group -v $DIR/..:/startupkit/ -v $MY_SCRATCH_DIR:/scratch/"
   if [ -n "$MY_DATA_DIR" ]; then
       DOCKER_MOUNTS+=" -v $MY_DATA_DIR:/data/:ro"
@@ -817,6 +818,7 @@ docker_cln_sh: |
             --env NUM_EPOCHS=${CLI_NUM_EPOCHS:-${NUM_EPOCHS:-100}} \
             --env CONFIG=${CLI_CONFIG:-${CONFIG:-unilateral}} \
             --env MEDISWARM_VERSION=__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_DOCKER_IMAGE__ \
+            --env TORCH_MULTIPROCESSING_SHARING_STRATEGY=${TORCH_MULTIPROCESSING_SHARING_STRATEGY:-file_system} \
             --env NVFLARE_TENSOR_MIN_DOWNLOAD_TIMEOUT=1800"
   # ↑ NVFLARE_TENSOR_MIN_DOWNLOAD_TIMEOUT: overrides NVFlare's FOBS tensor
   #   streaming timeout (default 300s). Large models (689MB+) over VPN need

--- a/docs/DUKE_IID_STARTUPKIT_SMOKE_TEST.md
+++ b/docs/DUKE_IID_STARTUPKIT_SMOKE_TEST.md
@@ -1,0 +1,80 @@
+# Duke IID Startup Kit Full Deploy Smoke Test
+
+This smoke test validates startup kits and job wiring before partner
+distribution. It is not a model-selection run: all jobs are built with
+`num_rounds=2`, and prediction metrics are recorded only to prove inference can
+load each final global checkpoint.
+
+## Topology
+
+| Role | Machine | Site | Data |
+|------|---------|------|------|
+| Server + admin | Cosmos | `dl3.tud.de` server/admin kits | no training data |
+| Client | `dl0` | `node_A` | `/mnt/dlhd0/DUKE_iid` |
+| Client | `dl2` | `node_B` | `/mnt/sda1/DUKE_iid` |
+| Client | `dl3` | `node_C` | `/mnt/swarm_alpha/DUKE_iid` |
+| Eval host | `dl0` | `test`, ODELIA institutions | Duke + `/mnt/dlhd0/medswarmdata` |
+
+## One-command Run
+
+Run from a clean `main` checkout:
+
+```bash
+scripts/deploy/run_duke_iid_startupkit_smoke.sh \
+  --conf deploy_sites_duke_iid.conf \
+  --num-rounds 2
+```
+
+The wrapper performs:
+
+1. preflight checks for branch, local Docker, remote SSH/Docker/GPU/data paths;
+2. Docker image + startup-kit build with `--num-rounds 2`;
+3. `docker push jefftud/odelia:<version>`;
+4. distributed startup-kit deployment and all six admin-submitted jobs via
+   `run_deploy_test.sh --skip-eval`;
+5. `dl0` prediction smoke evaluation on Duke test and ODELIA institutions;
+6. Markdown + JSON reports under
+   `workspace/deploy_test_results/startupkit_smoke_<timestamp>/`.
+
+The underlying build script uses `git archive HEAD` and refuses tracked local
+changes, so commit or stash tracked edits before running the full wrapper.
+
+## Manual Steps
+
+If you need to split the run:
+
+```bash
+bash scripts/build/buildDockerImageAndStartupKits.sh \
+  -p application/provision/project_duke_iid_3site.yml \
+  --num-rounds 2
+
+docker push jefftud/odelia:$(scripts/build/getVersionNumber.sh)
+
+RUN_DIR=workspace/deploy_test_results/startupkit_smoke_$(date -u +%Y%m%dT%H%M%SZ)
+
+scripts/deploy/run_deploy_test.sh \
+  --all \
+  --conf deploy_sites_duke_iid.conf \
+  --skip-eval \
+  --results-dir "$RUN_DIR/training"
+
+scripts/deploy/run_startupkit_smoke_eval_dl0.sh \
+  --conf deploy_sites_duke_iid.conf \
+  --checkpoint-root "$RUN_DIR/training" \
+  --output-dir "$RUN_DIR/eval" \
+  --image jefftud/odelia:$(scripts/build/getVersionNumber.sh)
+```
+
+## Pass Criteria
+
+- Server, admin, and `node_A/node_B/node_C` startup kits are generated and used.
+- All six jobs are submitted via admin `submit_job`.
+- All three clients register for every job.
+- Every job completes two rounds without fatal NVFlare errors.
+- Every model has exactly three `FL_global_model.pt` files.
+- The three final global checkpoints for each model have identical md5 hashes.
+- `predict.py` on `dl0` produces prediction outputs for Duke test plus
+  `CAM`, `MHA`, `RSH`, `RUMC`, `UKA`, and `UMCU`.
+
+The final report is `RUN.md`; training details are in `training/summary.json`,
+and prediction smoke details are in `eval/summary.json` plus `eval/REPORT.md`.

--- a/kit_live_sync/live_sync.sh
+++ b/kit_live_sync/live_sync.sh
@@ -118,14 +118,18 @@ find_latest_local_run_name() {
   if [ -n "$SCRATCHDIR" ]; then
     base="$SCRATCHDIR/runs/$SITE_NAME"
     if [ -d "$base" ]; then
-      result="$(find "$base" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's#.*/##' | sort | tail -n 1 || true)"
+      result="$(find "$base" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %f\n' 2>/dev/null | \
+        awk -v min_ts="${MEDISWARM_LOCAL_SYNC_START_TS:-0}" '$1 >= min_ts {print $2}' | \
+        sort | tail -n 1 || true)"
     fi
   fi
   # Fall back to startup dir (backward compatibility with older builds)
   if [ -z "$result" ]; then
     base="$STARTUP_DIR/runs/$SITE_NAME"
     if [ -d "$base" ]; then
-      result="$(find "$base" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's#.*/##' | sort | tail -n 1 || true)"
+      result="$(find "$base" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %f\n' 2>/dev/null | \
+        awk -v min_ts="${MEDISWARM_LOCAL_SYNC_START_TS:-0}" '$1 >= min_ts {print $2}' | \
+        sort | tail -n 1 || true)"
     fi
   fi
   printf '%s' "$result"

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -2,29 +2,28 @@
 # ============================================================================
 # run_deploy_test.sh — Orchestrate multi-site ODELIA deploy tests
 #
-# Runs all 6 ODELIA models through a full federated training + evaluation
-# cycle across 3 physical machines connected via Tailscale VPN, with
-# Cosmos as the server/admin node (no training client on Cosmos).
+# Runs all 6 ODELIA models through a federated startup-kit deploy test across
+# physical machines connected via Tailscale VPN, with Cosmos as the server/admin
+# node (no training client on Cosmos).
 #
 # Architecture:
 #   Cosmos (localhost) — NVFlare server + admin only
-#   dl0                — RUMC_1 client
-#   dl2                — MHA_1 client
-#   dl3                — CAM_1 + UMCU_1 clients (2 clients on one machine)
+#   clients            — configured by CLIENT_SITES in the deploy_sites*.conf
 #
 # For each model:
 #   1. Stop any lingering containers (local + remote)
 #   2. Start the NVFlare server on Cosmos
-#   3. Start 4 training clients on the remote machines
+#   3. Start configured training clients on the remote machines
 #   4. Submit the corresponding training job via admin
 #   5. Poll for training completion (Server runner finished)
 #   6. Stop all containers
-#   7. Evaluate the final global model on UKA_1 (held-out test site)
+#   7. Optionally evaluate the final global model on the configured eval site
 #   8. Record pass/fail + metrics
 #
 # Usage:
 #   ./scripts/deploy/run_deploy_test.sh --all --conf deploy_sites_4node_test.conf
 #   ./scripts/deploy/run_deploy_test.sh --model MST --job ODELIA_ternary_classification --conf deploy_sites_4node_test.conf
+#   ./scripts/deploy/run_deploy_test.sh --all --conf deploy_sites_duke_iid.conf --skip-eval --results-dir workspace/deploy_test_results/startupkit_smoke_<ts>/training
 #
 # The Docker image and startup kits must be built BEFORE running this script:
 #   ./scripts/build/buildDockerImageAndStartupKits.sh -p application/provision/project_deploy_test_4site.yml
@@ -55,6 +54,8 @@ SINGLE_MODEL=""
 SINGLE_JOB=""
 CONF_FILE=""
 SKIP_BUILD=false
+SKIP_EVAL=false
+RESULTS_DIR_OVERRIDE=""
 TIMEOUT_MINUTES=10080   # Per-model training timeout (7 days)
 
 while [[ $# -gt 0 ]]; do
@@ -64,9 +65,11 @@ while [[ $# -gt 0 ]]; do
         --job)          SINGLE_JOB="$2"; shift ;;
         --conf)         CONF_FILE="$2"; shift ;;
         --skip-build)   SKIP_BUILD=true ;;
+        --skip-eval)    SKIP_EVAL=true ;;
+        --results-dir)  RESULTS_DIR_OVERRIDE="$2"; shift ;;
         --timeout)      TIMEOUT_MINUTES="$2"; shift ;;
         -h|--help)
-            echo "Usage: $0 [--all | --model NAME --job JOB_DIR] --conf CONF_FILE [--skip-build] [--timeout MINUTES]"
+            echo "Usage: $0 [--all | --model NAME --job JOB_DIR] --conf CONF_FILE [--skip-build] [--skip-eval] [--results-dir DIR] [--timeout MINUTES]"
             exit 0
             ;;
         *)
@@ -103,6 +106,7 @@ fi
 source "$CONF_FILE"
 
 VERSION=$("$REPO_ROOT/scripts/build/getVersionNumber.sh")
+GIT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 DOCKER_IMAGE="jefftud/odelia:$VERSION"
 
 PROJECT_NAME=$(grep "^name: " "$REPO_ROOT/$PROJECT_FILE" \
@@ -116,8 +120,20 @@ SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLeve
 DEPLOY_BASE="${COSMOS_DEPLOY_DIR:-/home/jeff/deploy_test}"
 
 # Results directory
-RESULTS_DIR="$REPO_ROOT/workspace/deploy_test_results"
+if [[ -n "$RESULTS_DIR_OVERRIDE" ]]; then
+    if [[ "$RESULTS_DIR_OVERRIDE" = /* ]]; then
+        RESULTS_DIR="$RESULTS_DIR_OVERRIDE"
+    else
+        RESULTS_DIR="$REPO_ROOT/$RESULTS_DIR_OVERRIDE"
+    fi
+else
+    RESULTS_DIR="$REPO_ROOT/workspace/deploy_test_results"
+fi
 mkdir -p "$RESULTS_DIR"
+
+# Updated by collect_checkpoints() so result JSON can record the run that was
+# actually evaluated/collected.
+LAST_JOB_ID=""
 
 # ── All 6 ODELIA models ───────────────────────────────────────────────────
 # Format: JOB_DIR:MODEL_NAME
@@ -457,6 +473,30 @@ start_clients() {
     ok "All clients started"
 }
 
+# ── Verify model selection made it into each client container ─────────────
+verify_client_model_env() {
+    local model_name="$1"
+    [[ -z "$model_name" ]] && return 0
+
+    info "Verifying client containers use MODEL_NAME=$model_name"
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name host
+        site_name=$(site_var "$site" SITE_NAME)
+        host=$(site_var "$site" HOST)
+
+        remote_exec "$site" "
+            container=\$(docker ps --filter 'name=odelia_swarm_client_${site_name}_' --format '{{.Names}}' | head -1)
+            test -n \"\$container\"
+            docker inspect \"\$container\" --format '{{range .Config.Env}}{{println .}}{{end}}' \
+                | grep -Fx 'MODEL_NAME=$model_name' >/dev/null
+        " || {
+            err "MODEL_NAME=$model_name not found in running client container for $site_name @ $host"
+            return 1
+        }
+        ok "  $site_name container has MODEL_NAME=$model_name"
+    done
+}
+
 # ── Wait for all clients to register with the server ─────────────────────
 wait_for_client_registration() {
     resolve_server_startup_dir
@@ -741,6 +781,7 @@ collect_checkpoints() {
     else
         info "Job ID from server log: $job_id"
     fi
+    LAST_JOB_ID="$job_id"
 
     # Staging directory on Cosmos for collected checkpoints
     local staging_dir="$RESULTS_DIR/${model_name}_checkpoints"
@@ -900,6 +941,8 @@ record_result() {
     local train_status="$3"   # pass or fail
     local eval_status="$4"    # pass, fail, or skipped
     local duration_seconds="$5"
+    local checkpoint_status="${6:-skipped}"  # pass, fail, or skipped
+    local job_id="${7:-$LAST_JOB_ID}"
 
     local result_file="$RESULTS_DIR/deploy_test_${model_name}.json"
     local timestamp
@@ -909,12 +952,17 @@ record_result() {
 {
     "model_name": "$model_name",
     "job_name": "$job_name",
+    "job_id": "$job_id",
     "training_status": "$train_status",
     "evaluation_status": "$eval_status",
+    "checkpoint_status": "$checkpoint_status",
     "duration_seconds": $duration_seconds,
     "timestamp": "$timestamp",
     "docker_image": "$DOCKER_IMAGE",
     "version": "$VERSION",
+    "git_sha": "$GIT_SHA",
+    "project_file": "$PROJECT_FILE",
+    "workspace_dir": "$WORKSPACE_DIR",
     "client_sites": $(printf '%s\n' "${CLIENT_SITES[@]}" | jq -R . | jq -s .)
 }
 EOF
@@ -936,13 +984,16 @@ _run_training_attempt() {
     # 3. Start clients on remote machines
     start_clients "$model_name"
 
-    # 4. Wait for ALL clients to register with the server
+    # 4. Verify the selected model was propagated to every client container
+    verify_client_model_env "$model_name"
+
+    # 5. Wait for ALL clients to register with the server
     wait_for_client_registration
 
-    # 5. Submit job via admin on Cosmos
+    # 6. Submit job via admin on Cosmos
     submit_job "$job_name"
 
-    # 6. Wait for training completion
+    # 7. Wait for training completion
     if wait_for_completion "$model_name"; then
         return 0
     else
@@ -969,6 +1020,8 @@ run_single_model() {
 
     local train_status="fail"
     local eval_status="skipped"
+    local checkpoint_status="skipped"
+    LAST_JOB_ID=""
 
     # Retry loop: transient failures (e.g. worker process race on dl3
     # when two NVFlare clients share the same machine) resolve on restart.
@@ -995,12 +1048,25 @@ run_single_model() {
     # Stop containers after training (pass or final failure)
     stop_all
 
-    # Evaluate on UKA_1 (only if training passed)
+    # Evaluate on UKA_1 by default. In startup-kit smoke mode, skip the legacy
+    # Cosmos/UKA evaluation but still collect checkpoints for the dl0 smoke
+    # evaluation script.
     if [[ "$train_status" == "pass" ]]; then
-        if evaluate_model "$model_name" "$job_name"; then
-            eval_status="pass"
+        if [[ "$SKIP_EVAL" == true ]]; then
+            info "Skipping built-in evaluation for $model_name (--skip-eval); collecting checkpoints only"
+            if collect_checkpoints "$model_name" >/dev/null; then
+                checkpoint_status="pass"
+            else
+                checkpoint_status="fail"
+            fi
         else
-            eval_status="fail"
+            if evaluate_model "$model_name" "$job_name"; then
+                eval_status="pass"
+                checkpoint_status="pass"
+            else
+                eval_status="fail"
+                checkpoint_status="fail"
+            fi
         fi
     else
         warn "Skipping evaluation for $model_name — training did not complete"
@@ -1012,13 +1078,15 @@ run_single_model() {
     end_time=$(date +%s)
     local duration=$(( end_time - start_time ))
 
-    record_result "$model_name" "$job_name" "$train_status" "$eval_status" "$duration"
+    record_result "$model_name" "$job_name" "$train_status" "$eval_status" "$duration" "$checkpoint_status" "$LAST_JOB_ID"
 
     echo ""
     if [[ "$train_status" == "pass" && "$eval_status" == "pass" ]]; then
         ok "PASSED: $model_name (training + evaluation) in ${duration}s"
+    elif [[ "$train_status" == "pass" && "$SKIP_EVAL" == true && "$checkpoint_status" == "pass" ]]; then
+        ok "PASSED: $model_name (training + checkpoint collection; evaluation skipped) in ${duration}s"
     elif [[ "$train_status" == "pass" ]]; then
-        warn "PARTIAL: $model_name (training passed, evaluation $eval_status) in ${duration}s"
+        warn "PARTIAL: $model_name (training passed, evaluation $eval_status, checkpoints $checkpoint_status) in ${duration}s"
     else
         err "FAILED: $model_name (training $train_status) in ${duration}s"
     fi
@@ -1040,18 +1108,19 @@ generate_summary() {
         [[ -f "$result_file" ]] || continue
         total=$((total + 1))
 
-        local model train eval_stat duration
+        local model train eval_stat checkpoint_stat duration
         model=$(jq -r '.model_name' "$result_file")
         train=$(jq -r '.training_status' "$result_file")
         eval_stat=$(jq -r '.evaluation_status' "$result_file")
+        checkpoint_stat=$(jq -r '.checkpoint_status // "skipped"' "$result_file")
         duration=$(jq -r '.duration_seconds' "$result_file")
 
-        if [[ "$train" == "pass" && "$eval_stat" == "pass" ]]; then
+        if [[ "$train" == "pass" && ( "$eval_stat" == "pass" || ( "$eval_stat" == "skipped" && "$checkpoint_stat" == "pass" ) ) ]]; then
             passed=$((passed + 1))
             echo -e "  ${GREEN}PASS${NC}  $model (${duration}s)"
         else
             failed=$((failed + 1))
-            echo -e "  ${RED}FAIL${NC}  $model (train=$train, eval=$eval_stat, ${duration}s)"
+            echo -e "  ${RED}FAIL${NC}  $model (train=$train, eval=$eval_stat, checkpoints=$checkpoint_stat, ${duration}s)"
         fi
     done
 
@@ -1067,7 +1136,13 @@ generate_summary() {
     "passed": $passed,
     "failed": $failed,
     "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-    "version": "$VERSION"
+    "version": "$VERSION",
+    "docker_image": "$DOCKER_IMAGE",
+    "git_sha": "$GIT_SHA",
+    "project_file": "$PROJECT_FILE",
+    "workspace_dir": "$WORKSPACE_DIR",
+    "results_dir": "$RESULTS_DIR",
+    "evaluation_skipped": $SKIP_EVAL
 }
 EOF
 

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -108,7 +108,7 @@ source "$CONF_FILE"
 VERSION=$("$REPO_ROOT/scripts/build/getVersionNumber.sh")
 GIT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 DOCKER_IMAGE="jefftud/odelia:$VERSION"
-NVFLARE_CONTAINER_RE='odelia_swarm|nvflare|^swarm-[[:alnum:]_.-]+-(server|client|admin)$'
+NVFLARE_CONTAINER_RE='odelia_swarm|nvflare|^swarm-'
 
 PROJECT_NAME=$(grep "^name: " "$REPO_ROOT/$PROJECT_FILE" \
     | sed 's/^name: //' \
@@ -300,7 +300,7 @@ stop_all() {
         fi
         visited_hosts[$host]=1
         remote_exec "$site" \
-            "docker ps -a --format '{{.Names}}' | grep -E 'odelia_swarm|nvflare|^swarm-[[:alnum:]_.-]+-(server|client|admin)$' | xargs -r docker rm -f 2>/dev/null" \
+            "docker ps -a --format '{{.Names}}' | grep -E 'odelia_swarm|nvflare|^swarm-' | xargs -r docker rm -f 2>/dev/null" \
             2>/dev/null || warn "  Could not stop containers on $host"
     done
 

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -108,6 +108,7 @@ source "$CONF_FILE"
 VERSION=$("$REPO_ROOT/scripts/build/getVersionNumber.sh")
 GIT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 DOCKER_IMAGE="jefftud/odelia:$VERSION"
+NVFLARE_CONTAINER_RE='odelia_swarm|nvflare|^swarm-[[:alnum:]_.-]+-(server|client|admin)$'
 
 PROJECT_NAME=$(grep "^name: " "$REPO_ROOT/$PROJECT_FILE" \
     | sed 's/^name: //' \
@@ -283,9 +284,8 @@ stop_all() {
 
     # Stop local containers on Cosmos (server + admin)
     local local_containers
-    local_containers=$(docker ps --format '{{.Names}}' | grep -E "odelia_swarm|nvflare" || true)
+    local_containers=$(docker ps -a --format '{{.Names}}' | grep -E "$NVFLARE_CONTAINER_RE" || true)
     if [[ -n "$local_containers" ]]; then
-        echo "$local_containers" | xargs docker kill 2>/dev/null || true
         echo "$local_containers" | xargs docker rm -f 2>/dev/null || true
     fi
 
@@ -300,8 +300,7 @@ stop_all() {
         fi
         visited_hosts[$host]=1
         remote_exec "$site" \
-            "docker ps --format '{{.Names}}' | grep -E 'odelia_swarm|nvflare' | xargs -r docker kill 2>/dev/null; \
-             docker ps -a --format '{{.Names}}' | grep -E 'odelia_swarm|nvflare' | xargs -r docker rm -f 2>/dev/null" \
+            "docker ps -a --format '{{.Names}}' | grep -E 'odelia_swarm|nvflare|^swarm-[[:alnum:]_.-]+-(server|client|admin)$' | xargs -r docker rm -f 2>/dev/null" \
             2>/dev/null || warn "  Could not stop containers on $host"
     done
 
@@ -322,6 +321,21 @@ stop_all() {
     # Wait for containers to fully stop
     sleep 5
     ok "All containers stopped"
+}
+
+clean_local_deploy_dir() {
+    local dir_name=$1
+    local target="$DEPLOY_BASE/$dir_name"
+
+    [[ -e "$target" ]] || return 0
+    rm -rf "$target" 2>/dev/null \
+        || sudo rm -rf "$target" 2>/dev/null \
+        || docker run --rm -v "$DEPLOY_BASE:/cleanup" alpine \
+            rm -rf "/cleanup/$dir_name" 2>/dev/null \
+        || {
+            warn "Could not fully clean $target (root-owned files may remain)"
+            return 1
+        }
 }
 
 # ── Pre-pull Docker image on all remote machines ─────────────────────────
@@ -387,7 +401,8 @@ deploy_kits() {
     if [[ -n "$server_zip" && -f "$server_zip" ]]; then
         mkdir -p "$DEPLOY_BASE"
         cp "$server_zip" "$DEPLOY_BASE/"
-        cd "$DEPLOY_BASE" && rm -rf "$server_name" && unzip -qo "$(basename "$server_zip")"
+        clean_local_deploy_dir "$server_name"
+        cd "$DEPLOY_BASE" && unzip -qo "$(basename "$server_zip")"
         cd "$REPO_ROOT"
         ok "  Deployed server kit ($server_name) locally on Cosmos"
     fi
@@ -399,7 +414,8 @@ deploy_kits() {
     fi
     if [[ -n "$admin_zip" && -f "$admin_zip" ]]; then
         cp "$admin_zip" "$DEPLOY_BASE/"
-        cd "$DEPLOY_BASE" && rm -rf "$ADMIN_USER" && unzip -qo "$(basename "$admin_zip")"
+        clean_local_deploy_dir "$ADMIN_USER"
+        cd "$DEPLOY_BASE" && unzip -qo "$(basename "$admin_zip")"
         cd "$REPO_ROOT"
         ok "  Deployed admin kit ($ADMIN_USER) locally on Cosmos"
     fi
@@ -433,7 +449,7 @@ start_server() {
     info "Waiting 15s for server to initialize..."
     sleep 15
 
-    if docker ps --format '{{.Names}}' | grep -qE "odelia_swarm|nvflare"; then
+    if docker ps --format '{{.Names}}' | grep -qE "$NVFLARE_CONTAINER_RE"; then
         ok "Server container is running"
     else
         warn "Server container not detected — it may still be starting"
@@ -723,7 +739,7 @@ wait_for_completion() {
         fi
 
         # Also check if the server container died
-        if ! docker ps --format '{{.Names}}' | grep -qE "odelia_swarm|nvflare"; then
+        if ! docker ps --format '{{.Names}}' | grep -qE "$NVFLARE_CONTAINER_RE"; then
             # Container is gone — do a final check on the log
             if [[ -f "$server_log" ]]; then
                 local new_lines

--- a/scripts/deploy/run_duke_iid_startupkit_smoke.sh
+++ b/scripts/deploy/run_duke_iid_startupkit_smoke.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# run_duke_iid_startupkit_smoke.sh — End-to-end startup-kit smoke test for the
+# Duke IID 3-client topology.
+#
+# This validates workflow mechanics, not model quality:
+#   build image + startup kits with num_rounds=2
+#   push image
+#   deploy server/admin/client kits
+#   submit all six ODELIA jobs through the admin kit
+#   collect final global checkpoints
+#   run dl0 prediction smoke tests on Duke + ODELIA data
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
+err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+step()  { echo -e "\n${BOLD}=== $* ===${NC}" >&2; }
+
+CONF_FILE="$REPO_ROOT/deploy_sites_duke_iid.conf"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RESULTS_ROOT="$REPO_ROOT/workspace/deploy_test_results/startupkit_smoke_$RUN_ID"
+TIMEOUT_MINUTES=10080
+NUM_ROUNDS=2
+SKIP_BUILD=false
+SKIP_PUSH=false
+USE_DOCKER_CACHE=false
+ALLOW_NON_MAIN=false
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --conf FILE            Deploy-site configuration file (default: deploy_sites_duke_iid.conf)
+  --results-root DIR     Top-level output directory
+  --timeout MINUTES      Per-model training timeout for run_deploy_test.sh
+  --num-rounds N         Federated rounds to inject into all jobs (default: 2)
+  --skip-build           Reuse existing image/startup kits
+  --skip-push            Do not docker push the image
+  --use-docker-cache     Pass --use-docker-cache to the build script
+  --allow-non-main       Do not fail if current branch is not main
+  -h, --help             Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --conf)             CONF_FILE="$2"; shift ;;
+        --results-root)     RESULTS_ROOT="$2"; shift ;;
+        --timeout)          TIMEOUT_MINUTES="$2"; shift ;;
+        --num-rounds)       NUM_ROUNDS="$2"; shift ;;
+        --skip-build)       SKIP_BUILD=true ;;
+        --skip-push)        SKIP_PUSH=true ;;
+        --use-docker-cache) USE_DOCKER_CACHE=true ;;
+        --allow-non-main)   ALLOW_NON_MAIN=true ;;
+        -h|--help)          usage; exit 0 ;;
+        *)                  err "Unknown argument: $1"; usage; exit 1 ;;
+    esac
+    shift
+done
+
+resolve_path() {
+    local p="$1"
+    if [[ "$p" = /* ]]; then
+        printf '%s\n' "$p"
+    else
+        printf '%s/%s\n' "$REPO_ROOT" "$p"
+    fi
+}
+
+CONF_FILE="$(resolve_path "$CONF_FILE")"
+RESULTS_ROOT="$(resolve_path "$RESULTS_ROOT")"
+
+if [[ ! -f "$CONF_FILE" ]]; then
+    err "Configuration file not found: $CONF_FILE"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$CONF_FILE"
+
+VERSION="$("$REPO_ROOT/scripts/build/getVersionNumber.sh")"
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+BRANCH="$(git -C "$REPO_ROOT" branch --show-current)"
+DOCKER_IMAGE="jefftud/odelia:$VERSION"
+PROJECT_FILE="${PROJECT_FILE:?PROJECT_FILE must be set in $CONF_FILE}"
+
+TRAINING_RESULTS_DIR="$RESULTS_ROOT/training"
+EVAL_RESULTS_DIR="$RESULTS_ROOT/eval"
+mkdir -p "$TRAINING_RESULTS_DIR" "$EVAL_RESULTS_DIR"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+site_var() {
+    local site="$1" var="$2"
+    local full_var="${site}_${var}"
+    echo "${!full_var}"
+}
+
+remote_exec_site() {
+    local site="$1"; shift
+    local host user pass
+    host="$(site_var "$site" HOST)"
+    user="$(site_var "$site" USER)"
+    pass="$(site_var "$site" PASS)"
+    if [[ -n "$pass" ]]; then
+        sshpass -p "$pass" ssh $SSH_OPTS "$user@$host" "$@"
+    else
+        ssh $SSH_OPTS "$user@$host" "$@"
+    fi
+}
+
+step "Preflight"
+if [[ "$BRANCH" != "main" && "$ALLOW_NON_MAIN" != true ]]; then
+    err "Current branch is '$BRANCH', expected 'main'. Use --allow-non-main to override."
+    exit 1
+fi
+ok "Branch: $BRANCH ($GIT_SHA)"
+
+for cmd in docker sshpass jq expect; do
+    command -v "$cmd" >/dev/null || { err "Missing required command: $cmd"; exit 1; }
+done
+docker info >/dev/null
+ok "Local Docker is available"
+
+for site in "${CLIENT_SITES[@]}"; do
+    site_name="$(site_var "$site" SITE_NAME)"
+    datadir="$(site_var "$site" DATADIR)"
+    scratchdir="$(site_var "$site" SCRATCHDIR)"
+    info "Checking $site_name data/GPU/Docker"
+    remote_exec_site "$site" "command -v docker >/dev/null && nvidia-smi >/dev/null && test -d '$datadir' && mkdir -p '$scratchdir'"
+    ok "$site_name preflight passed"
+done
+
+remote_exec_site "DL0" "test -d '${DL0_DUKE_DATA:-/mnt/dlhd0/DUKE_iid}' && test -d '${DL0_ODELIA_DATA:-/mnt/dlhd0/medswarmdata}'"
+ok "dl0 evaluation data paths are present"
+
+if [[ "$SKIP_BUILD" != true ]]; then
+    step "Build Docker image and startup kits"
+    build_args=("-p" "$PROJECT_FILE" "--num-rounds" "$NUM_ROUNDS")
+    if [[ "$USE_DOCKER_CACHE" == true ]]; then
+        build_args+=("--use-docker-cache")
+    fi
+    (cd "$REPO_ROOT" && bash scripts/build/buildDockerImageAndStartupKits.sh "${build_args[@]}")
+else
+    warn "Skipping build; reusing existing startup kits/image for $DOCKER_IMAGE"
+fi
+
+if [[ "$SKIP_PUSH" != true ]]; then
+    step "Push Docker image"
+    docker push "$DOCKER_IMAGE"
+    ok "Pushed $DOCKER_IMAGE"
+else
+    warn "Skipping docker push for $DOCKER_IMAGE"
+fi
+
+step "Train all six models through distributed startup kits"
+"$REPO_ROOT/scripts/deploy/run_deploy_test.sh" \
+    --all \
+    --conf "$CONF_FILE" \
+    --skip-eval \
+    --results-dir "$TRAINING_RESULTS_DIR" \
+    --timeout "$TIMEOUT_MINUTES"
+
+step "Run dl0 prediction smoke evaluation"
+"$REPO_ROOT/scripts/deploy/run_startupkit_smoke_eval_dl0.sh" \
+    --conf "$CONF_FILE" \
+    --checkpoint-root "$TRAINING_RESULTS_DIR" \
+    --output-dir "$EVAL_RESULTS_DIR" \
+    --image "$DOCKER_IMAGE"
+
+{
+    echo "# Duke IID Startup Kit Full Deploy Smoke Test"
+    echo ""
+    echo "- Run ID: \`$RUN_ID\`"
+    echo "- Status: \`pass\`"
+    echo "- Branch: \`$BRANCH\`"
+    echo "- Git SHA: \`$GIT_SHA\`"
+    echo "- Docker image: \`$DOCKER_IMAGE\`"
+    echo "- Federated rounds: \`$NUM_ROUNDS\`"
+    echo "- Config: \`$CONF_FILE\`"
+    echo "- Training summary: \`$TRAINING_RESULTS_DIR/summary.json\`"
+    echo "- Eval summary: \`$EVAL_RESULTS_DIR/summary.json\`"
+    echo "- Eval report: \`$EVAL_RESULTS_DIR/REPORT.md\`"
+} > "$RESULTS_ROOT/RUN.md"
+
+ok "Full startup-kit smoke test passed. Report: $RESULTS_ROOT/RUN.md"

--- a/scripts/deploy/run_startupkit_smoke_eval_dl0.sh
+++ b/scripts/deploy/run_startupkit_smoke_eval_dl0.sh
@@ -154,6 +154,7 @@ run_predict_on_dl0() {
     if remote_exec "
         docker run --rm \
             --gpus='$DL0_GPU' \
+            --ulimit nofile=65536:65536 \
             --net=host --ipc=host \
             -v '$data_dir:/data:ro' \
             -v '$remote_ckpt_dir:/workspace:ro' \
@@ -164,6 +165,7 @@ run_predict_on_dl0() {
             --env MODEL_NAME='$model' \
             --env TORCH_HOME=/torch_home \
             --env CONFIG=unilateral \
+            --env TORCH_MULTIPROCESSING_SHARING_STRATEGY=file_system \
             '$DOCKER_IMAGE' \
             python3 /MediSwarm/scripts/evaluation/predict.py \
                 --checkpoint /workspace/FL_global_model.pt \

--- a/scripts/deploy/run_startupkit_smoke_eval_dl0.sh
+++ b/scripts/deploy/run_startupkit_smoke_eval_dl0.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# run_startupkit_smoke_eval_dl0.sh — Validate collected startup-kit smoke
+# checkpoints and run post-training prediction smoke tests on dl0.
+#
+# Expected input:
+#   <checkpoint-root>/<MODEL>_checkpoints/app_<SITE>/FL_global_model.pt
+#
+# Typical use:
+#   scripts/deploy/run_startupkit_smoke_eval_dl0.sh \
+#       --conf deploy_sites_duke_iid.conf \
+#       --checkpoint-root workspace/deploy_test_results/startupkit_smoke_<ts>/training \
+#       --output-dir workspace/deploy_test_results/startupkit_smoke_<ts>/eval
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
+err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+step()  { echo -e "\n${BOLD}=== $* ===${NC}" >&2; }
+
+CONF_FILE="$REPO_ROOT/deploy_sites_duke_iid.conf"
+CHECKPOINT_ROOT="$REPO_ROOT/workspace/deploy_test_results"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTPUT_DIR="$REPO_ROOT/workspace/deploy_test_results/startupkit_smoke_${RUN_ID}/eval"
+DOCKER_IMAGE=""
+REMOTE_STAGE=""
+MODELS_CSV=""
+ODELIA_SITES_CSV="CAM,MHA,RSH,RUMC,UKA,UMCU"
+
+usage() {
+    cat <<EOF
+Usage: $0 --conf FILE --checkpoint-root DIR [options]
+
+Options:
+  --conf FILE              Deploy-site configuration file (default: deploy_sites_duke_iid.conf)
+  --checkpoint-root DIR    Directory containing <MODEL>_checkpoints dirs
+  --output-dir DIR         Local output directory for reports/predictions
+  --image IMAGE            Docker image to run on dl0 (default: jefftud/odelia:<current version>)
+  --remote-stage DIR       dl0 staging dir (default: <DL0_SCRATCHDIR>/startupkit_smoke_eval/<run_id>)
+  --models CSV             Models to evaluate (default: all six deploy-test models)
+  --odelia-sites CSV       ODELIA institutions (default: CAM,MHA,RSH,RUMC,UKA,UMCU)
+  -h, --help               Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --conf)            CONF_FILE="$2"; shift ;;
+        --checkpoint-root) CHECKPOINT_ROOT="$2"; shift ;;
+        --output-dir)      OUTPUT_DIR="$2"; shift ;;
+        --image)           DOCKER_IMAGE="$2"; shift ;;
+        --remote-stage)    REMOTE_STAGE="$2"; shift ;;
+        --models)          MODELS_CSV="$2"; shift ;;
+        --odelia-sites)    ODELIA_SITES_CSV="$2"; shift ;;
+        -h|--help)         usage; exit 0 ;;
+        *)                 err "Unknown argument: $1"; usage; exit 1 ;;
+    esac
+    shift
+done
+
+resolve_path() {
+    local p="$1"
+    if [[ "$p" = /* ]]; then
+        printf '%s\n' "$p"
+    else
+        printf '%s/%s\n' "$REPO_ROOT" "$p"
+    fi
+}
+
+CONF_FILE="$(resolve_path "$CONF_FILE")"
+CHECKPOINT_ROOT="$(resolve_path "$CHECKPOINT_ROOT")"
+OUTPUT_DIR="$(resolve_path "$OUTPUT_DIR")"
+
+if [[ ! -f "$CONF_FILE" ]]; then
+    err "Configuration file not found: $CONF_FILE"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$CONF_FILE"
+
+VERSION="$("$REPO_ROOT/scripts/build/getVersionNumber.sh")"
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+DOCKER_IMAGE="${DOCKER_IMAGE:-jefftud/odelia:$VERSION}"
+DL0_SCRATCHDIR="${DL0_SCRATCHDIR:-/mnt/dlhd0/deploy_test_duke_iid}"
+REMOTE_STAGE="${REMOTE_STAGE:-$DL0_SCRATCHDIR/startupkit_smoke_eval/$RUN_ID}"
+
+IFS=',' read -r -a MODELS <<< "${MODELS_CSV:-MST,1DivideAndConquer,2BCN_AIM,3agaldran,4LME_ABMIL,5Pimed}"
+IFS=',' read -r -a ODELIA_SITES <<< "$ODELIA_SITES_CSV"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+DL0_HOST="${DL0_HOST:?DL0_HOST must be set in $CONF_FILE}"
+DL0_USER="${DL0_USER:?DL0_USER must be set in $CONF_FILE}"
+DL0_PASS="${DL0_PASS:-}"
+DL0_DUKE_DATA="${DL0_DUKE_DATA:-/mnt/dlhd0/DUKE_iid}"
+DL0_ODELIA_DATA="${DL0_ODELIA_DATA:-/mnt/dlhd0/medswarmdata}"
+DL0_GPU="${DL0_GPU:-device=0}"
+
+mkdir -p "$OUTPUT_DIR"
+: > "$OUTPUT_DIR/model_results.jsonl"
+
+remote_exec() {
+    if [[ -n "$DL0_PASS" ]]; then
+        sshpass -p "$DL0_PASS" ssh $SSH_OPTS "$DL0_USER@$DL0_HOST" "$@"
+    else
+        ssh $SSH_OPTS "$DL0_USER@$DL0_HOST" "$@"
+    fi
+}
+
+remote_copy_to() {
+    local src="$1" dst="$2"
+    if [[ -n "$DL0_PASS" ]]; then
+        sshpass -p "$DL0_PASS" scp $SSH_OPTS "$src" "$DL0_USER@$DL0_HOST:$dst"
+    else
+        scp $SSH_OPTS "$src" "$DL0_USER@$DL0_HOST:$dst"
+    fi
+}
+
+remote_copy_from_dir() {
+    local remote_dir="$1" local_dir="$2"
+    mkdir -p "$local_dir"
+    if [[ -n "$DL0_PASS" ]]; then
+        sshpass -p "$DL0_PASS" scp -r $SSH_OPTS "$DL0_USER@$DL0_HOST:$remote_dir/." "$local_dir/"
+    else
+        scp -r $SSH_OPTS "$DL0_USER@$DL0_HOST:$remote_dir/." "$local_dir/"
+    fi
+}
+
+run_predict_on_dl0() {
+    local model="$1"
+    local dataset_name="$2"
+    local site_name="$3"
+    local data_dir="$4"
+    local remote_ckpt_dir="$5"
+    local model_remote_out="$REMOTE_STAGE/outputs/$model/$dataset_name"
+    local model_local_out="$OUTPUT_DIR/$model/$dataset_name"
+    local stdout_log="$model_local_out/predict_stdout.log"
+
+    mkdir -p "$model_local_out"
+    remote_exec "rm -rf '$model_remote_out' && mkdir -p '$model_remote_out'"
+
+    info "Evaluating $model on $dataset_name (SITE_NAME=$site_name, DATA_DIR=$data_dir)"
+    if remote_exec "
+        docker run --rm \
+            --gpus='$DL0_GPU' \
+            --net=host --ipc=host \
+            -v '$data_dir:/data:ro' \
+            -v '$remote_ckpt_dir:/workspace:ro' \
+            -v '$model_remote_out:/output' \
+            --env SITE_NAME='$site_name' \
+            --env DATA_DIR=/data \
+            --env SCRATCH_DIR=/output \
+            --env MODEL_NAME='$model' \
+            --env TORCH_HOME=/torch_home \
+            --env CONFIG=unilateral \
+            '$DOCKER_IMAGE' \
+            python3 /MediSwarm/scripts/evaluation/predict.py \
+                --checkpoint /workspace/FL_global_model.pt \
+                --model-name '$model' \
+                --output-dir /output \
+                --split test
+    " > "$stdout_log" 2>&1; then
+        remote_copy_from_dir "$model_remote_out" "$model_local_out"
+        if [[ -s "$model_local_out/prediction_results.json" ]] && compgen -G "$model_local_out/predictions_*.csv" >/dev/null; then
+            ok "Prediction smoke passed: $model / $dataset_name"
+            return 0
+        fi
+        err "Prediction outputs missing for $model / $dataset_name"
+        return 1
+    fi
+
+    remote_copy_from_dir "$model_remote_out" "$model_local_out" 2>/dev/null || true
+    err "Prediction command failed for $model / $dataset_name (see $stdout_log)"
+    return 1
+}
+
+step "Preflight on dl0"
+remote_exec "command -v docker >/dev/null && docker image inspect '$DOCKER_IMAGE' >/dev/null && nvidia-smi >/dev/null && test -d '$DL0_DUKE_DATA' && test -d '$DL0_ODELIA_DATA'"
+ok "dl0 has Docker image, GPU, Duke data, and ODELIA data"
+
+overall_status="pass"
+
+for model in "${MODELS[@]}"; do
+    step "Smoke evaluation: $model"
+    model_status="pass"
+    checkpoint_status="pass"
+    ckpts=()
+    eval_results_jsonl="$OUTPUT_DIR/${model}_eval_results.jsonl"
+    : > "$eval_results_jsonl"
+
+    checkpoint_dir="$CHECKPOINT_ROOT/${model}_checkpoints"
+    model_out="$OUTPUT_DIR/$model"
+    mkdir -p "$model_out"
+
+    if [[ ! -d "$checkpoint_dir" ]]; then
+        err "Checkpoint directory missing: $checkpoint_dir"
+        checkpoint_status="fail"
+        model_status="fail"
+    else
+        mapfile -t ckpts < <(find "$checkpoint_dir" -path '*/app_*/FL_global_model.pt' -type f | sort)
+        if [[ "${#ckpts[@]}" -ne 3 ]]; then
+            err "Expected exactly 3 FL_global_model.pt files for $model, found ${#ckpts[@]}"
+            checkpoint_status="fail"
+            model_status="fail"
+        else
+            md5sum "${ckpts[@]}" | tee "$model_out/checkpoint_md5s.txt" >/dev/null
+            unique_hashes="$(awk '{print $1}' "$model_out/checkpoint_md5s.txt" | sort -u | wc -l | tr -d ' ')"
+            if [[ "$unique_hashes" != "1" ]]; then
+                err "Final global checkpoints are not byte-identical for $model"
+                checkpoint_status="fail"
+                model_status="fail"
+            else
+                ok "All three final global checkpoints are byte-identical for $model"
+            fi
+        fi
+    fi
+
+    if [[ "$checkpoint_status" == "pass" ]]; then
+        remote_ckpt_dir="$REMOTE_STAGE/checkpoints/$model"
+        remote_exec "rm -rf '$remote_ckpt_dir' && mkdir -p '$remote_ckpt_dir'"
+        remote_copy_to "${ckpts[0]}" "$remote_ckpt_dir/FL_global_model.pt"
+
+        if run_predict_on_dl0 "$model" "duke_test" "test" "$DL0_DUKE_DATA" "$remote_ckpt_dir"; then
+            jq -n --arg dataset "duke_test" --arg status "pass" '{dataset:$dataset,status:$status}' >> "$eval_results_jsonl"
+        else
+            jq -n --arg dataset "duke_test" --arg status "fail" '{dataset:$dataset,status:$status}' >> "$eval_results_jsonl"
+            model_status="fail"
+        fi
+
+        for inst in "${ODELIA_SITES[@]}"; do
+            dataset="odelia_$inst"
+            if run_predict_on_dl0 "$model" "$dataset" "$inst" "$DL0_ODELIA_DATA" "$remote_ckpt_dir"; then
+                jq -n --arg dataset "$dataset" --arg status "pass" '{dataset:$dataset,status:$status}' >> "$eval_results_jsonl"
+            else
+                jq -n --arg dataset "$dataset" --arg status "fail" '{dataset:$dataset,status:$status}' >> "$eval_results_jsonl"
+                model_status="fail"
+            fi
+        done
+    fi
+
+    evals_json="$(jq -s '.' "$eval_results_jsonl")"
+    md5s_json="[]"
+    if [[ -f "$model_out/checkpoint_md5s.txt" ]]; then
+        md5s_json="$(jq -R 'split("  ") | {md5:.[0], path:.[1]}' "$model_out/checkpoint_md5s.txt" | jq -s '.')"
+    fi
+
+    checkpoint_count="${#ckpts[@]}"
+    jq -n \
+        --arg model "$model" \
+        --arg status "$model_status" \
+        --arg checkpoint_status "$checkpoint_status" \
+        --argjson checkpoint_count "$checkpoint_count" \
+        --argjson md5s "$md5s_json" \
+        --argjson evals "$evals_json" \
+        '{model:$model,status:$status,checkpoint_status:$checkpoint_status,checkpoint_count:$checkpoint_count,md5s:$md5s,evals:$evals}' \
+        >> "$OUTPUT_DIR/model_results.jsonl"
+
+    if [[ "$model_status" != "pass" ]]; then
+        overall_status="fail"
+    fi
+done
+
+jq -s \
+    --arg run_id "$RUN_ID" \
+    --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --arg git_sha "$GIT_SHA" \
+    --arg docker_image "$DOCKER_IMAGE" \
+    --arg conf_file "$CONF_FILE" \
+    --arg checkpoint_root "$CHECKPOINT_ROOT" \
+    --arg output_dir "$OUTPUT_DIR" \
+    --arg remote_stage "$REMOTE_STAGE" \
+    --arg status "$overall_status" \
+    '{
+        run_id:$run_id,
+        timestamp:$timestamp,
+        status:$status,
+        git_sha:$git_sha,
+        docker_image:$docker_image,
+        conf_file:$conf_file,
+        checkpoint_root:$checkpoint_root,
+        output_dir:$output_dir,
+        remote_stage:$remote_stage,
+        models:.
+    }' "$OUTPUT_DIR/model_results.jsonl" > "$OUTPUT_DIR/summary.json"
+
+{
+    echo "# Duke IID Startup Kit Smoke Evaluation"
+    echo ""
+    echo "- Status: \`$overall_status\`"
+    echo "- Git SHA: \`$GIT_SHA\`"
+    echo "- Docker image: \`$DOCKER_IMAGE\`"
+    echo "- Checkpoint root: \`$CHECKPOINT_ROOT\`"
+    echo "- dl0 remote stage: \`$REMOTE_STAGE\`"
+    echo ""
+    echo "| Model | Status | Checkpoints | Eval datasets |"
+    echo "|-------|--------|-------------|---------------|"
+    jq -r '.models[] | [.model, .status, (.checkpoint_status + " (" + (.checkpoint_count|tostring) + ")"), (([.evals[]? | select(.status=="pass")] | length | tostring) + "/" + ((.evals|length)|tostring))] | @tsv' "$OUTPUT_DIR/summary.json" \
+        | while IFS=$'\t' read -r model status checkpoints evals; do
+            echo "| $model | $status | $checkpoints | $evals |"
+          done
+    echo ""
+    echo "Prediction outputs are under per-model dataset directories in this folder."
+} > "$OUTPUT_DIR/REPORT.md"
+
+if [[ "$overall_status" == "pass" ]]; then
+    ok "Startup-kit smoke evaluation passed. Report: $OUTPUT_DIR/REPORT.md"
+    exit 0
+fi
+
+err "Startup-kit smoke evaluation failed. Report: $OUTPUT_DIR/REPORT.md"
+exit 1


### PR DESCRIPTION
## Summary

Adds the PR301 deploy-validation tooling and fixes needed to run a realistic Duke IID startup-kit validation before merging PR301.

Changes include:
- Duke IID 3-site startup-kit project config for Cosmos server/admin plus `node_A`/`node_B`/`node_C` clients.
- Deploy smoke runner support for skipping built-in eval, selecting result directories, collecting checkpoints/logs, checking client logs, and cleaning stale NVFlare containers more aggressively.
- `dl0` post-training eval smoke script for Duke test and ODELIA challenge institutions.
- Local training live-monitor fixes: capture console output into `local_training_console_output.txt`, preserve training exit status, and keep final live sync behavior.
- Live-sync run selection fix so local monitor uploads the active startup-kit run instead of stale root-owned scratch artifacts.
- Startup-kit container robustness fix for PyTorch/NVFlare file descriptor pressure: raise Docker `nofile` to 65536 and set torch multiprocessing sharing strategy to `file_system`.

## Root Cause / Why

The PR301 validation hit two integration issues before the full run could complete:

1. Local training output was not reliably visible in the web live monitor because the startup-kit local-training path did not tee the training console into a startup-dir file that `live_sync.sh` could upload.
2. The 20-round MST swarm run failed near round 19 under the default Docker file descriptor limit. Persistent DataLoader workers and PyTorch multiprocessing shared-memory handles reached the default `nofile=1024` limit.

This branch fixes both issues and adds repeatable scripts/docs for the same validation workflow.

## Validation

Performed on the 3-node Duke IID infrastructure:

- Local monitor debug: MST `NUM_EPOCHS=1` ran on `dl0`, `dl2`, and `dl3`; console output, heartbeat/final heartbeat, and artifacts uploaded to `/srv/mediswarm/live`.
- Full startup-kit MST run on image `jefftud/odelia:1.4.3-dev.260429.8ac8f85` completed 20/20 rounds.
- MST job id: `7564b543-d4c9-4a3a-8a49-8b3afe891f63`.
- Final `FL_global_model.pt` collected from all three sites with identical md5: `43e4b0e92648a9c71a3223a019655681`.
- `dl0` eval smoke passed on Duke held-out test and ODELIA `CAM MHA RSH RUMC UKA UMCU`.

`1DivideAndConquer` was deliberately terminated at user request before the full 20-round run so we could inspect MST validation and performance first.

## Notes

The deploy-site config remains local-only and is ignored because it contains machine-specific paths and credentials.