### PR TITLE
Raise DataLoader worker cap 8->16 + per-node tuning docs (#315)

### DIFF
--- a/application/jobs/_shared/custom/env_config.py
+++ b/application/jobs/_shared/custom/env_config.py
@@ -15,7 +15,12 @@ def _env_flag(name: str, default: bool = False) -> bool:
 
 def load_environment_variables():
     scratch_dir = os.environ['SCRATCH_DIR']
-    default_loader_workers = min(mp.cpu_count(), 8)
+    # Default DataLoader worker count. PR301 capped this at 8, which regressed
+    # loader concurrency on the ~16-CPU deploy nodes (the older path used all
+    # CPUs). Raise the cap to 16 so those nodes are not throttled by default,
+    # while still bounding very-large hosts. Tune per node via ODELIA_NUM_WORKERS
+    # (lower it on RAM-constrained nodes). See #315.
+    default_loader_workers = min(mp.cpu_count(), 16)
 
     return {
         'site_name': os.environ['SITE_NAME'],

--- a/assets/readme/README.developer.md
+++ b/assets/readme/README.developer.md
@@ -94,6 +94,8 @@ See [README.participant.md](./README.participant.md).
 | `NUM_EPOCHS`         | `1` (test mode) | Number of training epochs (used in preflight/local training)         |
 | `TRAINING_MODE`      | derived         | Internal use. Automatically set based on flags like `--start_client` |
 | `ODELIA_PREDICTION_EXPORT_EVERY_N_ROUNDS` | `0` | Swarm: cadence of the per-round aggregated prediction CSV export (`0`=final round only, `1`=every round, `N`=every Nth round + final). Throttled by default — it runs full train+val inference and dominates round time (#314). |
+| `ODELIA_NUM_WORKERS`  | `min(CPU count, 16)` | DataLoader workers. Tune per node: set to roughly the CPU count on IO/CPU-bound nodes for faster rounds; lower it if the host is RAM-constrained (3D loaders are memory-heavy). Measure round-interval impact (#315). |
+| `ODELIA_HASH_NUM_WORKERS` | `0` | Worker threads for dataset hashing/dedup (0 = inline). |
 
 These are injected into the container as `--env` variables. You can modify their defaults by editing `docker.sh` or exporting before run:
 


### PR DESCRIPTION
Refs #315. **Stacked on #314** (base `feat/throttle-prediction-export`; retarget to `main` after #314 merges).

PR301's default cap of **8** DataLoader workers (`env_config.py`) regressed loader concurrency on the ~16-CPU deploy nodes (the older path used all CPUs), contributing to the per-round slowdown alongside #314.

- Raise the default to **`min(cpu_count, 16)`** so the 16-CPU deploy nodes aren't throttled by default, while still bounding very-large hosts.
- The per-node override `ODELIA_NUM_WORKERS` (forwarded by `docker.sh` / `master_template.yml`) is unchanged — lower it on RAM-constrained nodes.
- Documented `ODELIA_NUM_WORKERS` + tuning guidance in `README.developer.md`.

The empirically-best per-node values (acceptance: measured round-interval improvement) will be recorded from the #313 1DC validation run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)