### PR TITLE
Fix Live Monitor truncation: read full nohup.out for label dist and metrics

### DIFF
--- a/server_tools/app.py
+++ b/server_tools/app.py
@@ -591,7 +591,12 @@ def _get_console_text(site: str, mode: str, run_id: str) -> str:
     for name in ["nohup.out", "local_training_console_output.txt"]:
         p = run_dir / name
         if p.exists():
-            return read_text(p, limit=500_000)
+            # Read up to 50 MB so dataset-setup output (label distribution,
+            # printed once at the start of the run) and the full epoch history
+            # are both parseable. Long swarm runs can produce ~16 MB logs;
+            # the previous 500 KB tail dropped everything except the last
+            # handful of epochs.
+            return read_text(p, limit=50_000_000)
     return ""
 
 


### PR DESCRIPTION
## Summary

- `_get_console_text` raised from a 500 KB tail to a 50 MB cap so long swarm runs (~16 MB `nohup.out`) parse fully.
- Restores the **Label Distribution** panel and the full **Training Metrics** epoch history on the run detail page.

## Root cause

[server_tools/app.py:589-594](server_tools/app.py#L589-L594) called `read_text(p, limit=500_000)`, slicing the **last 500 KB** of `nohup.out` before feeding it to all 4 console parsers (training metrics, training summary, label distribution, P2P transfers). Long swarm runs produce ~16 MB of console output, so:

- "Label Distribution" parses lines like `Total samples in training set: 22` printed once at dataset setup → outside the tail window → panel empty.
- "Training Metrics" parses every `Epoch N - train ...` line → only the trailing handful survive the slice.

## Verification

Tested against [/srv/mediswarm/live/node_A/swarm/7564b543-d4c9-4a3a-8a49-8b3afe891f63/nohup.out](file:///srv/mediswarm/live/node_A/swarm/7564b543-d4c9-4a3a-8a49-8b3afe891f63/nohup.out) (15.7 MB, completed 20-round MST validation run from PR #312):

| Behavior | Label Distribution splits | Training Metrics epochs |
| --- | --- | --- |
| **Old (500 KB tail)** | 0 (empty) | 4 (epochs 116-119) |
| **New (50 MB cap)**   | 3 (training=416, validation=104, test=0) | 120 (epochs 0-119) |

## Deployment

Restart the FastAPI service serving `server_tools/app.py`. The dashboard parses `nohup.out` at request time, so the fix applies immediately to all existing runs (no retraining needed).

## Test plan

- [ ] Restart Live Monitor service
- [ ] Open detail page for run `7564b543-d4c9-4a3a-8a49-8b3afe891f63` → confirm Label Distribution shows 3 splits and Training Metrics shows full 0-119 epoch range
- [ ] Open detail page for run `8c0ad23d-f3be-47f3-a662-a9425bd91498` → confirm same restoration

🤖 Generated with [Claude Code](https://claude.com/claude-code)