### PR TITLE
Guard ODELIA normalization against zero-std images

### DIFF
--- a/application/jobs/_shared/custom/data/augmentation/augmentations_3d.py
+++ b/application/jobs/_shared/custom/data/augmentation/augmentations_3d.py
@@ -1,3 +1,7 @@
+import json
+import os
+import time
+from pathlib import Path
 from typing import Union, Optional, Sequence
 
 import torchio as tio
@@ -17,6 +21,9 @@ import random
 
 import torch
 import torch.nn.functional as F
+
+
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
 class Random3DAugmentation:
@@ -166,6 +173,79 @@ class ZNormalization(tio.ZNormalization):
         self.per_channel = per_channel
         self.per_slice = per_slice
 
+    @staticmethod
+    def _zero_std_guard_log_path() -> Path:
+        scratch_dir = os.getenv("SCRATCH_DIR") or os.getenv("SCRATCHDIR") or "/scratch"
+        return Path(scratch_dir) / "odelia_zero_std_guard.jsonl"
+
+    @staticmethod
+    def _stringify_image_path(image_path) -> str:
+        if image_path is None:
+            return ""
+        if isinstance(image_path, (list, tuple)):
+            return ";".join(str(path) for path in image_path)
+        return str(image_path)
+
+    @staticmethod
+    def _maybe_float(value):
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _json_safe_percentiles(percentiles):
+        try:
+            return torch.as_tensor(percentiles).detach().cpu().tolist()
+        except (TypeError, ValueError):
+            return str(percentiles)
+
+    def _write_zero_std_guard_event(
+        self,
+        *,
+        reason: str,
+        image_name: str,
+        image_path,
+        masked_voxels: int,
+        pre_clamp_std: float | None,
+        post_clamp_std: float | None = None,
+    ) -> None:
+        log_path = self._zero_std_guard_log_path()
+        record = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "pid": os.getpid(),
+            "reason": reason,
+            "image_name": str(image_name),
+            "image_path": self._stringify_image_path(image_path),
+            "masked_voxels": int(masked_voxels),
+            "pre_clamp_std": self._maybe_float(pre_clamp_std),
+            "post_clamp_std": self._maybe_float(post_clamp_std),
+            "percentiles": self._json_safe_percentiles(self.percentiles),
+        }
+
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, sort_keys=True) + "\n")
+        except OSError as exc:
+            print(
+                f"[ODELIA_ZERO_STD_GUARD_LOG_FAILED] reason={reason} "
+                f"image_name={image_name} error={type(exc).__name__}: {exc}",
+                flush=True,
+            )
+            return
+
+        detail = ""
+        if os.getenv("ODELIA_ZERO_STD_GUARD_LOG_DETAILS", "").lower() in _TRUTHY_ENV_VALUES:
+            detail = f" image_path={record['image_path']}"
+        print(
+            f"[ODELIA_ZERO_STD_GUARD] reason={reason} image_name={image_name} "
+            f"masked_voxels={masked_voxels} details_file={log_path}{detail}",
+            flush=True,
+        )
+
     def apply_normalization(self, subject: Subject, image_name: str, mask: torch.Tensor) -> None:
         image = subject[image_name]
         per_channel = parse_per_channel(self.per_channel, image.shape[0])
@@ -180,13 +260,32 @@ class ZNormalization(tio.ZNormalization):
         )
 
     def _znorm(self, image_data, mask, image_name, image_path):
-        cutoff = torch.quantile(image_data.masked_select(mask).float(), torch.tensor(self.percentiles) / 100.0)
+        masked = image_data.masked_select(mask).float()
+        masked_voxels = masked.numel()
+        pre_clamp_std = masked.std(unbiased=False).item() if masked_voxels else None
+
+        def _zeros(reason: str, post_clamp_std: float | None = None):
+            self._write_zero_std_guard_event(
+                reason=reason,
+                image_name=image_name,
+                image_path=image_path,
+                masked_voxels=masked_voxels,
+                pre_clamp_std=pre_clamp_std,
+                post_clamp_std=post_clamp_std,
+            )
+            return torch.zeros_like(image_data)
+
+        if masked_voxels < 2:
+            return _zeros("empty_or_too_small_mask")
+
+        percentiles = torch.tensor(self.percentiles, device=masked.device, dtype=masked.dtype) / 100.0
+        cutoff = torch.quantile(masked, percentiles)
         torch.clamp(image_data, *cutoff.to(image_data.dtype).tolist(), out=image_data)
         standardized = self.znorm(image_data, mask)
         if standardized is None:
-            raise RuntimeError(
-                f'Standard deviation is 0 for masked values in image "{image_name}" ({image_path})'
-            )
+            post_clamp_values = image_data.masked_select(mask).float()
+            post_clamp_std = post_clamp_values.std(unbiased=False).item() if post_clamp_values.numel() else None
+            return _zeros("zero_std_after_masking_or_clipping", post_clamp_std=post_clamp_std)
         return standardized
 
 

--- a/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
+++ b/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
@@ -332,6 +332,13 @@ class ODELIA_Dataset3D(data.Dataset):
             loader=self.load_img,
         )
 
+    @staticmethod
+    def _attach_source_path(image: tio.ScalarImage, path_img: Path) -> tio.ScalarImage:
+        # TorchIO keeps `.path` for file-backed images, but tensor-backed cached
+        # images need it restored so local diagnostics can point to the source.
+        image.path = str(path_img)
+        return image
+
     def __getitem__(self, index):
         idx = self.item_pointers[index]
         item = self.df.loc[idx]
@@ -340,7 +347,10 @@ class ODELIA_Dataset3D(data.Dataset):
 
         target = np.stack(item[self.labels].values)
         path_img = self.get_image_path(uid, institution)
-        img = self._load_source_image(path_img, institution, uid)
+        img = self._attach_source_path(
+            self._load_source_image(path_img, institution, uid),
+            path_img,
+        )
         img = self.transform(img)
 
         return {'uid': uid, 'source': img, 'target': target}

--- a/tests/unit_tests/test_odelia_zero_std_guard.py
+++ b/tests/unit_tests/test_odelia_zero_std_guard.py
@@ -1,0 +1,202 @@
+import json
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_CUSTOM_DIR = REPO_ROOT / "application" / "jobs" / "_shared" / "custom"
+sys.path.insert(0, str(SHARED_CUSTOM_DIR))
+
+fake_pandas = types.ModuleType("pandas")
+fake_pandas.__spec__ = importlib.machinery.ModuleSpec("pandas", loader=None)
+sys.modules.setdefault("pandas", fake_pandas)
+
+
+class _FakeTorchioZNormalization:
+    def __init__(self, masking_method=None, **_kwargs):
+        self.masking_method = masking_method
+
+    def znorm(self, image_data, mask):
+        values = image_data.masked_select(mask).float()
+        if values.numel() == 0:
+            return None
+        std = values.std(unbiased=False)
+        if std.item() == 0:
+            return None
+        return (image_data - values.mean().to(image_data.dtype)) / std.to(image_data.dtype)
+
+
+class _FakeScalarImage:
+    def __init__(self, tensor=None, affine=None, path=None):
+        self.data = tensor
+        self.affine = affine
+        self.path = path
+
+
+class _FakeSubject(dict):
+    def check_consistent_space(self):
+        return None
+
+
+class _FakeCropOrPad:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+fake_torchio = types.ModuleType("torchio")
+fake_torchio.__spec__ = importlib.machinery.ModuleSpec("torchio", loader=None)
+fake_torchio.ZNormalization = _FakeTorchioZNormalization
+fake_torchio.ScalarImage = _FakeScalarImage
+fake_torchio.LabelMap = _FakeScalarImage
+fake_torchio.Subject = _FakeSubject
+fake_torchio.Image = _FakeScalarImage
+fake_torchio.CropOrPad = _FakeCropOrPad
+fake_torchio.INTENSITY = "intensity"
+fake_torchio.Compose = MagicMock()
+fake_torchio.Lambda = MagicMock()
+fake_torchio.ToCanonical = MagicMock()
+fake_torchio.Resample = MagicMock()
+fake_torchio.Flip = MagicMock()
+fake_torchio.OneOf = MagicMock()
+fake_torchio.RandomAffine = MagicMock()
+fake_torchio.RandomFlip = MagicMock()
+fake_torchio.RandomNoise = MagicMock()
+fake_torchio.Pad = MagicMock()
+fake_torchio.Crop = MagicMock()
+
+fake_torchio_typing = types.ModuleType("torchio.typing")
+fake_torchio_typing.__spec__ = importlib.machinery.ModuleSpec("torchio.typing", loader=None)
+fake_torchio_typing.TypeRangeFloat = tuple
+fake_torchio_typing.TypeTripletInt = tuple
+
+fake_torchio_transform = types.ModuleType("torchio.transforms.transform")
+fake_torchio_transform.__spec__ = importlib.machinery.ModuleSpec("torchio.transforms.transform", loader=None)
+fake_torchio_transform.TypeMaskingMethod = object
+
+sys.modules.setdefault("torchio", fake_torchio)
+sys.modules.setdefault("torchio.typing", fake_torchio_typing)
+sys.modules.setdefault("torchio.transforms.transform", fake_torchio_transform)
+
+from data.augmentation.augmentations_3d import ZNormalization  # noqa: E402
+from data.datasets.dataset_3d_odelia import ODELIA_Dataset3D  # noqa: E402
+
+
+def _read_guard_records(tmp_path):
+    log_path = tmp_path / "odelia_zero_std_guard.jsonl"
+    return [json.loads(line) for line in log_path.read_text().splitlines()]
+
+
+def test_zero_std_masked_image_returns_zeros_and_logs_locally(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SCRATCH_DIR", str(tmp_path))
+    image_data = torch.ones((1, 2, 2, 2), dtype=torch.float32)
+    mask = torch.ones_like(image_data, dtype=torch.bool)
+
+    normalized = ZNormalization(percentiles=(0, 100))._znorm(
+        image_data=image_data,
+        mask=mask,
+        image_name="img",
+        image_path="/sensitive/site/UID/Sub_1.nii.gz",
+    )
+
+    assert torch.equal(normalized, torch.zeros_like(image_data))
+    record = _read_guard_records(tmp_path)[0]
+    assert record["reason"] == "zero_std_after_masking_or_clipping"
+    assert record["masked_voxels"] == 8
+    assert record["image_path"].endswith("Sub_1.nii.gz")
+
+    stdout = capsys.readouterr().out
+    assert "[ODELIA_ZERO_STD_GUARD]" in stdout
+    assert "/sensitive/site/UID" not in stdout
+
+
+def test_empty_or_tiny_mask_returns_zeros_and_logs_locally(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCRATCH_DIR", str(tmp_path))
+    image_data = torch.arange(8, dtype=torch.float32).reshape(1, 2, 2, 2)
+    mask = torch.zeros_like(image_data, dtype=torch.bool)
+    mask[..., 0, 0, 0] = True
+
+    normalized = ZNormalization(percentiles=(0, 100))._znorm(
+        image_data=image_data,
+        mask=mask,
+        image_name="img",
+        image_path="/sensitive/site/UID/Sub_1.nii.gz",
+    )
+
+    assert torch.equal(normalized, torch.zeros_like(image_data))
+    record = _read_guard_records(tmp_path)[0]
+    assert record["reason"] == "empty_or_too_small_mask"
+    assert record["masked_voxels"] == 1
+
+
+def test_normal_image_still_normalizes_without_guard_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCRATCH_DIR", str(tmp_path))
+    image_data = torch.arange(8, dtype=torch.float32).reshape(1, 2, 2, 2)
+    mask = torch.ones_like(image_data, dtype=torch.bool)
+
+    normalized = ZNormalization(percentiles=(0, 100))._znorm(
+        image_data=image_data,
+        mask=mask,
+        image_name="img",
+        image_path="/sensitive/site/UID/Sub_1.nii.gz",
+    )
+
+    assert torch.isfinite(normalized).all()
+    assert not torch.equal(normalized, torch.zeros_like(image_data))
+    assert normalized.mean().item() == pytest.approx(0.0, abs=1e-6)
+    assert not (tmp_path / "odelia_zero_std_guard.jsonl").exists()
+
+
+def test_odelia_dataset_attaches_source_path_before_transform(tmp_path):
+    source_path = tmp_path / "USZ_1" / "data_unilateral" / "uid-1" / "Sub_1.nii.gz"
+    captured = {}
+
+    class _Values:
+        def __init__(self, values):
+            self.values = values
+
+    class _Row(dict):
+        def __getitem__(self, key):
+            if isinstance(key, list):
+                return _Values([dict.__getitem__(self, item) for item in key])
+            return dict.__getitem__(self, key)
+
+    class _Loc:
+        def __init__(self, row):
+            self.row = row
+
+        def __getitem__(self, _idx):
+            return self.row
+
+    class _Frame:
+        def __init__(self, row):
+            self.loc = _Loc(row)
+
+    dataset = object.__new__(ODELIA_Dataset3D)
+    dataset.item_pointers = [0]
+    dataset.df = _Frame(_Row({"UID": "uid-1", "Institution": "USZ_1", "Lesion": 2}))
+    dataset.labels = ["Lesion"]
+    dataset.get_image_path = lambda uid, institution: source_path
+    dataset._load_source_image = lambda path_img, institution, uid: _FakeScalarImage(
+        tensor=torch.ones((1, 2, 2, 2), dtype=torch.float32),
+        affine=np.eye(4),
+    )
+
+    def _capture_transform(image):
+        captured["path"] = image.path
+        return image.data
+
+    dataset.transform = _capture_transform
+
+    sample = ODELIA_Dataset3D.__getitem__(dataset, 0)
+
+    assert captured["path"] == str(source_path)
+    assert sample["uid"] == "uid-1"
+    assert sample["target"].tolist() == [2]


### PR DESCRIPTION
## Summary

Add a cleaned robustness patch for the collaborator-reported ODELIA local-training crash around masked Z-normalization:

- `ZNormalization` now returns a zero tensor instead of raising when the mask has fewer than 2 voxels or when TorchIO normalization reports zero standard deviation.
- Percentile tensors are created on the same device/dtype path as the masked image tensor.
- A local JSONL diagnostic is written to `$SCRATCH_DIR/odelia_zero_std_guard.jsonl` or `/scratch/odelia_zero_std_guard.jsonl` with the detailed image path and guard reason.
- Stdout only emits a short sanitized marker by default, so full image paths/UIDs are not broadcast through live monitor logs. Full stdout details remain opt-in via `ODELIA_ZERO_STD_GUARD_LOG_DETAILS=1`.
- `ODELIA_Dataset3D` restores the source `path_img` on tensor-backed cached images before transforms, so local diagnostics can still identify the problematic source file.

## Why

A collaborator had to patch local files to avoid crashes during local training. We should ship the fix through the normal PR/release/startup-kit flow rather than asking partners to overwrite files inside containers or startup kits.

## Validation

- `python3 -m py_compile application/jobs/_shared/custom/data/augmentation/augmentations_3d.py application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py`
- `.venv/bin/pytest -q tests/unit_tests/test_odelia_zero_std_guard.py tests/unit_tests/test_data_module.py tests/unit_tests/test_threedcnn_ptl.py` -> 28 passed
- `git diff --check`

## Follow-up after merge

- Rebuild all-sites startup kits from `main`.
- Push the new Docker image.
- Ask the collaborator to rerun the same local-training command that previously crashed and confirm whether `odelia_zero_std_guard.jsonl` is produced only locally when problematic images are encountered.