### PR TITLE
CI: 3DCNN simulation test silently passes on an aborted run (#353)

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -11,14 +11,20 @@ on:
 permissions:
   contents: read
 
-# Only one validation run at a time on the self-hosted runner to prevent
-# resource contention (GPU, Docker, disk) that causes flaky test failures.
+# Cancel superseded validation runs for the same PR/ref. The GPU-heavy
+# validate-swarm job below also queues globally to avoid self-hosted GPU
+# contention across different PRs.
 concurrency:
   group: pr-validation-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   validate-swarm:
+    # The self-hosted runner has one shared GPU; running multiple validation jobs
+    # at once can OOM otherwise independent PRs.
+    concurrency:
+      group: mediswarm-self-hosted-gpu-validation
+      cancel-in-progress: false
     runs-on: [self-hosted, ci]
     timeout-minutes: 60
 

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -486,15 +486,18 @@ run_3dcnn_simulation_mode () {
     # requires having built a startup kit and synthetic dataset
     echo "[Run] Simulation mode of 3DCNN training in Docker (capturing output)"
 
-    OUTPUT=$(_run_test_in_docker tests/integration_tests/_run_3dcnn_simulation_mode.sh 2>&1)
+    if ! OUTPUT=$(_run_test_in_docker tests/integration_tests/_run_3dcnn_simulation_mode.sh 2>&1); then
+        echo "$OUTPUT"
+        echo "❌ 3DCNN simulation mode failed."
+        exit 1
+    fi
 
     echo "$OUTPUT"
 
-    echo "TODO add check that no error happened when clean synthetic dataset is used"
-    if grep -qi "Epoch 19: 100%" <<< "$OUTPUT"; then
-        echo "✅ 3DCNN proof-of-concept mode succeeded."
+    if grep -q "=== 3DCNN Simulation Mode PASSED ===" <<< "$OUTPUT"; then
+        echo "✅ 3DCNN simulation mode succeeded."
     else
-        echo "❌ 3DCNN proof-of-concept mode failed."
+        echo "❌ Missing 3DCNN simulation success marker."
         exit 1
     fi
 }

--- a/tests/integration_tests/_run_3dcnn_simulation_mode.sh
+++ b/tests/integration_tests/_run_3dcnn_simulation_mode.sh
@@ -19,6 +19,24 @@ run_3dcnn_simulation_mode () {
     echo "RUN ${APP_DIR} with MODEL_NAME=${MODEL_NAME}"
     cp -RL application/jobs/${APP_DIR} ${TMPDIR}/${APP_DIR}
     sed -i 's/num_rounds = .*/num_rounds = 2/' ${TMPDIR}/${APP_DIR}/app/config/config_fed_server.conf
+    # Production ODELIA jobs use long timeouts to ride out VPN stalls. This
+    # synthetic CI simulation should fail promptly and print the simulator log.
+    sed -i \
+        -e 's/start_task_timeout = .*/start_task_timeout = 300/' \
+        -e 's/progress_timeout = .*/progress_timeout = 600/' \
+        -e 's/configure_task_timeout = .*/configure_task_timeout = 300/' \
+        ${TMPDIR}/${APP_DIR}/app/config/config_fed_server.conf
+    sed -i \
+        -e 's/last_result_transfer_timeout = .*/last_result_transfer_timeout = 300/' \
+        -e 's/external_pre_init_timeout = .*/external_pre_init_timeout = 300/' \
+        -e 's/peer_read_timeout = .*/peer_read_timeout = 300/' \
+        -e 's/heartbeat_timeout = .*/heartbeat_timeout = 300/' \
+        -e 's/learn_task_timeout = .*/learn_task_timeout = 600/' \
+        -e 's/learn_task_abort_timeout = .*/learn_task_abort_timeout = 60/' \
+        -e 's/learn_task_ack_timeout = .*/learn_task_ack_timeout = 300/' \
+        -e 's/final_result_ack_timeout = .*/final_result_ack_timeout = 300/' \
+        -e 's/wait_time_after_min_resps_received = .*/wait_time_after_min_resps_received = 60/' \
+        ${TMPDIR}/${APP_DIR}/app/config/config_fed_client.conf
     export CONFIG=unilateral
     # Keep this integration test as an end-to-end smoke test. The default swarm
     # epoch weighting is sized for real training and expands this tiny synthetic

--- a/tests/integration_tests/_run_3dcnn_simulation_mode.sh
+++ b/tests/integration_tests/_run_3dcnn_simulation_mode.sh
@@ -7,6 +7,11 @@ run_3dcnn_simulation_mode () {
     # change training configuration to run 2 rounds
     cd /MediSwarm
     export TMPDIR=$(mktemp -d)
+    # Default to a valid 3D-CNN ternary model when MODEL_NAME is unset/empty.
+    # Without this the persistor's create_model() receives an empty name
+    # ("Unsupported model name: ."), both clients fail to configure, and the run
+    # aborts -- which previously still showed up as a CI pass (see #353).
+    MODEL_NAME="${MODEL_NAME:-ResNet18}"
     if [[ $MODEL_NAME =~ ^[0-9] ]]; then
         # this is a challenges team members name without challenge prefix
         APP_DIR="challenge_"${MODEL_NAME}
@@ -19,7 +24,7 @@ run_3dcnn_simulation_mode () {
             APP_DIR="ODELIA_ternary_classification"
         fi
     fi
-    echo "RUN "$APP_DIR 
+    echo "RUN ${APP_DIR} with MODEL_NAME=${MODEL_NAME}"
     cp -RL application/jobs/${APP_DIR} ${TMPDIR}/${APP_DIR}
     sed -i 's/num_rounds = .*/num_rounds = 2/' ${TMPDIR}/${APP_DIR}/app/config/config_fed_server.conf
     export TRAINING_MODE="swarm"
@@ -29,8 +34,35 @@ run_3dcnn_simulation_mode () {
     export TORCH_HOME=/torch_home
     export MODEL_NAME=${MODEL_NAME}
     export CONFIG=unilateral
-    nvflare simulator -w /tmp/${APP_DIR} -n 2 -t 2 ${TMPDIR}/${APP_DIR} -c client_A,client_B
-    rm -rf ${TMPDIR}
+    local WS=/tmp/${APP_DIR}
+    local LOG=${TMPDIR}/sim.log
+
+    # `nvflare simulator` returns exit code 0 even when the federated run aborts
+    # with a FATAL_SYSTEM_ERROR, so the run outcome MUST be asserted explicitly
+    # (otherwise an aborted simulation silently passes CI -- #353).
+    set +e
+    nvflare simulator -w ${WS} -n 2 -t 2 ${TMPDIR}/${APP_DIR} -c client_A,client_B 2>&1 | tee ${LOG}
+    local RC=${PIPESTATUS[0]}
+    set -e
+
+    local fail=""
+    if grep -qiE "FATAL_SYSTEM_ERROR|Aborting current RUN|failed to configure clients" ${LOG}; then
+        fail="run aborted (FATAL_SYSTEM_ERROR / failed to configure clients)"
+    elif [ "${RC}" -ne 0 ]; then
+        fail="simulator exited with code ${RC}"
+    elif ! find ${WS} -name 'FL_global_model.pt' 2>/dev/null | grep -q .; then
+        # a completed run persists a global model; its absence means the run did not finish
+        fail="no global model (FL_global_model.pt) was produced"
+    fi
+
+    if [ -n "${fail}" ]; then
+        echo "=== 3DCNN Simulation Mode FAILED: ${fail} ==="
+        rm -rf ${TMPDIR} ${WS}
+        exit 1
+    fi
+
+    echo "=== 3DCNN Simulation Mode PASSED ==="
+    rm -rf ${TMPDIR} ${WS}
 }
 
 run_3dcnn_simulation_mode

--- a/tests/integration_tests/_run_3dcnn_simulation_mode.sh
+++ b/tests/integration_tests/_run_3dcnn_simulation_mode.sh
@@ -34,6 +34,15 @@ run_3dcnn_simulation_mode () {
     export TORCH_HOME=/torch_home
     export MODEL_NAME=${MODEL_NAME}
     export CONFIG=unilateral
+    # Keep this integration test as an end-to-end smoke test. The default swarm
+    # epoch weighting is sized for real training and expands this tiny synthetic
+    # dataset to 10 epochs per round, which makes CI hold GPU memory longer than
+    # necessary.
+    export EPOCHS_PER_ROUND="${EPOCHS_PER_ROUND:-1}"
+    export EPOCHS_REFERENCE_DATASET_SIZE="${EPOCHS_REFERENCE_DATASET_SIZE:-18}"
+    export EPOCHS_MAX_CAP="${EPOCHS_MAX_CAP:-1}"
+    export ODELIA_NUM_WORKERS="${ODELIA_NUM_WORKERS:-0}"
+    export ODELIA_HASH_NUM_WORKERS="${ODELIA_HASH_NUM_WORKERS:-0}"
     local WS=/tmp/${APP_DIR}
     local LOG=${TMPDIR}/sim.log
 


### PR DESCRIPTION
Fixes #353.

**Problem:** the `run_3dcnn_simulation_mode` CI step printed fatal errors but passed:
1. `MODEL_NAME` was empty → `create_model()` got `Unsupported model name: .` → both clients failed to configure → run aborted (`FATAL_SYSTEM_ERROR ... only 0/2 configured`).
2. `nvflare simulator` exits **0 even on a FATAL abort**, and the test had **no success assertion**, so `set -e` never tripped → false pass.

**Fix** (`tests/integration_tests/_run_3dcnn_simulation_mode.sh`):
- Default `MODEL_NAME` to `ResNet18` (a valid ternary 3D-CNN) when unset/empty.
- Assert real success: **fail** on `FATAL_SYSTEM_ERROR` / `failed to configure clients`, on a non-zero simulator exit, or if no `FL_global_model.pt` was produced; print `=== 3DCNN Simulation Mode PASSED ===` only on real success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)