### PR TITLE
VPN resilience: faster tunnel-down detection + mandate auto-recovering service (#348)

### DIFF
--- a/assets/readme/README.participant.md
+++ b/assets/readme/README.participant.md
@@ -158,6 +158,15 @@ To have a baseline for swarm training, train the same model in a comparable way 
 
 1. Connect to VPN as described in [VPN setup guide(GUI).pdf](../VPN%20setup%20guide%28GUI%29.pdf) (GUI) or [VPN setup guide(CLI).md](../VPN%20setup%20guide%28CLI%29.md) (command line).
 
+2. **For multi-hour swarm runs, install the VPN as an auto-recovering systemd service (strongly recommended).** A manual/GUI OpenVPN connection that drops and does not reconnect quickly is the most common cause of a long run aborting. Install the tunnel in systemd mode (`mediswarm-vpn.service`, `Restart=always`) plus a health watchdog that re-ups it within ~30 s of a drop:
+   ```bash
+   # first time: install OpenVPN, store credentials, and register the systemd service
+   sudo ./scripts/client_node_setup/setup_vpntunnel.sh -d <YourSite> -n -s
+   # install a 30 s health-check timer that restarts the tunnel if the interface drops or the gateway is unreachable
+   sudo ./scripts/client_node_setup/vpn_health_monitor.sh --install-timer
+   ```
+   Verify with `systemctl status mediswarm-vpn mediswarm-vpn-health.timer`. Combined with the swarm's 24 h round timeouts, this lets a run ride out a brief VPN blip instead of aborting.
+
 #### Start the Client
 
 1. From the directory where you unpacked the startup kit:
@@ -215,6 +224,18 @@ ping dl3.tud.de
 * If dl3.tud.de cannot be resolved, double-check whether it is contained in `/etc/hosts`
 * If it cannot be reached at all, double-check if the VPN connection is working.
 * If intermittent package loss occurs, double-check if your network connection is working properly. Creating new VPN credentials and certificate for connection may also help, contact your Swarm Operator for this purpose.
+
+### VPN Drops During a Run / Node "deemed disconnected"?
+
+A multi-hour run can abort if your tunnel drops and does not come back quickly (the server logs the site as `deemed disconnected`, or a peer reports a transient comms error). To make the tunnel self-heal:
+
+* Run the VPN as the `mediswarm-vpn` **systemd service** (`Restart=always`), not a manual/GUI connection — see [Start Swarm Node → VPN](#vpn).
+* Install the health watchdog so a dropped tunnel is restarted within ~30 s:
+  ```bash
+  sudo ./scripts/client_node_setup/vpn_health_monitor.sh --install-timer
+  ```
+  It restarts the tunnel immediately if the `tun0` interface disappears, or after a few failed gateway pings. Check its log with `journalctl -t mediswarm-vpn-health`.
+* If drops recur, capture your OpenVPN client logs around the outage and report to your Swarm Operator (the gateway provider may need to investigate).
 
 ### Training Very Slow / GPU Under-utilized?
 

--- a/scripts/client_node_setup/vpn_health_monitor.sh
+++ b/scripts/client_node_setup/vpn_health_monitor.sh
@@ -8,11 +8,15 @@
 # Usage:
 #   ./vpn_health_monitor.sh                  # run once (suitable for cron/systemd timer)
 #   ./vpn_health_monitor.sh --daemon         # run in a loop (every INTERVAL seconds)
-#   ./vpn_health_monitor.sh --install-timer  # install a systemd timer that runs every minute
+#   ./vpn_health_monitor.sh --install-timer  # install a systemd timer that runs every 30 seconds
+#
+# A missing/IP-less tunnel interface triggers an immediate restart; gateway-ping
+# failures restart only after FAIL_THRESHOLD consecutive misses.
 #
 # Environment variables (all optional):
 #   VPN_GATEWAY        IP to ping              (default: 172.24.4.1)
 #   VPN_SERVICE        systemd service name    (default: mediswarm-vpn)
+#   VPN_IFACE          tunnel interface to check (default: tun0)
 #   FAIL_THRESHOLD     consecutive fails before restart (default: 3)
 #   PING_INTERVAL      seconds between checks in daemon mode (default: 60)
 #   STATE_FILE         path for failure counter (default: /tmp/mediswarm_vpn_health.state)
@@ -28,6 +32,7 @@ VPN_SERVICE="${VPN_SERVICE:-mediswarm-vpn}"
 FAIL_THRESHOLD="${FAIL_THRESHOLD:-3}"
 PING_INTERVAL="${PING_INTERVAL:-60}"
 STATE_FILE="${STATE_FILE:-/tmp/mediswarm_vpn_health.state}"
+VPN_IFACE="${VPN_IFACE:-tun0}"
 
 # ---------------------------------------------------------------------------
 # Logging helper
@@ -59,6 +64,21 @@ write_failures() {
 check_vpn() {
     local failures
     failures=$(read_failures)
+
+    # Fast path: a missing or IP-less tunnel interface is a definitive drop
+    # (OpenVPN exited, or NetworkManager tore tun0 down). Restart immediately
+    # instead of waiting out the ping threshold -- this is the failure that
+    # repeatedly stalled long swarm runs (see #348).
+    if ! ip -o addr show "$VPN_IFACE" 2>/dev/null | grep -q "inet "; then
+        log err "VPN interface $VPN_IFACE is down or has no IP -- restarting $VPN_SERVICE"
+        if sudo systemctl restart "$VPN_SERVICE"; then
+            log info "$VPN_SERVICE restarted (interface was down)"
+        else
+            log err "Failed to restart $VPN_SERVICE (exit code $?)"
+        fi
+        write_failures 0
+        return 0
+    fi
 
     if ping -c 2 -W 5 "$VPN_GATEWAY" &>/dev/null; then
         if (( failures > 0 )); then
@@ -103,15 +123,16 @@ ExecStart=$script_path
 Environment=VPN_GATEWAY=$VPN_GATEWAY
 Environment=VPN_SERVICE=$VPN_SERVICE
 Environment=FAIL_THRESHOLD=$FAIL_THRESHOLD
+Environment=VPN_IFACE=$VPN_IFACE
 EOF
 
     sudo tee /etc/systemd/system/mediswarm-vpn-health.timer >/dev/null <<EOF
 [Unit]
-Description=Run MediSwarm VPN health check every minute
+Description=Run MediSwarm VPN health check every 30 seconds
 
 [Timer]
 OnBootSec=120
-OnUnitActiveSec=60
+OnUnitActiveSec=30
 AccuracySec=5s
 
 [Install]


### PR DESCRIPTION
Refs #348.

Long swarm runs kept aborting on a single site's VPN drop. The repo already has the right primitives — `mediswarm-vpn.service` (`Restart=always`) and `vpn_health_monitor.sh` — but the failing sites used ad-hoc GUI / bare `openvpn --config` setups, and the monitor only reacted after 3 failed gateway pings (~3 min).

**Changes:**
- `vpn_health_monitor.sh`: **immediate restart when the tunnel interface (`tun0`) is down / IP-less** (the definitive drop signal), in addition to the existing gateway-ping threshold; timer tightened to **30 s**; new `VPN_IFACE` env (default `tun0`).
- `README.participant.md`: make the **auto-recovering systemd setup the recommended path** (`setup_vpntunnel.sh -d <site> -n -s` + `vpn_health_monitor.sh --install-timer`) and add a *VPN drops mid-run / 'deemed disconnected'* troubleshooting entry.

Together with the 24 h round timeouts (#345), a tunnel restored in ~30 s lets a run ride out a transient blip instead of aborting. (GoodAccess gateway-side escalation is tracked separately / external.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)