### PR TITLE
Warm-continue + central checkpointing for swarm runs (#347, #160)

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
@@ -108,8 +108,13 @@
     }
     {
       id = "persistor"
-      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      path = "warm_continue.WarmStartablePTFileModelPersistor"
       args {
+        # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
+        # uniform local path; falls back to fresh init if absent (first run). The scratch
+        # mount persists across runs, so a chain of short runs auto-resumes.
+        source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
+        latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {
           path = "models.models_config.create_model"
           args {

--- a/application/jobs/_shared/custom/warm_continue.py
+++ b/application/jobs/_shared/custom/warm_continue.py
@@ -1,0 +1,70 @@
+"""Warm-continue / central checkpointing for swarm runs (issues #347, #160).
+
+Problem: when a run aborts, the latest aggregated global lives only in the
+rotating aggregator's per-run directory -- often on the very node that crashed,
+and at a path that changes every run (it contains the job id). So progress is
+lost, and resuming would require shipping a ~689 MB checkpoint to every client
+(bundling it in the job overruns the deploy timeout -- see #347).
+
+``WarmStartablePTFileModelPersistor`` solves both with a uniform, run-independent
+mirror on each client:
+
+* Every time a new best global is saved, it is also copied to a fixed local path
+  (``latest_global_path``, default ``/scratch/mediswarm_latest_global.pt``). That
+  path persists on the host scratch mount across runs, so the *next* run finds the
+  prior run's global locally -- no bundling, no per-site staging.
+* On start, if ``source_ckpt_file_full_name`` points at an absolute path that does
+  not exist yet (the first run of a chain), it is disabled so the run initializes
+  fresh instead of ``system_panic``; on later runs the mirror exists and the run
+  warm-starts from it.
+
+Wiring it into every job's client persistor with
+``source_ckpt_file_full_name = latest_global_path`` makes a chain of short runs
+auto-resume: each block continues from the previous block's global. Collect the
+mirrors from all sites with ``scripts/collect_swarm_globals.sh`` (#160).
+"""
+
+import os
+import shutil
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
+
+DEFAULT_LATEST_GLOBAL_PATH = "/scratch/mediswarm_latest_global.pt"
+
+
+class WarmStartablePTFileModelPersistor(PTFileModelPersistor):
+    def __init__(self, latest_global_path: str = DEFAULT_LATEST_GLOBAL_PATH, **kwargs):
+        super().__init__(**kwargs)
+        self.latest_global_path = latest_global_path
+        # Graceful warm-start: if the configured source checkpoint is an absolute
+        # path that doesn't exist yet (first run of a chain), disable it so we
+        # init fresh instead of system_panic. On later runs the prior run's
+        # mirror is present and we warm-start from it.
+        sc = self.source_ckpt_file_full_name
+        if sc and os.path.isabs(sc):
+            if os.path.exists(sc):
+                self.logger.info(f"WarmStart: will warm-start from existing checkpoint {sc}")
+            else:
+                self.logger.info(f"WarmStart: source checkpoint {sc} not present yet; initializing fresh")
+                self.source_ckpt_file_full_name = None
+
+    def handle_event(self, event: str, fl_ctx: FLContext):
+        # let the base persistor do its normal save/init first
+        super().handle_event(event, fl_ctx)
+
+        if event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE:
+            # mirror the just-saved best global to the uniform, run-independent
+            # path so the next run can warm-start from it locally (no bundling).
+            try:
+                src = getattr(self, "_best_ckpt_save_path", None)
+                if src and os.path.exists(src):
+                    dst = os.path.abspath(self.latest_global_path)
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    shutil.copy2(src, dst)
+                    self.log_info(fl_ctx, f"WarmStart: mirrored best global -> {dst}")
+            except Exception as e:
+                # mirroring is best-effort; never let it break the run
+                self.log_warning(fl_ctx, f"WarmStart: failed to mirror best global to {self.latest_global_path}: {e}")

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -108,8 +108,13 @@
     }
     {
       id = "persistor"
-      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      path = "warm_continue.WarmStartablePTFileModelPersistor"
       args {
+        # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
+        # uniform local path; falls back to fresh init if absent (first run). The scratch
+        # mount persists across runs, so a chain of short runs auto-resumes.
+        source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
+        latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {
           path = "models.challenge.1DivideAndConquer.model.create_model"
           args {

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -108,8 +108,13 @@
     }
     {
       id = "persistor"
-      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      path = "warm_continue.WarmStartablePTFileModelPersistor"
       args {
+        # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
+        # uniform local path; falls back to fresh init if absent (first run). The scratch
+        # mount persists across runs, so a chain of short runs auto-resumes.
+        source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
+        latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {
           path = "models.challenge.2bcnaim.swinunetr.create_model"
           args {

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -108,8 +108,13 @@
     }
     {
       id = "persistor"
-      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      path = "warm_continue.WarmStartablePTFileModelPersistor"
       args {
+        # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
+        # uniform local path; falls back to fresh init if absent (first run). The scratch
+        # mount persists across runs, so a chain of short runs auto-resumes.
+        source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
+        latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {
           path = "models.challenge.3agaldran.model_factory.model_factory"
           args {

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -108,8 +108,13 @@
     }
     {
       id = "persistor"
-      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      path = "warm_continue.WarmStartablePTFileModelPersistor"
       args {
+        # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
+        # uniform local path; falls back to fresh init if absent (first run). The scratch
+        # mount persists across runs, so a chain of short runs auto-resumes.
+        source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
+        latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {
           path = "models.challenge.4abmil.model.create_model"
           args {

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -108,8 +108,13 @@
     }
     {
       id = "persistor"
-      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      path = "warm_continue.WarmStartablePTFileModelPersistor"
       args {
+        # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
+        # uniform local path; falls back to fresh init if absent (first run). The scratch
+        # mount persists across runs, so a chain of short runs auto-resumes.
+        source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
+        latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {
           path = "models.challenge.5pimed.model.create_model"
           args {

--- a/scripts/collect_swarm_globals.sh
+++ b/scripts/collect_swarm_globals.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Collect swarm global checkpoints + client logs from all sites (#160, #347)
+# =============================================================================
+# Pulls, from each swarm site:
+#   - the latest aggregated global mirrored by WarmStartablePTFileModelPersistor
+#     (default /scratch/mediswarm_latest_global.pt inside the client container)
+#   - the NVFlare client log (log.txt at the startup-kit root)
+# into a local directory, so the operator has a central copy of progress that is
+# never stranded on a crashed node, and a checkpoint to warm-start the next run.
+#
+# Sites are read from a config file (default: ./swarm_sites.conf), one per line:
+#     <SITE_NAME> <SSH_HOST> [<CLIENT_CONTAINER_NAME>]
+# e.g.:
+#     UKA   swarm@172.24.4.79   odelia_swarm_client_UKA_1
+# SSH auth uses your ssh config / agent (no credentials are stored here).
+# If <CLIENT_CONTAINER_NAME> is omitted, the first container matching 'client'
+# is used. Prefix the ssh command with sudo on the remote via your ssh config if
+# docker requires it there.
+#
+# Usage:
+#   ./collect_swarm_globals.sh [-f sites.conf] [-o out_dir] [-p container_global_path]
+# =============================================================================
+
+set -uo pipefail
+
+SITES_FILE="./swarm_sites.conf"
+OUT_DIR="./swarm_artifacts_$(date -u +%Y%m%dT%H%M%SZ)"
+GLOBAL_PATH="/scratch/mediswarm_latest_global.pt"
+
+while getopts "f:o:p:h" opt; do
+    case "$opt" in
+        f) SITES_FILE="$OPTARG" ;;
+        o) OUT_DIR="$OPTARG" ;;
+        p) GLOBAL_PATH="$OPTARG" ;;
+        h) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown option"; exit 1 ;;
+    esac
+done
+
+if [[ ! -f "$SITES_FILE" ]]; then
+    echo "Sites file '$SITES_FILE' not found. See the header of this script for the format." >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+echo "Collecting to $OUT_DIR (global mirror: $GLOBAL_PATH)"
+
+while read -r SITE HOST CONTAINER _rest; do
+    [[ -z "${SITE:-}" || "${SITE:0:1}" == "#" ]] && continue
+    echo "=== $SITE ($HOST) ==="
+    # resolve the client container name if not given
+    if [[ -z "${CONTAINER:-}" ]]; then
+        CONTAINER=$(ssh -o ConnectTimeout=15 "$HOST" "docker ps --format '{{.Names}}' | grep -i client | head -1" 2>/dev/null)
+    fi
+    if [[ -z "${CONTAINER:-}" ]]; then
+        echo "  ! no client container found on $HOST"; continue
+    fi
+
+    # 1) latest global mirror
+    if ssh -o ConnectTimeout=15 "$HOST" "docker exec '$CONTAINER' test -f '$GLOBAL_PATH'" 2>/dev/null; then
+        ssh -o ConnectTimeout=30 "$HOST" "docker exec '$CONTAINER' cat '$GLOBAL_PATH'" > "$OUT_DIR/${SITE}_latest_global.pt" 2>/dev/null \
+            && echo "  global  -> ${SITE}_latest_global.pt ($(du -h "$OUT_DIR/${SITE}_latest_global.pt" 2>/dev/null | cut -f1))" \
+            || echo "  ! failed to pull global from $SITE"
+    else
+        echo "  - no global mirror at $GLOBAL_PATH yet"
+    fi
+
+    # 2) client log (NVFlare log.txt at the startup-kit root)
+    ssh -o ConnectTimeout=20 "$HOST" "docker exec '$CONTAINER' bash -lc 'cat \$(ls -t /startupkit/log.txt /*/log.txt 2>/dev/null | head -1)'" \
+        > "$OUT_DIR/${SITE}_log.txt" 2>/dev/null \
+        && echo "  log     -> ${SITE}_log.txt" \
+        || echo "  - no client log collected for $SITE"
+done < "$SITES_FILE"
+
+echo "Done. Artifacts in $OUT_DIR"


### PR DESCRIPTION
Refs #347, #160. **Stacked on #346** (chain: main ← #345 ← #346 ← #347; retarget to `main` as the chain merges).

Solves losing all progress on an abort, and the 689 MB warm-start *delivery* problem (bundling overruns the deploy timeout).

- **`WarmStartablePTFileModelPersistor`** (`_shared/custom/warm_continue.py`): mirrors each new best global to a **uniform, run-independent local path** (`/scratch/mediswarm_latest_global.pt`, persists on the scratch mount across runs) and **gracefully inits fresh** if `source_ckpt` is absent (first run).
- **Configs**: persistor → the subclass with `source_ckpt_file_full_name` = the uniform path → a chain of short runs **auto-resumes** (each block continues from the prior block's global, read locally — no bundling, no per-site staging).
- **`scripts/collect_swarm_globals.sh`** (#160): pull the mirrored global + client log from every site to a central dir, so progress is never stranded on a crashed node.

**Testing:** verify the mirror is written each round, that a fresh first run starts clean, and that a second run warm-starts from the mirror; then chain short blocks and confirm rounds accumulate. Eval the result vs current best (macro 0.677 / class-2 0.837).

🤖 Generated with [Claude Code](https://claude.com/claude-code)