### PR TITLE
Bump version to 1.4.4

### DIFF
--- a/odelia_image.version
+++ b/odelia_image.version
@@ -1,2 +1,2 @@
 # version of the ODELIA Docker image, read by different scripts
-1.4.3
+1.4.4


### PR DESCRIPTION
Bumps `odelia_image.version` from 1.4.3 to 1.4.4 ahead of the v1.4.4 release.

## Included since v1.4.3 (already merged on main)

- #301 — Optimize ODELIA preflight data path for large datasets
- #312 — PR301 startup-kit deploy validation fixes (live console sync, run selection, stale-container cleanup, fd-limit, smoke scripts)
- #306 — Update apt versions in Dockerfile_ODELIA
- #317 — Fix Live Monitor console truncation losing label distribution and early epochs

(#298 was merged then reverted via #304 — no net change.)

## Validation

MST 3-node startup-kit deploy run completed 20/20 rounds with byte-identical global checkpoints across `node_A`/`node_B`/`node_C` (md5 `43e4b0e92648a9c71a3223a019655681`). Duke held-out + ODELIA challenge institutions evaluated; results in PR #312 comment.