### PR TITLE
Default local training to 1DivideAndConquer + document preprocess cache

### DIFF
--- a/assets/readme/README.developer.md
+++ b/assets/readme/README.developer.md
@@ -106,7 +106,7 @@ export CONFIG=original
 For `--preflight_check` and `--local_training` modes, the `--job` flag selects which model to run:
 
 ```bash
-# Default (ODELIA_ternary_classification)
+# Default (challenge_1DivideAndConquer)
 ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check
 
 # Specific challenge model

--- a/assets/readme/README.participant.md
+++ b/assets/readme/README.participant.md
@@ -104,7 +104,7 @@ The dataset must be in the following format.
       ```bash
       ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --job challenge_5pimed
       ```
-    * Available jobs: `ODELIA_ternary_classification` (default), `challenge_1DivideAndConquer`, `challenge_2BCN_AIM`, `challenge_3agaldran`, `challenge_4abmil`, `challenge_5pimed`
+    * Available jobs: `challenge_1DivideAndConquer` (default), `ODELIA_ternary_classification`, `challenge_2BCN_AIM`, `challenge_3agaldran`, `challenge_4abmil`, `challenge_5pimed`
 5. Check your local dataset for discrepancies.
    * Check `preflight_check_console_output.txt` for errors and warnings about the dataset.
        * There should be no duplicate UIDs.
@@ -134,6 +134,15 @@ To have a baseline for swarm training, train the same model in a comparable way 
       ```bash
       ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training --job challenge_2BCN_AIM 2>&1 | tee local_training_console_output.txt
       ```
+    * **Speed up training (recommended for large datasets).** Enable the on-disk preprocessing cache so each image volume is preprocessed once and stored as a compressed `.npz`; later epochs read from the cache instead of re-decoding NIfTI every time. This removes the data-loading bottleneck and keeps the GPU busy. Set the two environment variables in front of the command:
+      ```bash
+      ODELIA_ENABLE_PREPROCESS_CACHE=1 \
+      ODELIA_PREPROCESS_CACHE_DIR=$SCRATCHDIR/odelia_preprocess_cache \
+      ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training 2>&1 | tee local_training_console_output.txt
+      ```
+        * The first epoch is still slow while the cache is built; subsequent epochs are much faster and GPU utilization rises significantly. If epochs are taking many hours and `nvidia-smi` shows low GPU usage, this is almost certainly the fix.
+        * The cache needs free disk space (roughly one compressed volume per case), so point `ODELIA_PREPROCESS_CACHE_DIR` at fast local storage with room to spare. If unset, it defaults to `$SCRATCHDIR/odelia_preprocess_cache`.
+        * The cache is reused across runs and auto-invalidates when a source image file changes. The same two variables also speed up `--preflight_check` and the swarm `--start_client` run, so it is worth enabling them everywhere.
 3. Output files:
     * Logged output during training: `startup/local_training_console_output.txt`
     * Training results are stored in `$SCRATCHDIR/runs/$SITE_NAME/<RUN_NAME>/`
@@ -206,6 +215,17 @@ ping dl3.tud.de
 * If dl3.tud.de cannot be resolved, double-check whether it is contained in `/etc/hosts`
 * If it cannot be reached at all, double-check if the VPN connection is working.
 * If intermittent package loss occurs, double-check if your network connection is working properly. Creating new VPN credentials and certificate for connection may also help, contact your Swarm Operator for this purpose.
+
+### Training Very Slow / GPU Under-utilized?
+
+If an epoch takes many hours (or more than a day) and `nvidia-smi` shows the GPU mostly idle (e.g. <30% utilization), training is bottlenecked on data loading, not on the GPU. Enable the on-disk preprocessing cache by prefixing the run command with:
+
+```bash
+ODELIA_ENABLE_PREPROCESS_CACHE=1 \
+ODELIA_PREPROCESS_CACHE_DIR=$SCRATCHDIR/odelia_preprocess_cache \
+```
+
+See [Run Local Training](#run-local-training) for details. This caches each preprocessed volume as a compressed `.npz` on fast local storage, so epochs after the first read quickly and the GPU stays fed. It applies to local training, the pre-flight check, and the swarm client.
 
 ### Further Possible Issues
 

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -739,7 +739,7 @@ docker_cln_sh: |
   done
 
   # Default job for preflight_check and local_training
-  : ${JOB_NAME:="ODELIA_ternary_classification"}
+  : ${JOB_NAME:="challenge_1DivideAndConquer"}
 
   # Auto-derive MODEL_NAME from challenge job names.
   # Challenge jobs (challenge_1DivideAndConquer, etc.) share identical code
@@ -961,10 +961,10 @@ docker_cln_sh: |
       echo ""
       echo "Optional:"
       echo "--job <name>             select job/model for preflight_check or local_training"
-      echo "                         (default: ODELIA_ternary_classification)"
-      echo "                         Available: ODELIA_ternary_classification, challenge_1DivideAndConquer,"
+      echo "                         (default: challenge_1DivideAndConquer)"
+      echo "                         Available: challenge_1DivideAndConquer, ODELIA_ternary_classification,"
       echo "                         challenge_2BCN_AIM, challenge_3agaldran, challenge_4abmil, challenge_5pimed"
-      echo "--model_name <name>      set model name (default: MST). Use this instead of 'export MODEL_NAME=...'"
+      echo "--model_name <name>      set model name (default: auto-derived from --job). Use this instead of 'export MODEL_NAME=...'"
       echo "                         when running with sudo, as sudo resets environment variables"
       echo "--num_epochs <n>         set number of training epochs (default: 100)"
       echo "--config <name>          set config name (default: unilateral)"

--- a/docs/deploy_test_runbook.md
+++ b/docs/deploy_test_runbook.md
@@ -83,8 +83,8 @@ Missing `--scratch_dir` or `--GPU` causes interactive prompts in non-interactive
 
 | Job directory | MODEL_NAME | Notes |
 |--------------|-----------|-------|
-| `ODELIA_ternary_classification` | `MST` | Default/baseline; uses DINOv2 backbone (slow) |
-| `challenge_1DivideAndConquer` | `1DivideAndConquer` | 3D ResNet variant |
+| `ODELIA_ternary_classification` | `MST` | Baseline; uses DINOv2 backbone (slow) |
+| `challenge_1DivideAndConquer` | `1DivideAndConquer` | Default for `--preflight_check`/`--local_training`; 3D ResNet variant |
 | `challenge_2BCN_AIM` | `2BCN_AIM` | SwinUNETR |
 | `challenge_3agaldran` | `3agaldran` | MViTv2 |
 | `challenge_4abmil` | `4LME_ABMIL` | Key fix in v1.4.2: was deriving `4abmil` (wrong) |


### PR DESCRIPTION
## Summary
- **Default model change:** the default `--job` for `--preflight_check` and `--local_training` is now `challenge_1DivideAndConquer` (was `ODELIA_ternary_classification` / MST). Running `./docker.sh ... --local_training` with no `--job` now trains 1DC. Help text and docs updated to match.
- **Preprocessing cache docs:** the participant guide now documents `ODELIA_ENABLE_PREPROCESS_CACHE=1` + `ODELIA_PREPROCESS_CACHE_DIR=...`, which caches each preprocessed volume as a compressed `.npz` so post-first epochs are much faster and the GPU stays fed.

## Why
A partner site reported >1-day epochs with GPU utilization <30% — a classic data-loading bottleneck. The preprocess cache (already supported in code: `env_config.py`, forwarded by docker.sh, unit-tested) resolves it; it was just undocumented.

## Scope / safety
- `--start_client` (swarm) does not use the default `JOB_NAME` — its job comes from the server — so swarm runs are unaffected.
- Passing `--job ODELIA_ternary_classification` still selects MST (backward compatible).
- Model-registry default tests (`test_default_is_mst`) target a different layer and are unaffected.
- Note: the repo-wide `unit-tests` check is failing on all branches incl. `main`, unrelated to this PR.

## Test plan
- [ ] `./docker.sh ... --local_training` (no `--job`) logs `Auto-derived MODEL_NAME='1DivideAndConquer'`
- [ ] `./docker.sh --help` shows the new default
- [ ] Cache run creates `.npz` files under `ODELIA_PREPROCESS_CACHE_DIR` and speeds up epoch 2+