### PR TITLE
Harden ODELIA swarm: 24h timeouts + wait-for-all, preflight checks, cgroupfs fix, docs

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
@@ -38,8 +38,8 @@
         args {
           # train task must be implemented by Executor
           learn_task_name = "train"
-          # max time for a single training round (8 hours — 10 nodes with large models)
-          learn_task_timeout = 28800
+          # max time for a single training round (24 hours — accommodates the largest-data site)
+          learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
@@ -52,8 +52,11 @@
           aggregator_id = "aggregator"
           shareable_generator_id = "shareable_generator"
           metric_comparator_id = "metric_comparator"
-          min_responses_required = 2
-          # time to wait for slower clients after minimum responses received (10 min)
+          # WAIT-FOR-ALL: require every participating client each round so a slow site (e.g. UKA)
+          # is never left behind (prevents MODEL_UNRECOGNIZED desync). Set to the NUMBER OF
+          # PARTICIPATING CLIENTS; if a client drops mid-round the round stalls until learn_task_timeout.
+          min_responses_required = 6
+          # time to wait for slower clients after min responses (10 h; only relevant if min_responses_required < #clients)
           wait_time_after_min_resps_received = 36000
         }
       }

--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
@@ -19,8 +19,8 @@
           last_result_transfer_timeout = 1800
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
-          # time to wait for peer to read sent message (30 min — large model streaming)
-          peer_read_timeout = 1800
+          # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
+          peer_read_timeout = 86400
           # time without heartbeat before declaring subprocess dead (15 min)
           heartbeat_timeout = 900
           params_exchange_format = "pytorch"
@@ -42,10 +42,10 @@
           learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
-          # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
-          learn_task_ack_timeout = 1800
-          # time for final result acknowledgment (30 min — 2GB over VPN)
-          final_result_ack_timeout = 1800
+          # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
+          learn_task_ack_timeout = 86400
+          # time for final result acknowledgment (24 h - ride out transient VPN stalls)
+          final_result_ack_timeout = 86400
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_server.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_server.conf
@@ -17,14 +17,14 @@ workflows = [
     args {
       # can also set aggregation clients and train clients, see class for all available args
       num_rounds = 20
-      # time for clients to configure and start (30 min — 10 nodes over VPN)
-      start_task_timeout = 1800
-      # max time without any progress before declaring failure (8 hours — 10 nodes × 20 rounds)
-      progress_timeout = 28800
-      # time for clients to acknowledge configuration (15 min)
-      configure_task_timeout = 900
-      # interval for clients to report status (5 min)
-      max_status_report_interval = 300
+      # time for clients to configure and start (60 min — 8 sites over VPN)
+      start_task_timeout = 3600
+      # max time without any progress before declaring failure (24 hours — slowest site gates each round)
+      progress_timeout = 86400
+      # time for clients to acknowledge configuration (30 min)
+      configure_task_timeout = 1800
+      # interval for clients to report status (24 h — a slow site can be silent for hours during a long round)
+      max_status_report_interval = 86400
     }
   }
 ]

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -38,8 +38,8 @@
         args {
           # train task must be implemented by Executor
           learn_task_name = "train"
-          # max time for a single training round (8 hours — 10 nodes with large models)
-          learn_task_timeout = 28800
+          # max time for a single training round (24 hours — accommodates the largest-data site)
+          learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
@@ -52,8 +52,11 @@
           aggregator_id = "aggregator"
           shareable_generator_id = "shareable_generator"
           metric_comparator_id = "metric_comparator"
-          min_responses_required = 2
-          # time to wait for slower clients after minimum responses received (10 min)
+          # WAIT-FOR-ALL: require every participating client each round so a slow site (e.g. UKA)
+          # is never left behind (prevents MODEL_UNRECOGNIZED desync). Set to the NUMBER OF
+          # PARTICIPATING CLIENTS; if a client drops mid-round the round stalls until learn_task_timeout.
+          min_responses_required = 6
+          # time to wait for slower clients after min responses (10 h; only relevant if min_responses_required < #clients)
           wait_time_after_min_resps_received = 36000
         }
       }

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -19,8 +19,8 @@
           last_result_transfer_timeout = 1800
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
-          # time to wait for peer to read sent message (30 min — large model streaming)
-          peer_read_timeout = 1800
+          # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
+          peer_read_timeout = 86400
           # time without heartbeat before declaring subprocess dead (15 min)
           heartbeat_timeout = 900
           params_exchange_format = "pytorch"
@@ -42,10 +42,10 @@
           learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
-          # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
-          learn_task_ack_timeout = 1800
-          # time for final result acknowledgment (30 min — 2GB over VPN)
-          final_result_ack_timeout = 1800
+          # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
+          learn_task_ack_timeout = 86400
+          # time for final result acknowledgment (24 h - ride out transient VPN stalls)
+          final_result_ack_timeout = 86400
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_server.conf
@@ -17,14 +17,14 @@ workflows = [
     args {
       # can also set aggregation clients and train clients, see class for all available args
       num_rounds = 20
-      # time for clients to configure and start (30 min — 10 nodes over VPN)
-      start_task_timeout = 1800
-      # max time without any progress before declaring failure (8 hours — 10 nodes × 20 rounds)
-      progress_timeout = 28800
-      # time for clients to acknowledge configuration (15 min)
-      configure_task_timeout = 900
-      # interval for clients to report status (5 min)
-      max_status_report_interval = 300
+      # time for clients to configure and start (60 min — 8 sites over VPN)
+      start_task_timeout = 3600
+      # max time without any progress before declaring failure (24 hours — slowest site gates each round)
+      progress_timeout = 86400
+      # time for clients to acknowledge configuration (30 min)
+      configure_task_timeout = 1800
+      # interval for clients to report status (24 h — a slow site can be silent for hours during a long round)
+      max_status_report_interval = 86400
     }
   }
 ]

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -38,8 +38,8 @@
         args {
           # train task must be implemented by Executor
           learn_task_name = "train"
-          # max time for a single training round (8 hours — 10 nodes with large models)
-          learn_task_timeout = 28800
+          # max time for a single training round (24 hours — accommodates the largest-data site)
+          learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
@@ -52,8 +52,11 @@
           aggregator_id = "aggregator"
           shareable_generator_id = "shareable_generator"
           metric_comparator_id = "metric_comparator"
-          min_responses_required = 2
-          # time to wait for slower clients after minimum responses received (10 min)
+          # WAIT-FOR-ALL: require every participating client each round so a slow site (e.g. UKA)
+          # is never left behind (prevents MODEL_UNRECOGNIZED desync). Set to the NUMBER OF
+          # PARTICIPATING CLIENTS; if a client drops mid-round the round stalls until learn_task_timeout.
+          min_responses_required = 6
+          # time to wait for slower clients after min responses (10 h; only relevant if min_responses_required < #clients)
           wait_time_after_min_resps_received = 36000
         }
       }

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -19,8 +19,8 @@
           last_result_transfer_timeout = 1800
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
-          # time to wait for peer to read sent message (30 min — large model streaming)
-          peer_read_timeout = 1800
+          # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
+          peer_read_timeout = 86400
           # time without heartbeat before declaring subprocess dead (15 min)
           heartbeat_timeout = 900
           params_exchange_format = "pytorch"
@@ -42,10 +42,10 @@
           learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
-          # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
-          learn_task_ack_timeout = 1800
-          # time for final result acknowledgment (30 min — 2GB over VPN)
-          final_result_ack_timeout = 1800
+          # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
+          learn_task_ack_timeout = 86400
+          # time for final result acknowledgment (24 h - ride out transient VPN stalls)
+          final_result_ack_timeout = 86400
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_server.conf
@@ -17,14 +17,14 @@ workflows = [
     args {
       # can also set aggregation clients and train clients, see class for all available args
       num_rounds = 20
-      # time for clients to configure and start (30 min — 10 nodes over VPN)
-      start_task_timeout = 1800
-      # max time without any progress before declaring failure (8 hours — 10 nodes × 20 rounds)
-      progress_timeout = 28800
-      # time for clients to acknowledge configuration (15 min)
-      configure_task_timeout = 900
-      # interval for clients to report status (5 min)
-      max_status_report_interval = 300
+      # time for clients to configure and start (60 min — 8 sites over VPN)
+      start_task_timeout = 3600
+      # max time without any progress before declaring failure (24 hours — slowest site gates each round)
+      progress_timeout = 86400
+      # time for clients to acknowledge configuration (30 min)
+      configure_task_timeout = 1800
+      # interval for clients to report status (24 h — a slow site can be silent for hours during a long round)
+      max_status_report_interval = 86400
     }
   }
 ]

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -38,8 +38,8 @@
         args {
           # train task must be implemented by Executor
           learn_task_name = "train"
-          # max time for a single training round (8 hours — 10 nodes with large models)
-          learn_task_timeout = 28800
+          # max time for a single training round (24 hours — accommodates the largest-data site)
+          learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
@@ -52,8 +52,11 @@
           aggregator_id = "aggregator"
           shareable_generator_id = "shareable_generator"
           metric_comparator_id = "metric_comparator"
-          min_responses_required = 2
-          # time to wait for slower clients after minimum responses received (10 min)
+          # WAIT-FOR-ALL: require every participating client each round so a slow site (e.g. UKA)
+          # is never left behind (prevents MODEL_UNRECOGNIZED desync). Set to the NUMBER OF
+          # PARTICIPATING CLIENTS; if a client drops mid-round the round stalls until learn_task_timeout.
+          min_responses_required = 6
+          # time to wait for slower clients after min responses (10 h; only relevant if min_responses_required < #clients)
           wait_time_after_min_resps_received = 36000
         }
       }

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -19,8 +19,8 @@
           last_result_transfer_timeout = 1800
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
-          # time to wait for peer to read sent message (30 min — large model streaming)
-          peer_read_timeout = 1800
+          # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
+          peer_read_timeout = 86400
           # time without heartbeat before declaring subprocess dead (15 min)
           heartbeat_timeout = 900
           params_exchange_format = "pytorch"
@@ -42,10 +42,10 @@
           learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
-          # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
-          learn_task_ack_timeout = 1800
-          # time for final result acknowledgment (30 min — 2GB over VPN)
-          final_result_ack_timeout = 1800
+          # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
+          learn_task_ack_timeout = 86400
+          # time for final result acknowledgment (24 h - ride out transient VPN stalls)
+          final_result_ack_timeout = 86400
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_server.conf
@@ -17,14 +17,14 @@ workflows = [
     args {
       # can also set aggregation clients and train clients, see class for all available args
       num_rounds = 20
-      # time for clients to configure and start (30 min — 10 nodes over VPN)
-      start_task_timeout = 1800
-      # max time without any progress before declaring failure (8 hours — 10 nodes × 20 rounds)
-      progress_timeout = 28800
-      # time for clients to acknowledge configuration (15 min)
-      configure_task_timeout = 900
-      # interval for clients to report status (5 min)
-      max_status_report_interval = 300
+      # time for clients to configure and start (60 min — 8 sites over VPN)
+      start_task_timeout = 3600
+      # max time without any progress before declaring failure (24 hours — slowest site gates each round)
+      progress_timeout = 86400
+      # time for clients to acknowledge configuration (30 min)
+      configure_task_timeout = 1800
+      # interval for clients to report status (24 h — a slow site can be silent for hours during a long round)
+      max_status_report_interval = 86400
     }
   }
 ]

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -38,8 +38,8 @@
         args {
           # train task must be implemented by Executor
           learn_task_name = "train"
-          # max time for a single training round (8 hours — 10 nodes with large models)
-          learn_task_timeout = 28800
+          # max time for a single training round (24 hours — accommodates the largest-data site)
+          learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
@@ -52,8 +52,11 @@
           aggregator_id = "aggregator"
           shareable_generator_id = "shareable_generator"
           metric_comparator_id = "metric_comparator"
-          min_responses_required = 2
-          # time to wait for slower clients after minimum responses received (10 min)
+          # WAIT-FOR-ALL: require every participating client each round so a slow site (e.g. UKA)
+          # is never left behind (prevents MODEL_UNRECOGNIZED desync). Set to the NUMBER OF
+          # PARTICIPATING CLIENTS; if a client drops mid-round the round stalls until learn_task_timeout.
+          min_responses_required = 6
+          # time to wait for slower clients after min responses (10 h; only relevant if min_responses_required < #clients)
           wait_time_after_min_resps_received = 36000
         }
       }

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -19,8 +19,8 @@
           last_result_transfer_timeout = 1800
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
-          # time to wait for peer to read sent message (30 min — large model streaming)
-          peer_read_timeout = 1800
+          # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
+          peer_read_timeout = 86400
           # time without heartbeat before declaring subprocess dead (15 min)
           heartbeat_timeout = 900
           params_exchange_format = "pytorch"
@@ -42,10 +42,10 @@
           learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
-          # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
-          learn_task_ack_timeout = 1800
-          # time for final result acknowledgment (30 min — 2GB over VPN)
-          final_result_ack_timeout = 1800
+          # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
+          learn_task_ack_timeout = 86400
+          # time for final result acknowledgment (24 h - ride out transient VPN stalls)
+          final_result_ack_timeout = 86400
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_4abmil/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_server.conf
@@ -17,14 +17,14 @@ workflows = [
     args {
       # can also set aggregation clients and train clients, see class for all available args
       num_rounds = 20
-      # time for clients to configure and start (30 min — 10 nodes over VPN)
-      start_task_timeout = 1800
-      # max time without any progress before declaring failure (8 hours — 10 nodes × 20 rounds)
-      progress_timeout = 28800
-      # time for clients to acknowledge configuration (15 min)
-      configure_task_timeout = 900
-      # interval for clients to report status (5 min)
-      max_status_report_interval = 300
+      # time for clients to configure and start (60 min — 8 sites over VPN)
+      start_task_timeout = 3600
+      # max time without any progress before declaring failure (24 hours — slowest site gates each round)
+      progress_timeout = 86400
+      # time for clients to acknowledge configuration (30 min)
+      configure_task_timeout = 1800
+      # interval for clients to report status (24 h — a slow site can be silent for hours during a long round)
+      max_status_report_interval = 86400
     }
   }
 ]

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -38,8 +38,8 @@
         args {
           # train task must be implemented by Executor
           learn_task_name = "train"
-          # max time for a single training round (8 hours — 10 nodes with large models)
-          learn_task_timeout = 28800
+          # max time for a single training round (24 hours — accommodates the largest-data site)
+          learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
@@ -52,8 +52,11 @@
           aggregator_id = "aggregator"
           shareable_generator_id = "shareable_generator"
           metric_comparator_id = "metric_comparator"
-          min_responses_required = 2
-          # time to wait for slower clients after minimum responses received (10 min)
+          # WAIT-FOR-ALL: require every participating client each round so a slow site (e.g. UKA)
+          # is never left behind (prevents MODEL_UNRECOGNIZED desync). Set to the NUMBER OF
+          # PARTICIPATING CLIENTS; if a client drops mid-round the round stalls until learn_task_timeout.
+          min_responses_required = 6
+          # time to wait for slower clients after min responses (10 h; only relevant if min_responses_required < #clients)
           wait_time_after_min_resps_received = 36000
         }
       }

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -19,8 +19,8 @@
           last_result_transfer_timeout = 1800
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
-          # time to wait for peer to read sent message (30 min — large model streaming)
-          peer_read_timeout = 1800
+          # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
+          peer_read_timeout = 86400
           # time without heartbeat before declaring subprocess dead (15 min)
           heartbeat_timeout = 900
           params_exchange_format = "pytorch"
@@ -42,10 +42,10 @@
           learn_task_timeout = 86400
           # time to wait for learn task to abort gracefully (5 min)
           learn_task_abort_timeout = 300
-          # time for task acknowledgment incl. model weight streaming (30 min — 2GB over VPN)
-          learn_task_ack_timeout = 1800
-          # time for final result acknowledgment (30 min — 2GB over VPN)
-          final_result_ack_timeout = 1800
+          # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
+          learn_task_ack_timeout = 86400
+          # time for final result acknowledgment (24 h - ride out transient VPN stalls)
+          final_result_ack_timeout = 86400
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_5pimed/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_server.conf
@@ -17,14 +17,14 @@ workflows = [
     args {
       # can also set aggregation clients and train clients, see class for all available args
       num_rounds = 20
-      # time for clients to configure and start (30 min — 10 nodes over VPN)
-      start_task_timeout = 1800
-      # max time without any progress before declaring failure (8 hours — 10 nodes × 20 rounds)
-      progress_timeout = 28800
-      # time for clients to acknowledge configuration (15 min)
-      configure_task_timeout = 900
-      # interval for clients to report status (5 min)
-      max_status_report_interval = 300
+      # time for clients to configure and start (60 min — 8 sites over VPN)
+      start_task_timeout = 3600
+      # max time without any progress before declaring failure (24 hours — slowest site gates each round)
+      progress_timeout = 86400
+      # time for clients to acknowledge configuration (30 min)
+      configure_task_timeout = 1800
+      # interval for clients to report status (24 h — a slow site can be silent for hours during a long round)
+      max_status_report_interval = 86400
     }
   }
 ]

--- a/assets/readme/README.developer.md
+++ b/assets/readme/README.developer.md
@@ -136,6 +136,38 @@ For `--preflight_check` and `--local_training` modes, the `--job` flag selects w
 
 Each challenge job has its own `config_fed_client.conf`, model code, and `main.py` with a hardcoded `MODEL_NAME`.
 
+## Operating & Hardening Swarm Runs
+
+Real multi-site runs surfaced several recurring failure modes; each now has a
+fix, a pre-flight check, or both. The full catalogue + operator playbook is in
+[`docs/SWARM_FAILURE_MODES.md`](../../docs/SWARM_FAILURE_MODES.md); timeout values
+are in [`docs/TIMEOUTS.md`](../../docs/TIMEOUTS.md). Summary:
+
+| Failure | Fix | Where |
+|---------|-----|-------|
+| Slow site → status-timeout abort | 24 h `max_status_report_interval`/`progress_timeout`/`learn_task_timeout` | job `config_fed_*.conf` |
+| Slow site → `MODEL_UNRECOGNIZED` desync | `min_responses_required` = number of participating clients (wait-for-all) | job `config_fed_client.conf` |
+| GPU `NVML: Unknown Error` mid-run | switch host Docker to `cgroupfs` driver | `scripts/client_node_setup/fix_docker_cgroupfs.sh` |
+| Client won't restart (stale lock) | delete `daemon_pid.fl` before relaunch | pre-flight check auto-clears |
+| Read-only cache crash | cache under `/scratch`, not `/data` | pre-flight check fails fast |
+| VPN tunnel drop | network/VPN side; 24 h timeout bounds a brief drop | — |
+
+**Pre-flight checks.** `docker.sh` (generated from `docker_config/master_template.yml`,
+`_preflight_host_checks`) runs host checks for `--dummy_training`/`--preflight_check`/`--start_client`
+(GPU usable in container, cgroup-driver risk, cache path, server reachability, stale lock).
+Always have participants re-run dummy + pre-flight before every scheduled run.
+
+**`min_responses_required` must equal the participating-client count.** Wait-for-all
+prevents the slow-node desync but means any mid-round drop stalls the round until
+`learn_task_timeout`. Set it per run; lower it only if a flaky site must be tolerated.
+
+**Operator diagnostics.** Drive the live server with the admin kit
+(`./fl_admin.sh`): `check_status server` (a frozen last-connect = a stale/dead
+client), `check_status client`, `list_jobs`, `abort_job <id>` (needs a `y`),
+`submit_job <path>`. Post-mortem of a finished/failed job: the run workspace is
+in the job store at `/tmp/nvflare/jobs-storage/<job_id>/workspace` (a zip) inside
+the server container — `log_error.txt` has the abort reason.
+
 ## Contributing Application Code
 
 

--- a/assets/readme/README.participant.md
+++ b/assets/readme/README.participant.md
@@ -165,6 +165,14 @@ To have a baseline for swarm training, train the same model in a comparable way 
    cd $SITE_NAME/startup  # Skip this if you just ran the pre-flight check
    ```
 
+> **Pre-run checklist — do this before _every_ swarm run, even if it passed last week.** Environments drift between runs (automatic OS/driver upgrades, IT changes, read-only mounts, re-synced or corrupted data), so a node that worked before can be broken today. Re-run the [dummy training](#local-testing-on-your-data) and [pre-flight check](#local-testing-on-your-data) above and confirm:
+> - the dummy training succeeds → the **GPU is usable inside the container**;
+> - your preprocessing cache `ODELIA_PREPROCESS_CACHE_DIR` is under `/scratch` (writable), **never under `/data`** (read-only);
+> - `dl3.tud.de:8002` is reachable (VPN up);
+> - when restarting a client, the old container is removed **and** any stale `daemon_pid.fl` is deleted.
+>
+> `docker.sh` now also runs **automatic pre-run checks** and prints a `Pre-run checks` block (PASS / WARN / FAIL) with remediation. In particular, if you are on Docker's `systemd` cgroup driver it will warn you to run `scripts/client_node_setup/fix_docker_cgroupfs.sh` to avoid the GPU dropping mid-run (see Troubleshooting below and [`docs/SWARM_FAILURE_MODES.md`](../../docs/SWARM_FAILURE_MODES.md)). Reserve enough time before the scheduled run to fix anything they flag.
+
 2. Start the client:
    ```bash
    ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --start_client
@@ -226,6 +234,41 @@ ODELIA_PREPROCESS_CACHE_DIR=$SCRATCHDIR/odelia_preprocess_cache \
 ```
 
 See [Run Local Training](#run-local-training) for details. This caches each preprocessed volume as a compressed `.npz` on fast local storage, so epochs after the first read quickly and the GPU stays fed. It applies to local training, the pre-flight check, and the swarm client.
+
+### GPU Lost Mid-Run (`NVML: Unknown Error`)
+
+If training crashes with `Failed to initialize NVML: Unknown Error` (or `This example does not work without GPU`) **while `nvidia-smi` on the host works fine**, the container lost access to the GPU. This happens on hosts using Docker's **systemd** cgroup driver (the Ubuntu default) when a `systemctl daemon-reload` runs — e.g. the **daily automatic apt upgrade** — which strips the GPU from already-running containers.
+
+* Quick check: `docker exec $(docker ps -q --filter name=odelia_swarm_client) nvidia-smi -L` fails while host `nvidia-smi` works.
+* **Durable fix** (persists across reboots, so the daily upgrade no longer breaks it):
+  ```bash
+  sudo bash scripts/client_node_setup/fix_docker_cgroupfs.sh
+  ```
+  Then recreate the client (next item). See [`docs/SWARM_FAILURE_MODES.md`](../../docs/SWARM_FAILURE_MODES.md) (F2).
+
+### Client Won't Start After a Restart (stale `daemon_pid.fl`)
+
+If you recreated the client (`docker rm -f …`) and it shows `Up … (healthy)` but never registers with the server, check `nohup.out` for `There seems to be one instance, pid=N, running … remove daemon_pid.fl`. An unclean stop left a lock file that makes `start.sh` refuse to launch.
+
+```bash
+docker rm -f $(docker ps -aq --filter name=odelia_swarm_client_$SITE_NAME)
+find . -maxdepth 2 -name daemon_pid.fl -delete      # from the kit root ($SITE_NAME/)
+./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --start_client
+```
+(The automatic pre-run check now clears a stale `daemon_pid.fl` for you when no client container is running.)
+
+### `Read-only file system` Crash
+
+If training crashes immediately with `OSError: [Errno 30] Read-only file system: '/data/...'`, your preprocessing cache points under `/data`, which is mounted read-only. Set it under `/scratch` (the container path), never under `/data`:
+```bash
+ODELIA_ENABLE_PREPROCESS_CACHE=1 \
+ODELIA_PREPROCESS_CACHE_DIR=/scratch/odelia_preprocess_cache \
+./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --start_client
+```
+
+### Node "Deemed Disconnected" Mid-Run (VPN drop)
+
+If the operator reports your node was `deemed disconnected` and the run aborted, your VPN tunnel to the server dropped *during* the run (the host stays up; only the VPN path fails). Check `ping dl3.tud.de` over time and `nc -vz dl3.tud.de 8002`. Persistent or intermittent drops should be raised with your network/VPN provider (a keepalive often helps) — in a wait-for-all swarm run, even a brief drop on one node can abort the whole round.
 
 ### Further Possible Issues
 

--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -910,6 +910,79 @@ docker_cln_sh: |
     fi
   }
 
+  # ── Pre-run host checks ────────────────────────────────────────────
+  # Surface the failure modes we have repeatedly hit (GPU/cgroup loss,
+  # read-only preprocessing cache, server unreachable, stale client lock)
+  # BEFORE a run, with concrete remediation. See docs/SWARM_FAILURE_MODES.md.
+  _preflight_host_checks() {
+      local fail=0
+      echo "──────────────── Pre-run checks ────────────────"
+
+      # F2: GPU usable inside a container (catches 'NVML: Unknown Error')
+      if timeout 90 docker run --rm --gpus=$GPU2USE $DOCKER_IMAGE nvidia-smi -L >/dev/null 2>&1; then
+          echo "[PASS] GPU usable inside the container."
+      else
+          echo "[FAIL] GPU NOT usable inside the container (likely 'NVML: Unknown Error')."
+          echo "       Fix: run  scripts/client_node_setup/fix_docker_cgroupfs.sh  then recreate the client (docs: F2)."
+          fail=1
+      fi
+
+      # F2 (preventive): systemd cgroup driver -> daemon-reload can strip the GPU mid-run
+      local cgdrv; cgdrv=$(docker info 2>/dev/null | sed -n 's/.*Cgroup Driver: //p' | head -1)
+      if [ "$cgdrv" = "systemd" ]; then
+          echo "[WARN] Docker cgroup driver is 'systemd'. A daily 'systemctl daemon-reload' (e.g. apt"
+          echo "       auto-upgrade) can strip the GPU from RUNNING containers mid-run. Recommended:"
+          echo "       scripts/client_node_setup/fix_docker_cgroupfs.sh  (switches to cgroupfs; docs: F2)."
+      fi
+
+      # F4: preprocessing cache must be writable and NOT under the read-only /data mount
+      if [ "${ODELIA_ENABLE_PREPROCESS_CACHE:-}" = "1" ]; then
+          case "${ODELIA_PREPROCESS_CACHE_DIR:-}" in
+            /data|/data/*)
+              echo "[FAIL] ODELIA_PREPROCESS_CACHE_DIR='$ODELIA_PREPROCESS_CACHE_DIR' is under /data, which is"
+              echo "       mounted READ-ONLY -> training crashes with 'Read-only file system'. Point it under"
+              echo "       /scratch, e.g. ODELIA_PREPROCESS_CACHE_DIR=/scratch/odelia_preprocess_cache (docs: F4)."
+              fail=1 ;;
+          esac
+      fi
+
+      # Checks that only matter when actually joining the swarm
+      if [ -n "$START_CLIENT" ]; then
+          # F6: swarm server reachable over the VPN (best-effort parse of host:port from kit config)
+          local ep host port
+          ep=$(grep -hoE '[A-Za-z0-9][A-Za-z0-9.-]+\.[A-Za-z]{2,}:80[0-9][0-9]' "$DIR"/*.json 2>/dev/null | head -1)
+          if [ -n "$ep" ]; then
+              host=${ep%%:*}; port=${ep##*:}
+              if timeout 6 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
+                  echo "[PASS] Swarm server $ep reachable."
+              else
+                  echo "[WARN] Swarm server $ep NOT reachable — check the VPN and /etc/hosts (docs: F6)."
+              fi
+          fi
+          # F3: a stale daemon_pid.fl blocks start.sh ("one instance running") after an unclean stop
+          local lock="$DIR/../daemon_pid.fl"
+          if [ -f "$lock" ]; then
+              if docker ps --filter "name=odelia_swarm_client" --format '{{.Names}}' | grep -q .; then
+                  echo "[WARN] $lock present and a client container is running; leaving it in place."
+              else
+                  echo "[INFO] Removing stale daemon_pid.fl (no client container running) so start.sh can launch (docs: F3)."
+                  rm -f "$lock"
+              fi
+          fi
+      fi
+
+      echo "─────────────────────────────────────────────────"
+      if [ "$fail" = "1" ]; then
+          echo "[ABORT] Pre-run checks failed — fix the [FAIL] item(s) above and retry."
+          exit 2
+      fi
+  }
+
+  # Run pre-run host checks for the GPU-using modes
+  if [ -n "$DUMMY_TRAINING" ] || [ -n "$PREFLIGHT_CHECK" ] || [ -n "$START_CLIENT" ]; then
+      _preflight_host_checks
+  fi
+
   # Execution modes
   if [ -n "$DUMMY_TRAINING" ]; then
       docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training $DOCKER_IMAGE \

--- a/docs/SWARM_FAILURE_MODES.md
+++ b/docs/SWARM_FAILURE_MODES.md
@@ -1,0 +1,99 @@
+# ODELIA Swarm — Failure Modes & Operator Runbook
+
+A catalogue of the failure modes seen in real multi-site ODELIA swarm runs, how to
+**detect** each (ideally before a run, via the pre-flight checks), how to **fix** it,
+and how to **prevent** it. Plus an operator diagnostic playbook.
+
+Most of these are now caught automatically by the pre-run checks in the startup-kit
+`docker.sh` (`--dummy_training` / `--preflight_check` / `--start_client`); see
+[`docker_config/master_template.yml`](../docker_config/master_template.yml) (`_preflight_host_checks`).
+
+## Quick reference
+
+| ID | Symptom | Root cause | Fix |
+|----|---------|-----------|-----|
+| F1 | Run aborts: `client X didn't report status for N seconds` | Slow site silent during its long round > `max_status_report_interval` | 24 h timeouts (committed in the job configs) |
+| F2 | `NVML: Unknown Error` in container; GPU "vanishes" mid-run | Daily `daemon-reload` strips GPU on cgroup v2 + **systemd** Docker driver | `scripts/client_node_setup/fix_docker_cgroupfs.sh` (→ cgroupfs) |
+| F3 | Client "healthy" but never registers after a restart | Stale `daemon_pid.fl` lock makes `start.sh` refuse to launch | Delete `daemon_pid.fl` in the kit root, relaunch |
+| F4 | Instant crash: `OSError: Read-only file system` | Preprocessing cache under the read-only `/data` mount | Point `ODELIA_PREPROCESS_CACHE_DIR` under `/scratch` |
+| F5 | Run aborts: `MODEL_UNRECOGNIZED` from a slow site | Swarm advanced a round without the slow site; its late model rejected | Wait-for-all (`min_responses_required = #clients`) |
+| F6 | Run aborts after a node goes `deemed disconnected` | VPN tunnel drop for that site | Stabilise the VPN (keepalive / network); wait-for-all bounds it by `learn_task_timeout` |
+| F7 | `DataLoader worker killed by signal: Bus error … shared memory` | `/dev/shm` too small for the dataloader workers | `--ipc=host` (already set for swarm clients) / `--shm-size` |
+
+---
+
+## F1 — Slow-node status timeout
+- **Symptom (server log):** `Aborting current RUN due to FATAL_SYSTEM_ERROR received: client UKA_1 didn't report status for 7200 seconds`.
+- **Root cause:** The largest-data site (UKA ≈ 9× the others) trains a single round for hours and reports no status in between. The `SwarmServerController.max_status_report_interval` declares it dead and aborts the job.
+- **Detection:** per-round wall-clock far exceeds the status interval; site finishes `start_learn_task` then goes silent.
+- **Fix:** the challenge/MST job configs now use **24 h** for `max_status_report_interval`, `progress_timeout`, and `learn_task_timeout`. These ship with the submitted job (byoc) — **no startup-kit rebuild needed**; the change takes effect on the next job submission.
+- **Prevention:** keep timeouts well above the slowest site's per-round time; see [`docs/TIMEOUTS.md`](TIMEOUTS.md).
+
+## F2 — GPU "NVML: Unknown Error" mid-run (the GPU vanishes)
+- **Symptom:** in-container `nvidia-smi` returns `Failed to initialize NVML: Unknown Error` while the **host** GPU is fine; training crashes with `This example does not work without GPU`. Recurs roughly daily.
+- **Root cause:** the host's daily `apt-daily-upgrade` runs `systemctl daemon-reload`, which on **cgroup v2 + Docker's `systemd` cgroup driver** re-applies device cgroup rules and strips the GPU from *already-running* containers.
+- **Detection:** the pre-run check warns when the Docker cgroup driver is `systemd`; `docker exec <client> nvidia-smi -L` fails while host `nvidia-smi` works.
+- **Fix (host-level, durable):** run **`scripts/client_node_setup/fix_docker_cgroupfs.sh`** (as root) — switches Docker to the `cgroupfs` driver and validates that a `daemon-reload` no longer drops the GPU. Then recreate the client (see F3). The change persists across reboots.
+- **Prevention:** use the `cgroupfs` driver on all client hosts; the pre-run check flags `systemd`.
+
+## F3 — Stale `daemon_pid.fl` blocks client restart
+- **Symptom:** after `docker rm -f` of a client, the new container is `Up … (healthy)` (the healthcheck only runs `nvidia-smi`) but the site never registers; `nohup.out` shows `There seems to be one instance, pid=N, running … remove daemon_pid.fl`.
+- **Root cause:** an unclean stop leaves a `daemon_pid.fl` lock in the kit root; `start.sh` refuses to launch a "second" instance.
+- **Detection:** the pre-run check (for `--start_client`) detects the lock and removes it when no client container is running.
+- **Fix:** delete `daemon_pid.fl` in the kit root, then relaunch `./docker.sh --start_client`.
+- **Prevention:** always clear the lock when recreating a client; the pre-run check now does this automatically.
+
+## F4 — Read-only preprocessing-cache path
+- **Symptom:** instant crash `OSError: [Errno 30] Read-only file system: '/data/.../odelia_preprocess_cache'`.
+- **Root cause:** `ODELIA_PREPROCESS_CACHE_DIR` was set under `/data`, which is mounted **read-only** in the container.
+- **Detection:** the pre-run check fails if `ODELIA_PREPROCESS_CACHE_DIR` is under `/data`.
+- **Fix:** set it to a container path under `/scratch`, e.g. `ODELIA_PREPROCESS_CACHE_DIR=/scratch/odelia_preprocess_cache`.
+- **Prevention:** always keep the cache under `/scratch` (writable); never under `/data`.
+
+## F5 — Slow-node desync (`MODEL_UNRECOGNIZED`)
+- **Symptom:** with `min_responses_required = 2`, fast sites finish round *r* and the swarm advances to *r+1*; when the slow site finally submits its round-*r* model, the aggregator rejects it: `cwf.error: MODEL_UNRECOGNIZED`, then the run aborts.
+- **Root cause:** the swarm did not wait for the slow site, so its contribution became stale.
+- **Fix:** **wait-for-all** — set `min_responses_required` to the number of participating clients, so a round cannot advance until every site (including the slowest) submits.
+- **Tradeoff:** wait-for-all is robust against desync but **fragile to drops** — if any client drops mid-round, the round stalls until `learn_task_timeout`. Set `min_responses_required` to the actual participating-client count for the run.
+
+## F6 — VPN tunnel drop ("deemed disconnected")
+- **Symptom (server log):** `received dead job report for client X` → `Client X is deemed disconnected!`; the site's heartbeats stop, then re-appear later. With wait-for-all, the round stalls until the site returns or `learn_task_timeout` fires.
+- **Root cause:** the site's VPN tunnel drops (observed: a ~2.5 h GoodAccess outage for the Aachen node). Host stays up; only the VPN path to the server is down.
+- **Detection:** site shows `cannot send to 'server': target_unreachable` continuously; the pre-run check warns if the server `host:port` is not reachable at start.
+- **Fix / prevention:** stabilise the VPN (keepalive / dead-peer-detection / dedicated gateway; raise with the VPN provider). The 24 h timeouts give a long window for a brief drop to self-heal before the run aborts.
+
+## F7 — Shared-memory (`/dev/shm`) bus error
+- **Symptom:** `ERROR: Unexpected bus error … insufficient shared memory (shm)` / `DataLoader worker … killed by signal: Bus error`.
+- **Root cause:** the container's default 64 MB `/dev/shm` is too small for multi-worker 3D dataloaders.
+- **Fix:** swarm clients run with `--ipc=host` (shares the host `/dev/shm`); ad-hoc containers can use `--shm-size=16g`.
+- **Prevention:** keep `--ipc=host` on swarm clients (already in `master_template.yml`).
+
+---
+
+## Operator diagnostic playbook
+
+**Drive the live server** via the admin startup kit (run `./fl_admin.sh` in the odelia image with `--net=host`, username line first):
+- `check_status server` — registered clients + last-connect times (a frozen last-connect = a stale/dead client).
+- `check_status client` — per-client job state (`No Reply` = client registered but not responding).
+- `list_jobs [<job_id>]` — job history/status.
+- `abort_job <job_id>` (needs a `y` confirmation) — stop a hung/failed run.
+- `submit_job <path>` — paths can be in-image (`/MediSwarm/application/jobs/<job>`) or mounted.
+
+**Live job log** (server side): `/<server-kit>/<job_id>/log.txt` inside the server container — round events (`start_learn_task` / `finished_learn_task` / `better_aggregation`).
+
+**Post-mortem of a FINISHED job:** the run workspace is moved to the job store at
+`/tmp/nvflare/jobs-storage/<job_id>/workspace` (a zip) inside the server container — read `log_error.txt` for the abort reason and `log.txt` for the round timeline.
+
+**Per-site logs:** each client keeps its NVFlare log at the kit root (`log.txt`), console at `startup/nohup.out`, and the global model under `<job_id>/app_<SITE>/{FL_global_model.pt,best_FL_global_model.pt}`.
+
+**Monitoring a long run:** poll `list_jobs <job_id>` on a low frequency and act on a *round advance*, an error, or a terminal state — rather than watching continuously. Rounds are gated by the slowest site.
+
+## Before every run
+Run the pre-flight checks from the startup kit, **even if they passed before** — environments drift between runs (auto-updates, driver/IT changes, read-only mounts, re-synced or corrupted data):
+
+```bash
+./docker.sh --scratch_dir $SCRATCHDIR --GPU device=0 --dummy_training      # GPU + container smoke
+./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check   # data + 1 epoch
+```
+
+Both now print a `Pre-run checks` block covering F2/F3/F4/F6. Reserve enough time before the scheduled run to resolve anything they flag.

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -10,13 +10,20 @@ ones, or the outer layer will kill a run that was still making progress.
 ```
 CI workflow timeout (3 days = 4320 min)
   └── Deploy script per-model timeout (7 days = 10080 min)
-        └── NVFlare progress_timeout (8 h = 28800 s)
-              └── learn_task_timeout (8 h = 28800 s)
+        └── NVFlare progress_timeout (24 h = 86400 s)
+              ├── max_status_report_interval (24 h = 86400 s)   # server declares a silent client dead
+              └── learn_task_timeout (24 h = 86400 s)
                     ├── heartbeat_timeout (15 min = 900 s)
                     ├── peer_read_timeout (30 min = 1800 s)
                     ├── external_pre_init_timeout (10 min = 600 s)
                     └── last_result_transfer_timeout (30 min = 1800 s)
 ```
+
+> **Heterogeneous (8-site) runs:** `progress_timeout`, `max_status_report_interval`,
+> and `learn_task_timeout` were raised to **24 h** because the slowest site (≈9× the
+> data of the others) gates every round and is *silent* for the whole duration of its
+> round. See [`SWARM_FAILURE_MODES.md`](SWARM_FAILURE_MODES.md) F1 and the
+> "Slow node & synchronization" section below.
 
 ---
 
@@ -56,10 +63,10 @@ These are set in each job's `config_fed_server.conf`:
 
 | Setting | Value | Description |
 |---------|-------|-------------|
-| `progress_timeout` | **28800 s** (8 h) | Max time without any client reporting progress before the server declares the job failed. |
-| `start_task_timeout` | **1800 s** (30 min) | Time for all clients to pull their startup kits, connect, and be ready. |
-| `configure_task_timeout` | **900 s** (15 min) | Time for clients to acknowledge the swarm configuration message. |
-| `max_status_report_interval` | **300 s** (5 min) | How often clients must report status to prove they are alive. |
+| `progress_timeout` | **86400 s** (24 h) | Max time without any client reporting progress before the server declares the job failed. |
+| `start_task_timeout` | **3600 s** (60 min) | Time for all clients to pull their startup kits, connect, and be ready. |
+| `configure_task_timeout` | **1800 s** (30 min) | Time for clients to acknowledge the swarm configuration message. |
+| `max_status_report_interval` | **86400 s** (24 h) | How long a client may be **silent** before the server declares it dead and aborts. A slow site is silent for the *entire* duration of its long round, so this must exceed the slowest per-round time. **Raised from 5 min — that was the cause of the UKA `didn't report status` abort (F1).** |
 
 **File:** `application/jobs/*/app/config/config_fed_server.conf`
 
@@ -75,17 +82,44 @@ These are set in each job's `config_fed_client.conf`:
 
 | Setting | Value | Description |
 |---------|-------|-------------|
-| `learn_task_timeout` | **28800 s** (8 h) | Max time for a single training round (all local epochs). The most critical timeout for large models. |
+| `learn_task_timeout` | **86400 s** (24 h) | Max time for a single training round (all local epochs). The most critical timeout for large models / large-data sites. |
 | `learn_task_abort_timeout` | **300 s** (5 min) | Grace period for a training round to finish after an abort is requested. |
 | `learn_task_ack_timeout` | **1800 s** (30 min) | Time for the training task acknowledgment, including streaming model weights to peers. |
 | `final_result_ack_timeout` | **1800 s** (30 min) | Time for the final aggregated result acknowledgment. |
-| `wait_time_after_min_resps_received` | **600 s** (10 min) | After `min_responses_required` clients have finished a round, wait this long for stragglers before proceeding. |
+| `min_responses_required` | **= number of participating clients** (wait-for-all) | How many client contributions a round must gather before aggregating and advancing. See "Slow node & synchronization" below. |
+| `wait_time_after_min_resps_received` | **36000 s** (10 h) | After `min_responses_required` clients finish a round, wait this long for stragglers. Largely **moot** when `min_responses_required` = all clients. |
 
 **File:** `application/jobs/*/app/config/config_fed_client.conf`
 
 **Risk if `learn_task_timeout` is too low:** Slow clients (small GPU, large
-model, many epochs) time out during training. The round is marked as failed and
-the job may abort. This was the bottleneck in early deploy tests (was 4h, now 8h).
+model, many epochs / large data) time out during training. The round is marked
+failed and the job may abort. Raised 4h → 8h → **24h** for 8-site runs.
+
+---
+
+## 4b. Slow node & synchronization
+
+Heterogeneous node speeds (one site with ~9× the data) exposed two distinct
+failure modes that are *not* fixed by timeouts alone — see
+[`SWARM_FAILURE_MODES.md`](SWARM_FAILURE_MODES.md):
+
+- **F1 — status timeout.** The slow site is silent for the whole duration of its
+  long round, so the server's `max_status_report_interval` declared it dead. Fixed
+  by raising that interval (and `progress_timeout` / `learn_task_timeout`) to 24 h.
+- **F5 — `MODEL_UNRECOGNIZED` desync.** With `min_responses_required = 2`, the fast
+  sites aggregated and advanced the round *without* the slow site; when it finally
+  submitted, the aggregator rejected its now-stale model and the run aborted.
+
+**Default: wait-for-all.** Set `min_responses_required` to the **number of
+participating clients** so a round cannot advance until every site (including the
+slowest) has submitted. This eliminates the desync.
+
+**Tradeoff (document for operators):** wait-for-all is robust against desync but
+**fragile to drops** — if any client disconnects mid-round (e.g. a VPN drop, F6),
+the round cannot reach the required count and **stalls until `learn_task_timeout`**
+(24 h) before failing. Set `min_responses_required` to the actual participating
+count for each run; if a flaky site must be tolerated, lower it (accepting that a
+much-slower site may desync).
 
 ---
 

--- a/scripts/client_node_setup/fix_docker_cgroupfs.sh
+++ b/scripts/client_node_setup/fix_docker_cgroupfs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Fix the recurring "Failed to initialize NVML: Unknown Error" that strips the GPU
+# from already-running containers after a `systemctl daemon-reload` (e.g. the daily
+# apt auto-upgrade) on hosts using Docker's *systemd* cgroup driver on cgroup v2.
+#
+# It switches Docker to the cgroupfs cgroup driver (daemon-reload-safe). This
+# restarts the Docker daemon, which briefly bounces ALL containers on the host
+# (they recover per their restart policy). The change auto-reverts if Docker fails
+# to come back. See docs/SWARM_FAILURE_MODES.md (failure mode F2).
+#
+#   Run as root:   sudo bash fix_docker_cgroupfs.sh
+set -u
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run as root, e.g.:  sudo bash $0"
+    exit 1
+fi
+
+D=/etc/docker/daemon.json
+
+echo "[1/4] Current Docker cgroup driver…"
+cur=$(docker info 2>/dev/null | sed -n 's/.*Cgroup Driver: //p' | head -1)
+echo "      driver = ${cur:-unknown}"
+if [ "$cur" = "cgroupfs" ]; then
+    echo "      Already on cgroupfs — nothing to do."
+    exit 0
+fi
+
+echo "[2/4] Backing up and updating $D (merging native.cgroupdriver=cgroupfs)…"
+BK=""
+if [ -f "$D" ]; then BK="$D.bak.$(date +%s)"; cp -a "$D" "$BK"; echo "      backup -> $BK"; fi
+python3 - <<'PY'
+import json, os
+p = "/etc/docker/daemon.json"; cfg = {}
+if os.path.exists(p):
+    try: cfg = json.load(open(p))
+    except Exception: cfg = {}
+opts = [o for o in cfg.get("exec-opts", []) if not o.startswith("native.cgroupdriver=")]
+opts.append("native.cgroupdriver=cgroupfs"); cfg["exec-opts"] = opts
+json.dump(cfg, open(p, "w"), indent=4)
+print("      new daemon.json:")
+print(open(p).read())
+PY
+
+echo "[3/4] Restarting Docker (briefly bounces all containers on this host)…"
+systemctl restart docker; sleep 10
+if ! docker info >/dev/null 2>&1; then
+    echo "[!!] Docker did not come back — reverting daemon.json."
+    if [ -n "$BK" ]; then cp -a "$BK" "$D"; else rm -f "$D"; fi
+    systemctl restart docker; sleep 8
+    docker info >/dev/null 2>&1 && echo "      Reverted; Docker is back up (still on the old driver)." \
+                                || echo "      Docker STILL DOWN — investigate manually."
+    exit 2
+fi
+echo "      Docker OK. driver = $(docker info 2>/dev/null | sed -n 's/.*Cgroup Driver: //p' | head -1)"
+
+echo "[4/4] Validating that a daemon-reload no longer strips the GPU…"
+C=$(docker ps --filter name=odelia_swarm_client --format '{{.Names}}' | head -1)
+if [ -n "$C" ]; then
+    systemctl daemon-reload; sleep 3
+    if docker exec "$C" nvidia-smi -L >/dev/null 2>&1; then
+        echo "      PASS: GPU still visible in $C after daemon-reload."
+    else
+        echo "      NOTE: GPU not visible in $C now — recreate the client:"
+        echo "            docker rm -f $C ; remove the kit's daemon_pid.fl ; ./docker.sh --start_client"
+    fi
+else
+    echo "      (No running odelia_swarm_client container to validate against — that's fine.)"
+fi
+
+echo
+echo "Done. The cgroupfs change persists across reboots; the swarm client does NOT —"
+echo "after a host reboot, relaunch it with ./docker.sh --start_client (clear daemon_pid.fl first)."


### PR DESCRIPTION
## Why
Consolidates the fixes from a real 8-site ODELIA swarm campaign so future builds/runs are robust and participants can self-detect/fix problems **before** a run. **Supersedes #339** (24 h timeouts); builds on **#327** (merged — per-model swarm configs, `--shm-size`, MODEL_NAME gating). Full catalogue: `docs/SWARM_FAILURE_MODES.md`.

## What

**Config — all 6 `challenge_*` jobs + `ODELIA_ternary_classification`**
- server (`config_fed_server.conf`): `max_status_report_interval` 300 s → **24 h**, `progress_timeout` 8 h → **24 h**, `start_task_timeout`→60 min, `configure_task_timeout`→30 min. (A slow site is silent for its whole round; the 5-min status interval caused the `didn't report status` abort — F1.)
- client (`config_fed_client.conf`): `learn_task_timeout` 8 h → **24 h**; **`min_responses_required` 2 → 6 (wait-for-all)** so a slow site is never left behind (prevents `MODEL_UNRECOGNIZED` desync — F5). Documented tradeoff: a mid-round drop then stalls until `learn_task_timeout`; set this to the participating-client count.

**Preflight checks** — `docker_config/master_template.yml` (`_preflight_host_checks`), run for `--dummy_training`/`--preflight_check`/`--start_client`, print a PASS/WARN/FAIL block with remediation for: GPU usable in container (F2), **systemd cgroup-driver risk** (F2), read-only cache path (F4), server reachability (F6), and a stale `daemon_pid.fl` (F3, auto-cleared when no client is running).

**`scripts/client_node_setup/fix_docker_cgroupfs.sh`** — durable host fix for the NVML "Unknown Error" GPU drop (daily `daemon-reload` on cgroup v2 + systemd driver): switches Docker to `cgroupfs`, auto-reverts if Docker won't restart, validates a `daemon-reload` no longer strips the GPU.

**Docs** — new `docs/SWARM_FAILURE_MODES.md` (F1–F7 + operator playbook); `docs/TIMEOUTS.md` updated (24 h values, `max_status_report_interval`/`min_responses_required`, slow-node & sync section); participant guide (pre-run checklist + 4 troubleshooting entries); developer guide (operating & hardening section).

## Notes
- No startup-kit rebuild needed for the timeout/sync change to reach a *running* server — it ships with the submitted job; the master_template change flows into newly built kits.
- These fixes were validated live: the current 1DC run cleared its previous failure points and is mid-training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)