### PR TITLE
Make ODELIA deploy CI configurable for 1DC smoke runs

### DIFF
--- a/.github/workflows/odelia-deploy-test.yml
+++ b/.github/workflows/odelia-deploy-test.yml
@@ -2,6 +2,47 @@ name: ODELIA Deploy Test
 
 on:
   workflow_dispatch:     # Manual trigger
+    inputs:
+      project_file:
+        description: "Provision YAML used to build startup kits"
+        required: false
+        default: "application/provision/project_deploy_test_4site.yml"
+        type: string
+      num_rounds:
+        description: "Number of FL rounds to bake into generated jobs"
+        required: false
+        default: "1"
+        type: string
+      conf_source:
+        description: "Deploy-site credential/config file on the Cosmos runner"
+        required: false
+        default: "/home/jeff/Projects/MediSwarm/deploy_sites_4node_test.conf"
+        type: string
+      run_all:
+        description: "Run all six ODELIA models instead of the selected model/job"
+        required: false
+        default: false
+        type: boolean
+      model:
+        description: "MODEL_NAME for a single-model run"
+        required: false
+        default: "1DivideAndConquer"
+        type: string
+      job:
+        description: "Job directory for a single-model run"
+        required: false
+        default: "challenge_1DivideAndConquer"
+        type: string
+      skip_eval:
+        description: "Skip deploy-runner post-training evaluation"
+        required: false
+        default: false
+        type: boolean
+      timeout_minutes:
+        description: "Per-model timeout passed to run_deploy_test.sh"
+        required: false
+        default: "10080"
+        type: string
   release:
     types: [published]   # Run on every tagged release
 
@@ -34,12 +75,77 @@ jobs:
           submodules: true
           fetch-depth: 0
 
+      - name: Resolve deploy test parameters
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PROJECT_FILE: ${{ inputs.project_file }}
+          INPUT_NUM_ROUNDS: ${{ inputs.num_rounds }}
+          INPUT_CONF_SOURCE: ${{ inputs.conf_source }}
+          INPUT_RUN_ALL: ${{ inputs.run_all }}
+          INPUT_MODEL: ${{ inputs.model }}
+          INPUT_JOB: ${{ inputs.job }}
+          INPUT_SKIP_EVAL: ${{ inputs.skip_eval }}
+          INPUT_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+        run: |
+          set -euo pipefail
+
+          project_file="${INPUT_PROJECT_FILE:-application/provision/project_deploy_test_4site.yml}"
+          num_rounds="${INPUT_NUM_ROUNDS:-1}"
+          conf_source="${INPUT_CONF_SOURCE:-/home/jeff/Projects/MediSwarm/deploy_sites_4node_test.conf}"
+          run_all="${INPUT_RUN_ALL:-false}"
+          model="${INPUT_MODEL:-1DivideAndConquer}"
+          job="${INPUT_JOB:-challenge_1DivideAndConquer}"
+          skip_eval="${INPUT_SKIP_EVAL:-false}"
+          timeout_minutes="${INPUT_TIMEOUT_MINUTES:-10080}"
+
+          # Release runs preserve the historical behavior: 4-site, one round,
+          # all six ODELIA models, evaluation enabled.
+          if [[ "$EVENT_NAME" != "workflow_dispatch" ]]; then
+            run_all="true"
+            skip_eval="false"
+          fi
+
+          case "$run_all" in true|false) ;; *) echo "run_all must be true/false: $run_all"; exit 1 ;; esac
+          case "$skip_eval" in true|false) ;; *) echo "skip_eval must be true/false: $skip_eval"; exit 1 ;; esac
+          [[ "$num_rounds" =~ ^[0-9]+$ ]] || { echo "num_rounds must be an integer: $num_rounds"; exit 1; }
+          [[ "$timeout_minutes" =~ ^[0-9]+$ ]] || { echo "timeout_minutes must be an integer: $timeout_minutes"; exit 1; }
+          [[ -f "$project_file" ]] || { echo "Project file not found: $project_file"; exit 1; }
+          [[ -f "$conf_source" ]] || { echo "Deploy config not found: $conf_source"; exit 1; }
+
+          conf_file="$GITHUB_WORKSPACE/deploy_sites_ci.conf"
+          cp "$conf_source" "$conf_file"
+          {
+            echo ""
+            echo "# GitHub Actions workflow override: keep build and deploy-runner workspace lookup aligned."
+            echo "PROJECT_FILE=$project_file"
+          } >> "$conf_file"
+          chmod 600 "$conf_file"
+
+          {
+            echo "DEPLOY_PROJECT_FILE=$project_file"
+            echo "DEPLOY_NUM_ROUNDS=$num_rounds"
+            echo "DEPLOY_CONF_FILE=$conf_file"
+            echo "DEPLOY_RUN_ALL=$run_all"
+            echo "DEPLOY_MODEL=$model"
+            echo "DEPLOY_JOB=$job"
+            echo "DEPLOY_SKIP_EVAL=$skip_eval"
+            echo "DEPLOY_TIMEOUT_MINUTES=$timeout_minutes"
+          } >> "$GITHUB_ENV"
+
+          echo "project_file=$project_file"
+          echo "num_rounds=$num_rounds"
+          echo "run_all=$run_all"
+          echo "model=$model"
+          echo "job=$job"
+          echo "skip_eval=$skip_eval"
+          echo "timeout_minutes=$timeout_minutes"
+
       - name: Build Docker image + startup kits
         run: |
           ./scripts/build/buildDockerImageAndStartupKits.sh \
-            -p application/provision/project_deploy_test_4site.yml \
+            -p "$DEPLOY_PROJECT_FILE" \
             --use-docker-cache \
-            --num-rounds 1
+            --num-rounds "$DEPLOY_NUM_ROUNDS"
 
       - name: Push Docker image to Docker Hub
         run: |
@@ -48,18 +154,22 @@ jobs:
           VERSION=$(./scripts/build/getVersionNumber.sh)
           docker push "jefftud/odelia:$VERSION"
 
-      - name: Copy deploy site credentials (gitignored)
+      - name: Run deploy test
         run: |
-          # deploy_sites_4node_test.conf contains site passwords and is
-          # gitignored, so it doesn't exist in the checkout.  Copy the
-          # persistent copy that lives in the dev checkout on Cosmos.
-          cp /home/jeff/Projects/MediSwarm/deploy_sites_4node_test.conf .
+          set -euo pipefail
 
-      - name: Run all 6 models deploy test
-        run: |
-          ./scripts/deploy/run_deploy_test.sh \
-            --all \
-            --conf deploy_sites_4node_test.conf
+          args=(--conf "$DEPLOY_CONF_FILE" --timeout "$DEPLOY_TIMEOUT_MINUTES")
+          if [[ "$DEPLOY_SKIP_EVAL" == "true" ]]; then
+            args+=(--skip-eval)
+          fi
+
+          if [[ "$DEPLOY_RUN_ALL" == "true" ]]; then
+            args=(--all "${args[@]}")
+          else
+            args=(--model "$DEPLOY_MODEL" --job "$DEPLOY_JOB" "${args[@]}")
+          fi
+
+          ./scripts/deploy/run_deploy_test.sh "${args[@]}"
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/assets/readme/README.developer.md
+++ b/assets/readme/README.developer.md
@@ -88,7 +88,7 @@ See [README.participant.md](./README.participant.md).
 | `DATA_DIR`           | *from flag*     | Path to the host folder that contains your local data                |
 | `SCRATCH_DIR`        | *from flag*     | Path for saving training outputs and temporary files                 |
 | `GPU_DEVICE`         | `device=0`      | GPU identifier to use inside the container (or `all`)                |
-| `MODEL_NAME`         | `MST`           | Model architecture (note: challenge jobs hardcode this in main.py)   |
+| `MODEL_NAME`         | auto / `MST`    | For `--preflight_check` and `--local_training`, `docker.sh` derives this from `--job` and defaults to `1DivideAndConquer`. `MST` is the fallback when no job-derived model is selected. |
 | `INSTITUTION`        | `ODELIA`        | Institution name, used to group experiment logs                      |
 | `CONFIG`             | `unilateral`    | Configuration schema for dataset (e.g. label scheme)                 |
 | `NUM_EPOCHS`         | `1` (test mode) | Number of training epochs (used in preflight/local training)         |
@@ -111,9 +111,12 @@ For `--preflight_check` and `--local_training` modes, the `--job` flag selects w
 
 # Specific challenge model
 ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --job challenge_5pimed
+
+# MST baseline
+./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --job ODELIA_ternary_classification
 ```
 
-**Note:** Each challenge job hardcodes its `MODEL_NAME` in `main.py` to avoid the Docker env var override (`MODEL_NAME=${MODEL_NAME:-MST}`). The `--job` flag changes which job's `main.py` is executed, not the `MODEL_NAME` env var.
+**Note:** Prefer `--job` over exporting `MODEL_NAME` for preflight/local training. The startup-kit `docker.sh` maps `challenge_1DivideAndConquer` to `MODEL_NAME=1DivideAndConquer` by default and maps `ODELIA_ternary_classification` to `MODEL_NAME=MST`.
 
 ## Running the Application
 
@@ -134,7 +137,7 @@ For `--preflight_check` and `--local_training` modes, the `--job` flag selects w
 | `challenge_4abmil` | CrossModalAttentionABMIL + Swin | `application/jobs/challenge_4abmil` |
 | `challenge_5pimed` | ResNet18 | `application/jobs/challenge_5pimed` |
 
-Each challenge job has its own `config_fed_client.conf`, model code, and `main.py` with a hardcoded `MODEL_NAME`.
+Each challenge job has its own `config_fed_client.conf`; the startup-kit `docker.sh` selects the matching model via `--job`/`MODEL_NAME`.
 
 ## Contributing Application Code
 

--- a/assets/readme/README.participant.md
+++ b/assets/readme/README.participant.md
@@ -99,12 +99,17 @@ The dataset must be in the following format.
    ```bash
    ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check  2>&1 | tee preflight_check_console_output.txt
    ```
+    * Without `--job`, this runs the default ODELIA challenge model: `challenge_1DivideAndConquer` (`MODEL_NAME=1DivideAndConquer`).
     * Training time depends on the size of the local dataset.
     * To test a specific challenge model, use the `--job` flag:
       ```bash
       ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --job challenge_5pimed
       ```
-    * Available jobs: `challenge_1DivideAndConquer` (default), `ODELIA_ternary_classification`, `challenge_2BCN_AIM`, `challenge_3agaldran`, `challenge_4abmil`, `challenge_5pimed`
+    * To test the MST baseline instead, use:
+      ```bash
+      ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check --job ODELIA_ternary_classification
+      ```
+    * Available jobs: `challenge_1DivideAndConquer` (default), `ODELIA_ternary_classification` (MST), `challenge_2BCN_AIM`, `challenge_3agaldran`, `challenge_4abmil`, `challenge_5pimed`
 5. Check your local dataset for discrepancies.
    * Check `preflight_check_console_output.txt` for errors and warnings about the dataset.
        * There should be no duplicate UIDs.
@@ -129,10 +134,15 @@ To have a baseline for swarm training, train the same model in a comparable way 
    ```bash
    ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training  2>&1 | tee local_training_console_output.txt
    ```
+    * Without `--job`, this trains `challenge_1DivideAndConquer` (`MODEL_NAME=1DivideAndConquer`).
     * This currently runs 100 epochs (somewhat comparable to 20 rounds with 5 epochs each in the swarm case).
     * To train a specific challenge model locally, use the `--job` flag:
       ```bash
       ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training --job challenge_2BCN_AIM 2>&1 | tee local_training_console_output.txt
+      ```
+    * To train the MST baseline locally, use:
+      ```bash
+      ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training --job ODELIA_ternary_classification 2>&1 | tee local_training_console_output.txt
       ```
     * **Speed up training (recommended for large datasets).** Enable the on-disk preprocessing cache so each image volume is preprocessed once and stored as a compressed `.npz`; later epochs read from the cache instead of re-decoding NIfTI every time. This removes the data-loading bottleneck and keeps the GPU busy. Set the two environment variables in front of the command:
       ```bash


### PR DESCRIPTION
## Summary

Clarify that ODELIA startup-kit preflight/local training defaults to `challenge_1DivideAndConquer`, and make the existing ODELIA deploy-test workflow practically runnable for targeted 1DC smoke validation.

## Changes

- Keep startup-kit behavior unchanged: `docker.sh --preflight_check` and `docker.sh --local_training` still default to `challenge_1DivideAndConquer`, with `MODEL_NAME=1DivideAndConquer` auto-derived.
- Update participant/developer docs with explicit 1DC default wording and explicit MST examples using `--job ODELIA_ternary_classification`.
- Add `workflow_dispatch` inputs to `ODELIA Deploy Test`:
  - `project_file`
  - `num_rounds`
  - `conf_source`
  - `run_all`
  - `model`
  - `job`
  - `skip_eval`
  - `timeout_minutes`
- Manual workflow default is now a single-model 1DC smoke: `model=1DivideAndConquer`, `job=challenge_1DivideAndConquer`, `num_rounds=1`, `run_all=false`.
- Release-trigger behavior preserves the previous all-six-model deploy test by forcing `run_all=true` for non-manual events.
- The selected `project_file` is appended into the copied deploy conf so build and `run_deploy_test.sh` resolve the same workspace.

## Validation

- `rg 'JOB_NAME:="challenge_1DivideAndConquer"|default: challenge_1DivideAndConquer|challenge_1DivideAndConquer` \(default\)|MODEL_NAME=1DivideAndConquer' docker_config/master_template.yml assets/readme/README.participant.md assets/readme/README.developer.md`
- `bash -n scripts/deploy/run_deploy_test.sh`
- `git diff --check`
- Parsed `.github/workflows/odelia-deploy-test.yml` with PyYAML and verified all expected manual inputs are present.
- `gh workflow list --all | grep -F 'ODELIA Deploy Test'` -> active

## Manual run examples after merge

Single-round 1DC smoke:

```bash
gh workflow run "ODELIA Deploy Test" \
  -f run_all=false \
  -f job=challenge_1DivideAndConquer \
  -f model=1DivideAndConquer \
  -f num_rounds=1
```

Two-round 1DC smoke:

```bash
gh workflow run "ODELIA Deploy Test" \
  -f run_all=false \
  -f job=challenge_1DivideAndConquer \
  -f model=1DivideAndConquer \
  -f num_rounds=2
```

Full all-model run:

```bash
gh workflow run "ODELIA Deploy Test" -f run_all=true
```

## Notes

This PR does not trigger the deploy workflow. It is a real self-hosted multi-node run and should be launched intentionally after review.