### PR TITLE
[codex] add admin-controlled warm continue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ deploy_sites_2node_stamp_test.conf
 deploy_sites_4node_test.conf
 deploy_sites_3node_test.conf
 deploy_sites_duke_iid.conf
+deploy_sites_*.local.conf
 kit_live_sync/sync.conf
 scripts/deploy/distribute_data.conf
 

--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
@@ -113,6 +113,7 @@
         # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
         # uniform local path; falls back to fresh init if absent (first run). The scratch
         # mount persists across runs, so a chain of short runs auto-resumes.
+        warm_start_mode = "auto"
         source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
         latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {

--- a/application/jobs/_shared/custom/fault_tolerant_ccwf.py
+++ b/application/jobs/_shared/custom/fault_tolerant_ccwf.py
@@ -43,6 +43,12 @@ from nvflare.app_common.ccwf.server_ctl import ClientStatus
 from nvflare.app_common.ccwf.swarm_client_ctl import Gatherer, SwarmClientController
 from nvflare.app_common.ccwf.swarm_server_ctl import SwarmServerController
 
+WARM_START_REQUIRED_MISSING = "WARM_START_REQUIRED_MISSING"
+
+
+def is_non_tolerable_client_error(error) -> bool:
+    return bool(error and WARM_START_REQUIRED_MISSING in str(error))
+
 
 class FaultTolerantGatherer(Gatherer):
     """Gatherer that tolerates a peer submitting a bad result instead of failing
@@ -167,6 +173,13 @@ class FaultTolerantSwarmServerController(SwarmServerController):
 
         if report.error:
             remaining = len(self.client_statuses) - 1
+            if is_non_tolerable_client_error(report.error):
+                self.asked_to_stop = True
+                self.system_panic(
+                    f"received non-tolerable warm-start failure report from client {client_name}: {report.error}",
+                    fl_ctx,
+                )
+                return
             if self.min_clients and self.min_clients > 0 and remaining >= self.min_clients:
                 # FAULT TOLERANCE (#346): tolerate one client's transient failure
                 # (peer ERROR / MODEL_UNRECOGNIZED desync / drop) -- prune it and

--- a/application/jobs/_shared/custom/models/models_config.py
+++ b/application/jobs/_shared/custom/models/models_config.py
@@ -140,11 +140,19 @@ def create_model(logger=None, model_name: str = None, num_classes: int = 3,
         env_vars = load_environment_variables()
     model_name = get_unified_model_name(logger, model_name, env_vars)
 
-    if not torch.cuda.is_available():
+    allow_cpu_model = os.environ.get("MEDISWARM_ALLOW_CPU_MODEL", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if not torch.cuda.is_available() and not allow_cpu_model:
         raise RuntimeError("This example requires a GPU")
 
     logger.info(f"Running code version {env_vars['mediswarm_version']}")
-    logger.info(f"Using GPU for training")
+    if torch.cuda.is_available():
+        logger.info(f"Using GPU for training")
+    else:
+        logger.info("Using CPU for model creation")
     logger.info(f"Model name: {model_name}")
 
     # Default LR scheduler: CosineAnnealingWarmRestarts gives a cyclical

--- a/application/jobs/_shared/custom/warm_continue.py
+++ b/application/jobs/_shared/custom/warm_continue.py
@@ -31,7 +31,9 @@ import os
 import shutil
 
 from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
+from nvflare.apis.workspace import WorkspaceConstants
 from nvflare.app_common.app_event_type import AppEventType
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 
@@ -55,13 +57,20 @@ def normalize_warm_start_mode(warm_start_mode: str) -> str:
     return mode
 
 
-def resolve_source_checkpoint(source_ckpt_file_full_name: str, warm_start_mode: str, exists=os.path.exists):
+def resolve_source_checkpoint(
+    source_ckpt_file_full_name: str,
+    warm_start_mode: str,
+    exists=os.path.exists,
+    validate_required: bool = True,
+):
     """Return the source checkpoint path the base persistor should use.
 
     ``auto`` preserves the historical behavior: missing absolute paths are
     disabled so the run starts fresh, while existing paths are passed through.
     ``fresh`` always disables warm-start. ``require`` passes through only an
-    existing source and raises a sentinel-bearing error otherwise.
+    existing source and raises a sentinel-bearing error otherwise, unless
+    ``validate_required`` is disabled so the runtime persistor can report the
+    failure through NVFlare's normal ``system_panic`` path after client config.
     """
 
     mode = normalize_warm_start_mode(warm_start_mode)
@@ -72,11 +81,15 @@ def resolve_source_checkpoint(source_ckpt_file_full_name: str, warm_start_mode: 
 
     if not source_ckpt:
         if mode == WARM_START_MODE_REQUIRE:
+            if not validate_required:
+                return None
             raise FileNotFoundError(f"{WARM_START_REQUIRED_MISSING}: no warm-start checkpoint path configured")
         return None
 
     if mode == WARM_START_MODE_REQUIRE:
         if not exists(source_ckpt):
+            if not validate_required:
+                return source_ckpt
             raise FileNotFoundError(
                 f"{WARM_START_REQUIRED_MISSING}: required warm-start checkpoint missing: {source_ckpt}"
             )
@@ -100,15 +113,47 @@ class WarmStartablePTFileModelPersistor(PTFileModelPersistor):
         self.warm_start_mode = normalize_warm_start_mode(warm_start_mode)
 
         sc = self.source_ckpt_file_full_name
-        resolved_sc = resolve_source_checkpoint(sc, self.warm_start_mode)
+        resolved_sc = resolve_source_checkpoint(sc, self.warm_start_mode, validate_required=False)
         self.source_ckpt_file_full_name = resolved_sc
 
         if self.warm_start_mode == WARM_START_MODE_FRESH:
             self.logger.info("WarmStart: warm_start_mode=fresh; initializing fresh and ignoring any local checkpoint")
-        elif resolved_sc:
+        elif resolved_sc and (self.warm_start_mode != WARM_START_MODE_REQUIRE or os.path.exists(resolved_sc)):
             self.logger.info(f"WarmStart: will warm-start from checkpoint {resolved_sc} (mode={self.warm_start_mode})")
+        elif resolved_sc and self.warm_start_mode == WARM_START_MODE_REQUIRE:
+            self.logger.info(f"WarmStart: require mode will validate checkpoint at runtime: {resolved_sc}")
         elif sc:
             self.logger.info(f"WarmStart: source checkpoint {sc} not present yet; initializing fresh")
+
+    def _runtime_source_checkpoint_path(self, fl_ctx: FLContext):
+        source_ckpt = self.source_ckpt_file_full_name
+        if not source_ckpt:
+            return None
+        if os.path.isabs(source_ckpt):
+            return source_ckpt
+
+        app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
+        if not app_root:
+            return source_ckpt
+        return os.path.join(app_root, WorkspaceConstants.CUSTOM_FOLDER_NAME, source_ckpt)
+
+    def load_model(self, fl_ctx: FLContext):
+        if self.warm_start_mode == WARM_START_MODE_REQUIRE:
+            ckpt_path = self._runtime_source_checkpoint_path(fl_ctx)
+            if not ckpt_path:
+                self.system_panic(
+                    reason=f"{WARM_START_REQUIRED_MISSING}: no warm-start checkpoint path configured",
+                    fl_ctx=fl_ctx,
+                )
+                return None
+            if not os.path.exists(ckpt_path):
+                self.system_panic(
+                    reason=f"{WARM_START_REQUIRED_MISSING}: required warm-start checkpoint missing: {ckpt_path}",
+                    fl_ctx=fl_ctx,
+                )
+                return None
+
+        return super().load_model(fl_ctx)
 
     def handle_event(self, event: str, fl_ctx: FLContext):
         # let the base persistor do its normal save/init first

--- a/application/jobs/_shared/custom/warm_continue.py
+++ b/application/jobs/_shared/custom/warm_continue.py
@@ -9,9 +9,11 @@ lost, and resuming would require shipping a ~689 MB checkpoint to every client
 ``WarmStartablePTFileModelPersistor`` solves both with a uniform, run-independent
 mirror on each client:
 
-* Every time a new best global is saved, it is also copied to a fixed local path
-  (``latest_global_path``, default ``/scratch/mediswarm_latest_global.pt``). That
-  path persists on the host scratch mount across runs, so the *next* run finds the
+* Every time a new global is saved, it is also copied to a fixed local path
+  (``latest_global_path``, default ``/scratch/mediswarm_latest_global.pt``). Best
+  globals are mirrored too, but continuation is based on the latest completed
+  global so jobs without a selected best metric can still continue. That path
+  persists on the host scratch mount across runs, so the *next* run finds the
   prior run's global locally -- no bundling, no per-site staging.
 * On start, if ``source_ckpt_file_full_name`` points at an absolute path that does
   not exist yet (the first run of a chain), it is disabled so the run initializes
@@ -155,20 +157,24 @@ class WarmStartablePTFileModelPersistor(PTFileModelPersistor):
 
         return super().load_model(fl_ctx)
 
+    def _mirror_checkpoint(self, src: str, fl_ctx: FLContext, label: str):
+        try:
+            if src and os.path.exists(src):
+                dst = os.path.abspath(self.latest_global_path)
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                shutil.copy2(src, dst)
+                self.log_info(fl_ctx, f"WarmStart: mirrored {label} global -> {dst}")
+        except Exception as e:
+            # mirroring is best-effort; never let it break the run
+            self.log_warning(fl_ctx, f"WarmStart: failed to mirror {label} global to {self.latest_global_path}: {e}")
+
+    def save_model(self, ml, fl_ctx: FLContext):
+        super().save_model(ml, fl_ctx)
+        self._mirror_checkpoint(getattr(self, "_ckpt_save_path", None), fl_ctx, "latest")
+
     def handle_event(self, event: str, fl_ctx: FLContext):
         # let the base persistor do its normal save/init first
         super().handle_event(event, fl_ctx)
 
         if event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE:
-            # mirror the just-saved best global to the uniform, run-independent
-            # path so the next run can warm-start from it locally (no bundling).
-            try:
-                src = getattr(self, "_best_ckpt_save_path", None)
-                if src and os.path.exists(src):
-                    dst = os.path.abspath(self.latest_global_path)
-                    os.makedirs(os.path.dirname(dst), exist_ok=True)
-                    shutil.copy2(src, dst)
-                    self.log_info(fl_ctx, f"WarmStart: mirrored best global -> {dst}")
-            except Exception as e:
-                # mirroring is best-effort; never let it break the run
-                self.log_warning(fl_ctx, f"WarmStart: failed to mirror best global to {self.latest_global_path}: {e}")
+            self._mirror_checkpoint(getattr(self, "_best_ckpt_save_path", None), fl_ctx, "best")

--- a/application/jobs/_shared/custom/warm_continue.py
+++ b/application/jobs/_shared/custom/warm_continue.py
@@ -17,6 +17,9 @@ mirror on each client:
   not exist yet (the first run of a chain), it is disabled so the run initializes
   fresh instead of ``system_panic``; on later runs the mirror exists and the run
   warm-starts from it.
+* ``warm_start_mode`` lets the admin make that choice explicit per submitted job:
+  ``auto`` keeps the current best-effort behavior, ``fresh`` ignores the mirror
+  without deleting it, and ``require`` aborts if the mirror is missing.
 
 Wiring it into every job's client persistor with
 ``source_ckpt_file_full_name = latest_global_path`` makes a chain of short runs
@@ -33,23 +36,79 @@ from nvflare.app_common.app_event_type import AppEventType
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 
 DEFAULT_LATEST_GLOBAL_PATH = "/scratch/mediswarm_latest_global.pt"
+WARM_START_MODE_AUTO = "auto"
+WARM_START_MODE_FRESH = "fresh"
+WARM_START_MODE_REQUIRE = "require"
+WARM_START_MODES = {
+    WARM_START_MODE_AUTO,
+    WARM_START_MODE_FRESH,
+    WARM_START_MODE_REQUIRE,
+}
+WARM_START_REQUIRED_MISSING = "WARM_START_REQUIRED_MISSING"
+
+
+def normalize_warm_start_mode(warm_start_mode: str) -> str:
+    mode = (warm_start_mode or WARM_START_MODE_AUTO).strip().lower()
+    if mode not in WARM_START_MODES:
+        expected = ", ".join(sorted(WARM_START_MODES))
+        raise ValueError(f"Invalid warm_start_mode '{warm_start_mode}'. Expected one of: {expected}")
+    return mode
+
+
+def resolve_source_checkpoint(source_ckpt_file_full_name: str, warm_start_mode: str, exists=os.path.exists):
+    """Return the source checkpoint path the base persistor should use.
+
+    ``auto`` preserves the historical behavior: missing absolute paths are
+    disabled so the run starts fresh, while existing paths are passed through.
+    ``fresh`` always disables warm-start. ``require`` passes through only an
+    existing source and raises a sentinel-bearing error otherwise.
+    """
+
+    mode = normalize_warm_start_mode(warm_start_mode)
+    source_ckpt = source_ckpt_file_full_name
+
+    if mode == WARM_START_MODE_FRESH:
+        return None
+
+    if not source_ckpt:
+        if mode == WARM_START_MODE_REQUIRE:
+            raise FileNotFoundError(f"{WARM_START_REQUIRED_MISSING}: no warm-start checkpoint path configured")
+        return None
+
+    if mode == WARM_START_MODE_REQUIRE:
+        if not exists(source_ckpt):
+            raise FileNotFoundError(
+                f"{WARM_START_REQUIRED_MISSING}: required warm-start checkpoint missing: {source_ckpt}"
+            )
+        return source_ckpt
+
+    if os.path.isabs(source_ckpt) and not exists(source_ckpt):
+        return None
+
+    return source_ckpt
 
 
 class WarmStartablePTFileModelPersistor(PTFileModelPersistor):
-    def __init__(self, latest_global_path: str = DEFAULT_LATEST_GLOBAL_PATH, **kwargs):
+    def __init__(
+        self,
+        latest_global_path: str = DEFAULT_LATEST_GLOBAL_PATH,
+        warm_start_mode: str = WARM_START_MODE_AUTO,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.latest_global_path = latest_global_path
-        # Graceful warm-start: if the configured source checkpoint is an absolute
-        # path that doesn't exist yet (first run of a chain), disable it so we
-        # init fresh instead of system_panic. On later runs the prior run's
-        # mirror is present and we warm-start from it.
+        self.warm_start_mode = normalize_warm_start_mode(warm_start_mode)
+
         sc = self.source_ckpt_file_full_name
-        if sc and os.path.isabs(sc):
-            if os.path.exists(sc):
-                self.logger.info(f"WarmStart: will warm-start from existing checkpoint {sc}")
-            else:
-                self.logger.info(f"WarmStart: source checkpoint {sc} not present yet; initializing fresh")
-                self.source_ckpt_file_full_name = None
+        resolved_sc = resolve_source_checkpoint(sc, self.warm_start_mode)
+        self.source_ckpt_file_full_name = resolved_sc
+
+        if self.warm_start_mode == WARM_START_MODE_FRESH:
+            self.logger.info("WarmStart: warm_start_mode=fresh; initializing fresh and ignoring any local checkpoint")
+        elif resolved_sc:
+            self.logger.info(f"WarmStart: will warm-start from checkpoint {resolved_sc} (mode={self.warm_start_mode})")
+        elif sc:
+            self.logger.info(f"WarmStart: source checkpoint {sc} not present yet; initializing fresh")
 
     def handle_event(self, event: str, fl_ctx: FLContext):
         # let the base persistor do its normal save/init first

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -113,6 +113,7 @@
         # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
         # uniform local path; falls back to fresh init if absent (first run). The scratch
         # mount persists across runs, so a chain of short runs auto-resumes.
+        warm_start_mode = "auto"
         source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
         latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -113,6 +113,7 @@
         # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
         # uniform local path; falls back to fresh init if absent (first run). The scratch
         # mount persists across runs, so a chain of short runs auto-resumes.
+        warm_start_mode = "auto"
         source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
         latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -113,6 +113,7 @@
         # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
         # uniform local path; falls back to fresh init if absent (first run). The scratch
         # mount persists across runs, so a chain of short runs auto-resumes.
+        warm_start_mode = "auto"
         source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
         latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -113,6 +113,7 @@
         # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
         # uniform local path; falls back to fresh init if absent (first run). The scratch
         # mount persists across runs, so a chain of short runs auto-resumes.
+        warm_start_mode = "auto"
         source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
         latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -113,6 +113,7 @@
         # WARM-CONTINUE (#347): warm-start from the prior run's global mirrored at this
         # uniform local path; falls back to fresh init if absent (first run). The scratch
         # mount persists across runs, so a chain of short runs auto-resumes.
+        warm_start_mode = "auto"
         source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
         latest_global_path = "/scratch/mediswarm_latest_global.pt"
         model {

--- a/application/provision/project_warm_continue_rsh_mha.yml
+++ b/application/provision/project_warm_continue_rsh_mha.yml
@@ -1,0 +1,38 @@
+api_version: 3
+name: odelia_warm_continue_rsh_mha___REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS___test
+description: ODELIA warm-continue full-eval test with Cosmos server/admin and RSH_1 + MHA_1 clients
+
+participants:
+  - name: dl3.tud.de
+    type: server
+    org: TUD
+    fed_learn_port: 8002
+    admin_port: 8003
+  - name: RSH_1
+    type: client
+    org: RSH
+  - name: MHA_1
+    type: client
+    org: MHA
+  - name: jiefu.zhu@tu-dresden.de
+    type: admin
+    org: TUD
+    role: project_admin
+
+builders:
+  - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
+    args:
+      template_file: master_template.yml
+  - path: nvflare.lighter.impl.template.TemplateBuilder
+  - path: nvflare.lighter.impl.static_file.StaticFileBuilder
+    args:
+      config_folder: config
+      scheme: http
+      docker_image: jefftud/odelia:__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__-warm-continue
+      overseer_agent:
+        path: nvflare.ha.dummy_overseer_agent.DummyOverseerAgent
+        overseer_exists: false
+        args:
+          sp_end_point: dl3.tud.de:8002:8003
+  - path: nvflare.lighter.impl.cert.CertBuilder
+  - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/assets/readme/README.operator.md
+++ b/assets/readme/README.operator.md
@@ -88,3 +88,36 @@ passwords somewhere, they are only displayed once (or you can download them agai
 5. Start the *admin* startup kit using the respective `startup/docker.sh` script to start the admin console
 6. Log in using the user name configured as "name" of the node of type "admin" (only user name needed, auth happens via certificate)
 7. Deploy a job by `submit_job <job folder>`
+
+### Fresh vs Continue ODELIA Jobs
+
+Admin startup kits include `prepare_odelia_job.sh`, which copies an in-image job into the admin kit's mounted
+`local/mediswarm_jobs` folder and patches only that copied job.
+
+Fresh start:
+```bash
+cd <admin-kit>/startup
+./prepare_odelia_job.sh --job ODELIA_ternary_classification --warm-start fresh
+./docker.sh --no_pull
+```
+Submit the printed `_fresh` path, for example:
+```text
+submit_job /fl_admin/local/mediswarm_jobs/ODELIA_ternary_classification_fresh
+```
+
+Continue from the last client-local global checkpoint:
+```bash
+cd <admin-kit>/startup
+./prepare_odelia_job.sh --job ODELIA_ternary_classification --warm-start continue
+./docker.sh --no_pull
+```
+Submit the printed `_continue` path, for example:
+```text
+submit_job /fl_admin/local/mediswarm_jobs/ODELIA_ternary_classification_continue
+```
+
+`continue` is strict: each client must have `/scratch/mediswarm_latest_global.pt` available through the same
+`--scratch_dir` used by the previous run. If any client is missing that checkpoint, the job aborts with
+`WARM_START_REQUIRED_MISSING` instead of silently starting fresh. `fresh` ignores old local checkpoints without
+deleting them. Direct `submit_job MediSwarm/application/jobs/...` remains supported and keeps automatic warm-start
+behavior.

--- a/assets/readme/README.participant.md
+++ b/assets/readme/README.participant.md
@@ -198,6 +198,10 @@ To have a baseline for swarm training, train the same model in a comparable way 
    ```
    If you have multiple GPUs and 0 is busy, use a different one.
 
+   For admin-requested continuation runs, reuse the same `--scratch_dir` as the previous run. MediSwarm stores the
+   latest global checkpoint at `/scratch/mediswarm_latest_global.pt` inside the client container, backed by that scratch
+   directory on the host. A fresh-start job ignores this file without requiring you to delete it.
+
 3. Console output is captured in `nohup.out`, which may have been created with limited permissions in the container, so
    make it readable if necessary:
    ```bash

--- a/deploy_sites_rsh_mha.local.conf.example
+++ b/deploy_sites_rsh_mha.local.conf.example
@@ -1,0 +1,31 @@
+# Copy to deploy_sites_rsh_mha.local.conf and export RSH_PASS/MHA_PASS before running.
+# Do not commit the copied .local.conf file or any password values.
+
+CLIENT_SITES=(RSH MHA)
+
+COSMOS_DEPLOY_DIR=/home/jeff/deploy_test
+SERVER_NAME=dl3.tud.de
+ADMIN_USER=jiefu.zhu@tu-dresden.de
+
+RSH_HOST=172.24.4.71
+RSH_USER=asoro
+RSH_PASS_ENV=RSH_PASS
+RSH_SITE_NAME=RSH_1
+RSH_DATADIR=/home/asoro/JULIA_ITERATION/odelia_breast_mri/odelia/RSH
+RSH_SCRATCHDIR=/home/asoro/JULIA_ITERATION/odelia_breast_mri/odelia/RSH/scratch
+RSH_DEPLOY_DIR=/home/asoro/mediswarm_warm_continue
+RSH_GPU="device=0"
+
+MHA_HOST=172.24.4.91
+MHA_USER=odelia
+MHA_PASS_ENV=MHA_PASS
+MHA_SITE_NAME=MHA_1
+MHA_DATADIR=/home/odelia/MediSwarm/data
+MHA_SCRATCHDIR=/home/odelia/MediSwarm/data/MHA_1/tmp
+MHA_DEPLOY_DIR=/home/odelia/mediswarm_warm_continue
+MHA_GPU="device=0"
+
+EVAL_SITE_NAME=UKA_1
+EVAL_DATA_DIR=/mnt/sda1/ODELIA_Challenge_unilateral
+EVAL_SCRATCH_DIR=/mnt/scratch/deploy_test_eval
+EVAL_GPU="device=0"

--- a/deploy_sites_rsh_mha.local.conf.example
+++ b/deploy_sites_rsh_mha.local.conf.example
@@ -4,6 +4,8 @@
 CLIENT_SITES=(RSH MHA)
 
 COSMOS_DEPLOY_DIR=/home/jeff/deploy_test
+# Optional override when clients cannot reach the automatically selected Cosmos IP.
+# COSMOS_HOST_IP=172.24.4.65
 SERVER_NAME=dl3.tud.de
 ADMIN_USER=jiefu.zhu@tu-dresden.de
 

--- a/kit_admin_tools/prepare_odelia_job.sh
+++ b/kit_admin_tools/prepare_odelia_job.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  ./prepare_odelia_job.sh --job JOB_NAME --warm-start fresh|continue
+  ./prepare_odelia_job.sh --job JOB_NAME --warm-start fresh|continue [--num-rounds N] [--min-clients N] [--min-responses N]
 
 Examples:
   ./prepare_odelia_job.sh --job ODELIA_ternary_classification --warm-start fresh
@@ -16,6 +16,9 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 JOB_NAME=""
 WARM_START=""
 OUTPUT_DIR="$DIR/../local/mediswarm_jobs"
+NUM_ROUNDS=""
+MIN_CLIENTS=""
+MIN_RESPONSES=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -41,6 +44,30 @@ while [ "$#" -gt 0 ]; do
         exit 2
       fi
       OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --num-rounds)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --num-rounds" >&2
+        exit 2
+      fi
+      NUM_ROUNDS="${2:-}"
+      shift 2
+      ;;
+    --min-clients)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --min-clients" >&2
+        exit 2
+      fi
+      MIN_CLIENTS="${2:-}"
+      shift 2
+      ;;
+    --min-responses)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --min-responses" >&2
+        exit 2
+      fi
+      MIN_RESPONSES="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -108,6 +135,18 @@ OUTPUT_ROOT="$(cd "$OUTPUT_DIR" && pwd -P)"
 DEST_NAME="${JOB_NAME}_${WARM_START}"
 DEST_HOST="$OUTPUT_ROOT/$DEST_NAME"
 JOB_SRC="/MediSwarm/application/jobs/$JOB_NAME"
+PATCH_ARGS=(--job-dir "/job_out/$DEST_NAME" --mode "$CONFIG_MODE")
+if [ -n "$NUM_ROUNDS" ]; then
+  PATCH_ARGS+=(--num-rounds "$NUM_ROUNDS")
+fi
+if [ -n "$MIN_CLIENTS" ]; then
+  PATCH_ARGS+=(--min-clients "$MIN_CLIENTS")
+fi
+if [ -n "$MIN_RESPONSES" ]; then
+  PATCH_ARGS+=(--min-responses "$MIN_RESPONSES")
+fi
+
+printf -v PATCH_ARGS_QUOTED ' %q' "${PATCH_ARGS[@]}"
 
 rm -rf "$DEST_HOST"
 
@@ -115,11 +154,20 @@ docker run --rm \
   -u "$(id -u):$(id -g)" \
   -v "$OUTPUT_ROOT":/job_out \
   "$DOCKER_IMAGE" \
-  bash -lc "set -euo pipefail; test -d '$JOB_SRC'; cp -R '$JOB_SRC' '/job_out/$DEST_NAME'; python3 /MediSwarm/scripts/admin/patch_warm_start_job.py --job-dir '/job_out/$DEST_NAME' --mode '$CONFIG_MODE'"
+  bash -lc "set -euo pipefail; test -d '$JOB_SRC'; cp -R '$JOB_SRC' '/job_out/$DEST_NAME'; python3 /MediSwarm/scripts/admin/patch_warm_start_job.py$PATCH_ARGS_QUOTED"
 
 echo
 echo "Prepared job: $DEST_HOST"
 echo "Client config warm_start_mode: $CONFIG_MODE"
+if [ -n "$NUM_ROUNDS" ]; then
+  echo "Server config num_rounds: $NUM_ROUNDS"
+fi
+if [ -n "$MIN_CLIENTS" ]; then
+  echo "Server config min_clients: $MIN_CLIENTS"
+fi
+if [ -n "$MIN_RESPONSES" ]; then
+  echo "Client config min_responses_required: $MIN_RESPONSES"
+fi
 echo
 echo "Submit from the admin console:"
 echo "  submit_job /fl_admin/local/mediswarm_jobs/$DEST_NAME"

--- a/kit_admin_tools/prepare_odelia_job.sh
+++ b/kit_admin_tools/prepare_odelia_job.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./prepare_odelia_job.sh --job JOB_NAME --warm-start fresh|continue
+
+Examples:
+  ./prepare_odelia_job.sh --job ODELIA_ternary_classification --warm-start fresh
+  ./prepare_odelia_job.sh --job ODELIA_ternary_classification --warm-start continue
+EOF
+}
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+JOB_NAME=""
+WARM_START=""
+OUTPUT_DIR="$DIR/../local/mediswarm_jobs"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --job)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --job" >&2
+        exit 2
+      fi
+      JOB_NAME="${2:-}"
+      shift 2
+      ;;
+    --warm-start)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --warm-start" >&2
+        exit 2
+      fi
+      WARM_START="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --output-dir" >&2
+        exit 2
+      fi
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$JOB_NAME" ] || [ -z "$WARM_START" ]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ ! "$JOB_NAME" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+  echo "Invalid job name: $JOB_NAME" >&2
+  echo "Use the job directory name only, for example ODELIA_ternary_classification." >&2
+  exit 2
+fi
+
+case "$WARM_START" in
+  fresh)
+    CONFIG_MODE="fresh"
+    ;;
+  continue)
+    CONFIG_MODE="require"
+    ;;
+  *)
+    echo "Invalid --warm-start value: $WARM_START" >&2
+    echo "Expected fresh or continue." >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to copy the job from the MediSwarm image." >&2
+  exit 1
+fi
+
+DOCKER_SH="$DIR/docker.sh"
+if [ ! -f "$DOCKER_SH" ]; then
+  echo "Missing startup docker.sh next to this helper: $DOCKER_SH" >&2
+  exit 1
+fi
+
+DOCKER_IMAGE="$(awk -F= '/^[[:space:]]*DOCKER_IMAGE=/{print $2; exit}' "$DOCKER_SH" | tr -d '[:space:]' | tr -d '"')"
+if [ -z "$DOCKER_IMAGE" ]; then
+  echo "Could not read DOCKER_IMAGE from $DOCKER_SH" >&2
+  exit 1
+fi
+
+if ! docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+  echo "Docker image is not available locally: $DOCKER_IMAGE" >&2
+  echo "Pull or build the image, then rerun this helper." >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_ROOT="$(cd "$OUTPUT_DIR" && pwd -P)"
+DEST_NAME="${JOB_NAME}_${WARM_START}"
+DEST_HOST="$OUTPUT_ROOT/$DEST_NAME"
+JOB_SRC="/MediSwarm/application/jobs/$JOB_NAME"
+
+rm -rf "$DEST_HOST"
+
+docker run --rm \
+  -u "$(id -u):$(id -g)" \
+  -v "$OUTPUT_ROOT":/job_out \
+  "$DOCKER_IMAGE" \
+  bash -lc "set -euo pipefail; test -d '$JOB_SRC'; cp -R '$JOB_SRC' '/job_out/$DEST_NAME'; python3 /MediSwarm/scripts/admin/patch_warm_start_job.py --job-dir '/job_out/$DEST_NAME' --mode '$CONFIG_MODE'"
+
+echo
+echo "Prepared job: $DEST_HOST"
+echo "Client config warm_start_mode: $CONFIG_MODE"
+echo
+echo "Submit from the admin console:"
+echo "  submit_job /fl_admin/local/mediswarm_jobs/$DEST_NAME"

--- a/scripts/admin/patch_warm_start_job.py
+++ b/scripts/admin/patch_warm_start_job.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Patch an NVFlare job copy with an explicit warm-start mode."""
+"""Patch an NVFlare job copy for admin-controlled warm-start tests."""
 
 import argparse
 import re
 from pathlib import Path
 
 CONFIG_RELATIVE_PATH = Path("app/config/config_fed_client.conf")
+SERVER_CONFIG_RELATIVE_PATH = Path("app/config/config_fed_server.conf")
 PERSISTOR_PATH = 'path = "warm_continue.WarmStartablePTFileModelPersistor"'
 
 MODE_AUTO = "auto"
@@ -35,7 +36,32 @@ def _line_ending(line: str) -> str:
     return ""
 
 
-def patch_config_text(config_text: str, mode: str) -> str:
+def _positive_int_or_none(value, name: str):
+    if value is None:
+        return None
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def patch_numeric_assignment(config_text: str, key: str, value: int) -> str:
+    value = _positive_int_or_none(value, key)
+    pattern = re.compile(
+        rf"^(\s*{re.escape(key)}\s*=\s*)\d+([^\S\r\n]*(?:#.*)?(?:\r?\n|$))",
+        re.MULTILINE,
+    )
+
+    def replace(match):
+        return f"{match.group(1)}{value}{match.group(2)}"
+
+    patched, count = pattern.subn(replace, config_text, count=1)
+    if count != 1:
+        raise ValueError(f"Config does not contain numeric assignment for {key}")
+    return patched
+
+
+def patch_config_text(config_text: str, mode: str, min_responses_required=None) -> str:
     internal_mode = normalize_warm_start_mode(mode)
     lines = config_text.splitlines(keepends=True)
 
@@ -70,16 +96,48 @@ def patch_config_text(config_text: str, mode: str) -> str:
         eol = _line_ending(lines[source_index]) or "\n"
         lines.insert(source_index, f'{indent}warm_start_mode = "{internal_mode}"{eol}')
 
-    return "".join(lines)
+    patched = "".join(lines)
+    min_responses_required = _positive_int_or_none(min_responses_required, "min_responses_required")
+    if min_responses_required is not None:
+        patched = patch_numeric_assignment(patched, "min_responses_required", min_responses_required)
+
+    return patched
 
 
-def patch_job_dir(job_dir: Path, mode: str) -> Path:
+def patch_server_config_text(config_text: str, num_rounds=None, min_clients=None) -> str:
+    patched = config_text
+    num_rounds = _positive_int_or_none(num_rounds, "num_rounds")
+    min_clients = _positive_int_or_none(min_clients, "min_clients")
+    if num_rounds is not None:
+        patched = patch_numeric_assignment(patched, "num_rounds", num_rounds)
+    if min_clients is not None:
+        patched = patch_numeric_assignment(patched, "min_clients", min_clients)
+    return patched
+
+
+def patch_job_dir(
+    job_dir: Path,
+    mode: str,
+    num_rounds=None,
+    min_clients=None,
+    min_responses_required=None,
+) -> Path:
     config_path = job_dir / CONFIG_RELATIVE_PATH
     if not config_path.is_file():
         raise FileNotFoundError(f"Missing job config: {config_path}")
 
     config_text = config_path.read_text()
-    config_path.write_text(patch_config_text(config_text, mode))
+    config_path.write_text(patch_config_text(config_text, mode, min_responses_required=min_responses_required))
+
+    if num_rounds is not None or min_clients is not None:
+        server_config_path = job_dir / SERVER_CONFIG_RELATIVE_PATH
+        if not server_config_path.is_file():
+            raise FileNotFoundError(f"Missing job server config: {server_config_path}")
+        server_config_text = server_config_path.read_text()
+        server_config_path.write_text(
+            patch_server_config_text(server_config_text, num_rounds=num_rounds, min_clients=min_clients)
+        )
+
     return config_path
 
 
@@ -91,11 +149,30 @@ def main() -> int:
         required=True,
         help="Warm-start mode. Use fresh, continue, auto, or internal require.",
     )
+    parser.add_argument("--num-rounds", type=int, help="Patch app/config/config_fed_server.conf num_rounds")
+    parser.add_argument("--min-clients", type=int, help="Patch app/config/config_fed_server.conf min_clients")
+    parser.add_argument(
+        "--min-responses",
+        type=int,
+        help="Patch app/config/config_fed_client.conf min_responses_required",
+    )
     args = parser.parse_args()
 
     internal_mode = normalize_warm_start_mode(args.mode)
-    config_path = patch_job_dir(args.job_dir, internal_mode)
+    config_path = patch_job_dir(
+        args.job_dir,
+        internal_mode,
+        num_rounds=args.num_rounds,
+        min_clients=args.min_clients,
+        min_responses_required=args.min_responses,
+    )
     print(f'Patched {config_path}: warm_start_mode = "{internal_mode}"')
+    if args.num_rounds is not None:
+        print(f"Patched {args.job_dir / SERVER_CONFIG_RELATIVE_PATH}: num_rounds = {args.num_rounds}")
+    if args.min_clients is not None:
+        print(f"Patched {args.job_dir / SERVER_CONFIG_RELATIVE_PATH}: min_clients = {args.min_clients}")
+    if args.min_responses is not None:
+        print(f"Patched {config_path}: min_responses_required = {args.min_responses}")
     return 0
 
 

--- a/scripts/admin/patch_warm_start_job.py
+++ b/scripts/admin/patch_warm_start_job.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Patch an NVFlare job copy with an explicit warm-start mode."""
+
+import argparse
+import re
+from pathlib import Path
+
+CONFIG_RELATIVE_PATH = Path("app/config/config_fed_client.conf")
+PERSISTOR_PATH = 'path = "warm_continue.WarmStartablePTFileModelPersistor"'
+
+MODE_AUTO = "auto"
+MODE_FRESH = "fresh"
+MODE_REQUIRE = "require"
+MODE_ALIASES = {
+    MODE_AUTO: MODE_AUTO,
+    MODE_FRESH: MODE_FRESH,
+    MODE_REQUIRE: MODE_REQUIRE,
+    "continue": MODE_REQUIRE,
+}
+
+
+def normalize_warm_start_mode(mode: str) -> str:
+    normalized = (mode or "").strip().lower()
+    if normalized not in MODE_ALIASES:
+        expected = ", ".join(sorted(MODE_ALIASES))
+        raise ValueError(f"Invalid warm-start mode '{mode}'. Expected one of: {expected}")
+    return MODE_ALIASES[normalized]
+
+
+def _line_ending(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def patch_config_text(config_text: str, mode: str) -> str:
+    internal_mode = normalize_warm_start_mode(mode)
+    lines = config_text.splitlines(keepends=True)
+
+    try:
+        persistor_index = next(i for i, line in enumerate(lines) if PERSISTOR_PATH in line)
+    except StopIteration as exc:
+        raise ValueError(f"Config does not reference {PERSISTOR_PATH}") from exc
+
+    source_re = re.compile(r"^(\s*)source_ckpt_file_full_name\s*=")
+    mode_re = re.compile(r"^(\s*)warm_start_mode\s*=")
+
+    source_index = None
+    for i in range(persistor_index + 1, len(lines)):
+        if source_re.match(lines[i]):
+            source_index = i
+            break
+
+    if source_index is None:
+        raise ValueError("Config does not contain source_ckpt_file_full_name after the warm-start persistor")
+
+    replacement_index = None
+    for i in range(persistor_index + 1, source_index + 1):
+        if mode_re.match(lines[i]):
+            replacement_index = i
+            break
+
+    if replacement_index is not None:
+        indent = mode_re.match(lines[replacement_index]).group(1)
+        lines[replacement_index] = f'{indent}warm_start_mode = "{internal_mode}"{_line_ending(lines[replacement_index])}'
+    else:
+        indent = source_re.match(lines[source_index]).group(1)
+        eol = _line_ending(lines[source_index]) or "\n"
+        lines.insert(source_index, f'{indent}warm_start_mode = "{internal_mode}"{eol}')
+
+    return "".join(lines)
+
+
+def patch_job_dir(job_dir: Path, mode: str) -> Path:
+    config_path = job_dir / CONFIG_RELATIVE_PATH
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Missing job config: {config_path}")
+
+    config_text = config_path.read_text()
+    config_path.write_text(patch_config_text(config_text, mode))
+    return config_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--job-dir", required=True, type=Path, help="Path to the copied NVFlare job directory")
+    parser.add_argument(
+        "--mode",
+        required=True,
+        help="Warm-start mode. Use fresh, continue, auto, or internal require.",
+    )
+    args = parser.parse_args()
+
+    internal_mode = normalize_warm_start_mode(args.mode)
+    config_path = patch_job_dir(args.job_dir, internal_mode)
+    print(f'Patched {config_path}: warm_start_mode = "{internal_mode}"')
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build/_injectLiveSyncIntoStartupKits.sh
+++ b/scripts/build/_injectLiveSyncIntoStartupKits.sh
@@ -13,6 +13,7 @@ TARGET_FOLDER="$(ls -d "$OUTPUT_FOLDER"/prod_* | tail -n 1)"
 HELPER_SOURCE_DIR="kit_live_sync"
 SYNC_CONF_SOURCE="$HELPER_SOURCE_DIR/sync.conf"
 SYNC_CONF_EXAMPLE_SOURCE="$HELPER_SOURCE_DIR/sync.conf.example"
+ADMIN_HELPER_SOURCE="kit_admin_tools/prepare_odelia_job.sh"
 
 if [ ! -d "$HELPER_SOURCE_DIR" ]; then
   echo "Missing helper directory: $HELPER_SOURCE_DIR"
@@ -21,6 +22,11 @@ fi
 
 if [ ! -f "$SYNC_CONF_SOURCE" ] && [ ! -f "$SYNC_CONF_EXAMPLE_SOURCE" ]; then
   echo "Missing live sync config files in $HELPER_SOURCE_DIR"
+  exit 1
+fi
+
+if [ ! -f "$ADMIN_HELPER_SOURCE" ]; then
+  echo "Missing admin helper: $ADMIN_HELPER_SOURCE"
   exit 1
 fi
 
@@ -54,6 +60,12 @@ find "$TARGET_FOLDER" -mindepth 1 -maxdepth 1 -type d | while read -r KIT_DIR; d
   cp "$HELPER_SOURCE_DIR/live_sync.sh" "$STARTUP_DIR/live_sync.sh"
 
   chmod +x "$STARTUP_DIR/build_heartbeat.sh" "$STARTUP_DIR/live_sync.sh"
+
+  if [ -f "$STARTUP_DIR/fl_admin.sh" ]; then
+    cp "$ADMIN_HELPER_SOURCE" "$STARTUP_DIR/prepare_odelia_job.sh"
+    chmod +x "$STARTUP_DIR/prepare_odelia_job.sh"
+    echo "Injected admin warm-start job helper into $STARTUP_DIR"
+  fi
 
   # Clean up legacy docker_original.sh wrapper if present from a previous build
   if [ -f "$STARTUP_DIR/docker_original.sh" ]; then

--- a/scripts/deploy/run_warm_continue_test.sh
+++ b/scripts/deploy/run_warm_continue_test.sh
@@ -1,0 +1,698 @@
+#!/usr/bin/env bash
+# Orchestrate the RSH/MHA warm-continue full-eval test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
+err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+step()  { echo -e "\n${BOLD}=== $* ===${NC}" >&2; }
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/deploy/run_warm_continue_test.sh \
+    --conf deploy_sites_rsh_mha.local.conf \
+    --project application/provision/project_warm_continue_rsh_mha.yml \
+    [--job challenge_5pimed] [--model 5Pimed] [--results-dir DIR]
+
+Options:
+  --skip-build      Reuse existing Docker image/startup kits.
+  --skip-push       Do not push the built Docker image before pulling on clients.
+  --timeout MIN     Per-phase wait timeout in minutes (default: 240).
+EOF
+}
+
+CONF_FILE=""
+PROJECT_FILE="$REPO_ROOT/application/provision/project_warm_continue_rsh_mha.yml"
+JOB_NAME="challenge_5pimed"
+MODEL_NAME="5Pimed"
+RESULTS_DIR=""
+SKIP_BUILD=false
+SKIP_PUSH=false
+TIMEOUT_MINUTES=240
+RUN_ID="warm_continue_$(date -u +%Y%m%d_%H%M%S)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --conf)        CONF_FILE="$2"; shift ;;
+        --project)     PROJECT_FILE="$2"; shift ;;
+        --job)         JOB_NAME="$2"; shift ;;
+        --model)       MODEL_NAME="$2"; shift ;;
+        --results-dir) RESULTS_DIR="$2"; shift ;;
+        --skip-build)  SKIP_BUILD=true ;;
+        --skip-push)   SKIP_PUSH=true ;;
+        --timeout)     TIMEOUT_MINUTES="$2"; shift ;;
+        -h|--help)     usage; exit 0 ;;
+        *)             err "Unknown argument: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+if [[ -z "$CONF_FILE" ]]; then
+    err "Missing --conf"
+    usage
+    exit 2
+fi
+
+resolve_path() {
+    local path="$1"
+    if [[ "$path" = /* ]]; then
+        echo "$path"
+    else
+        echo "$REPO_ROOT/$path"
+    fi
+}
+
+CONF_FILE="$(resolve_path "$CONF_FILE")"
+PROJECT_FILE="$(resolve_path "$PROJECT_FILE")"
+
+if [[ ! -f "$CONF_FILE" ]]; then
+    err "Config file not found: $CONF_FILE"
+    exit 1
+fi
+if [[ ! -f "$PROJECT_FILE" ]]; then
+    err "Project file not found: $PROJECT_FILE"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$CONF_FILE"
+
+VERSION="$("$REPO_ROOT/scripts/build/getVersionNumber.sh")"
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+DOCKER_IMAGE="$(grep 'docker_image:' "$PROJECT_FILE" \
+    | sed 's/.*docker_image:[[:space:]]*//' \
+    | sed "s#__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__#$VERSION#")"
+PROJECT_NAME="$(grep '^name: ' "$PROJECT_FILE" \
+    | sed 's/^name: //' \
+    | sed "s#__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__#$VERSION#")"
+WORKSPACE_DIR="$REPO_ROOT/workspace/$PROJECT_NAME"
+DEPLOY_BASE="${COSMOS_DEPLOY_DIR:-/home/jeff/deploy_test}"
+SERVER_NAME="${SERVER_NAME:-dl3.tud.de}"
+ADMIN_USER="${ADMIN_USER:-jiefu.zhu@tu-dresden.de}"
+EVAL_SITE_NAME="${EVAL_SITE_NAME:-UKA_1}"
+EVAL_DATA_DIR="${EVAL_DATA_DIR:-/mnt/sda1/ODELIA_Challenge_unilateral}"
+EVAL_SCRATCH_DIR="${EVAL_SCRATCH_DIR:-/mnt/scratch/deploy_test_eval}"
+EVAL_GPU="${EVAL_GPU:-device=0}"
+CLIENT_COUNT="${#CLIENT_SITES[@]}"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+NVFLARE_CONTAINER_RE='odelia_swarm|nvflare|^swarm-'
+
+if [[ -z "$RESULTS_DIR" ]]; then
+    RESULTS_DIR="$REPO_ROOT/workspace/warm_continue_results/$RUN_ID"
+elif [[ "$RESULTS_DIR" != /* ]]; then
+    RESULTS_DIR="$REPO_ROOT/$RESULTS_DIR"
+fi
+mkdir -p "$RESULTS_DIR"
+
+declare -A PASS_CACHE=()
+
+site_var() {
+    local site="$1" var="$2" name="${site}_${var}"
+    echo "${!name-}"
+}
+
+ensure_site_pass() {
+    local site="$1"
+    if [[ -n "${PASS_CACHE[$site]+set}" ]]; then
+        return
+    fi
+
+    local pass env_name host user
+    pass="$(site_var "$site" PASS)"
+    env_name="$(site_var "$site" PASS_ENV)"
+    if [[ -z "$pass" && -n "$env_name" && -n "${!env_name-}" ]]; then
+        pass="${!env_name}"
+    fi
+
+    if [[ -z "$pass" ]]; then
+        host="$(site_var "$site" HOST)"
+        user="$(site_var "$site" USER)"
+        read -r -s -p "Password for $user@$host ($site, hidden; leave empty for SSH key/no sudo): " pass
+        echo >&2
+    fi
+
+    PASS_CACHE[$site]="$pass"
+}
+
+site_scratch() {
+    local site="$1" root
+    root="$(site_var "$site" SCRATCHDIR)"
+    echo "${root%/}/$RUN_ID"
+}
+
+remote_exec() {
+    local site="$1"; shift
+    local host user pass
+    host="$(site_var "$site" HOST)"
+    user="$(site_var "$site" USER)"
+    ensure_site_pass "$site"
+    pass="${PASS_CACHE[$site]}"
+
+    if [[ -n "$pass" ]]; then
+        SSHPASS="$pass" sshpass -e ssh $SSH_OPTS "$user@$host" "$@"
+    else
+        ssh $SSH_OPTS "$user@$host" "$@"
+    fi
+}
+
+remote_sudo_exec() {
+    local site="$1"; shift
+    local cmd="$*"
+    local host user pass remote_cmd
+    host="$(site_var "$site" HOST)"
+    user="$(site_var "$site" USER)"
+    ensure_site_pass "$site"
+    pass="${PASS_CACHE[$site]}"
+    remote_cmd="sudo -S bash -lc $(printf '%q' "$cmd")"
+
+    if [[ -n "$pass" ]]; then
+        printf '%s\n' "$pass" | SSHPASS="$pass" sshpass -e ssh $SSH_OPTS "$user@$host" "$remote_cmd"
+    else
+        ssh $SSH_OPTS "$user@$host" "sudo -n bash -lc $(printf '%q' "$cmd")"
+    fi
+}
+
+remote_copy() {
+    local site="$1" src="$2" dst="$3"
+    local host user pass
+    host="$(site_var "$site" HOST)"
+    user="$(site_var "$site" USER)"
+    ensure_site_pass "$site"
+    pass="${PASS_CACHE[$site]}"
+
+    if [[ -n "$pass" ]]; then
+        SSHPASS="$pass" sshpass -e scp $SSH_OPTS "$src" "$user@$host:$dst"
+    else
+        scp $SSH_OPTS "$src" "$user@$host:$dst"
+    fi
+}
+
+remote_download() {
+    local site="$1" src="$2" dst="$3"
+    local host user pass
+    host="$(site_var "$site" HOST)"
+    user="$(site_var "$site" USER)"
+    ensure_site_pass "$site"
+    pass="${PASS_CACHE[$site]}"
+
+    if [[ -n "$pass" ]]; then
+        SSHPASS="$pass" sshpass -e scp $SSH_OPTS "$user@$host:$src" "$dst"
+    else
+        scp $SSH_OPTS "$user@$host:$src" "$dst"
+    fi
+}
+
+find_latest_prod() {
+    if [[ ! -d "$WORKSPACE_DIR" ]]; then
+        err "Workspace not found: $WORKSPACE_DIR"
+        exit 1
+    fi
+    ls -d "$WORKSPACE_DIR"/prod_* 2>/dev/null | sort -V | tail -n 1
+}
+
+clean_local_deploy_dir() {
+    local dir_name="$1" target="$DEPLOY_BASE/$dir_name"
+    [[ -e "$target" ]] || return 0
+    rm -rf "$target" 2>/dev/null \
+        || sudo rm -rf "$target" 2>/dev/null \
+        || docker run --rm -v "$DEPLOY_BASE:/cleanup" alpine rm -rf "/cleanup/$dir_name" 2>/dev/null \
+        || warn "Could not fully clean $target"
+}
+
+stop_all() {
+    info "Stopping local and remote NVFlare containers"
+    docker ps -a --format '{{.Names}}' | grep -E "$NVFLARE_CONTAINER_RE" | xargs -r docker rm -f 2>/dev/null || true
+
+    local -A visited=()
+    for site in "${CLIENT_SITES[@]}"; do
+        local host
+        host="$(site_var "$site" HOST)"
+        [[ -n "${visited[$host]+set}" ]] && continue
+        visited[$host]=1
+        remote_exec "$site" \
+            "docker ps -a --format '{{.Names}}' | grep -E 'odelia_swarm|nvflare|^swarm-' | xargs -r docker rm -f 2>/dev/null" \
+            >/dev/null 2>&1 || warn "Could not stop containers on $host"
+    done
+}
+
+build_and_push() {
+    if [[ "$SKIP_BUILD" == true ]]; then
+        info "Skipping build; reusing $DOCKER_IMAGE"
+        return
+    fi
+
+    step "Building Docker image and startup kits"
+    bash "$REPO_ROOT/scripts/build/buildDockerImageAndStartupKits.sh" \
+        -p "$PROJECT_FILE" \
+        --use-docker-cache
+
+    if [[ "$SKIP_PUSH" == true ]]; then
+        warn "Skipping docker push for $DOCKER_IMAGE"
+    else
+        docker push "$DOCKER_IMAGE"
+    fi
+}
+
+deploy_kits() {
+    local prod_dir
+    prod_dir="$(find_latest_prod)"
+    step "Deploying startup kits from $prod_dir"
+
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name deploy_dir zip_file
+        site_name="$(site_var "$site" SITE_NAME)"
+        deploy_dir="$(site_var "$site" DEPLOY_DIR)"
+        zip_file="$prod_dir/${site_name}_${VERSION}.zip"
+        [[ -f "$zip_file" ]] || zip_file="$(ls "$prod_dir"/${site_name}*.zip 2>/dev/null | head -1 || true)"
+        [[ -n "$zip_file" && -f "$zip_file" ]] || { err "Missing startup kit for $site_name"; exit 1; }
+
+        remote_exec "$site" "mkdir -p '$deploy_dir'"
+        remote_copy "$site" "$zip_file" "$deploy_dir/"
+        remote_exec "$site" "cd '$deploy_dir' && rm -rf '$site_name' && unzip -qo '$(basename "$zip_file")'"
+        ok "Deployed $site_name"
+    done
+
+    local server_zip admin_zip
+    server_zip="$prod_dir/${SERVER_NAME}_${VERSION}.zip"
+    [[ -f "$server_zip" ]] || server_zip="$(ls "$prod_dir"/${SERVER_NAME}*.zip 2>/dev/null | head -1 || true)"
+    [[ -n "$server_zip" && -f "$server_zip" ]] || { err "Missing server startup kit for $SERVER_NAME"; exit 1; }
+
+    admin_zip="$prod_dir/${ADMIN_USER}_${VERSION}.zip"
+    [[ -f "$admin_zip" ]] || admin_zip="$(ls "$prod_dir"/${ADMIN_USER}*.zip 2>/dev/null | head -1 || true)"
+    [[ -n "$admin_zip" && -f "$admin_zip" ]] || { err "Missing admin startup kit for $ADMIN_USER"; exit 1; }
+
+    mkdir -p "$DEPLOY_BASE"
+    cp "$server_zip" "$admin_zip" "$DEPLOY_BASE/"
+    clean_local_deploy_dir "$SERVER_NAME"
+    clean_local_deploy_dir "$ADMIN_USER"
+    (cd "$DEPLOY_BASE" && unzip -qo "$(basename "$server_zip")" && unzip -qo "$(basename "$admin_zip")")
+    ok "Deployed server/admin kits on Cosmos"
+}
+
+fix_remote_dns() {
+    local cosmos_ip
+    cosmos_ip="$(tailscale ip -4 2>/dev/null)" || {
+        err "Cannot determine Cosmos Tailscale IP"
+        exit 1
+    }
+
+    step "Ensuring $SERVER_NAME resolves to Cosmos ($cosmos_ip) on clients"
+    for site in "${CLIENT_SITES[@]}"; do
+        local current
+        current="$(remote_exec "$site" "grep -E '\\b${SERVER_NAME}\\b' /etc/hosts 2>/dev/null | awk '{print \$1}' | head -1" 2>/dev/null || true)"
+        if [[ "$current" == "$cosmos_ip" ]]; then
+            ok "$site already maps $SERVER_NAME to $cosmos_ip"
+            continue
+        fi
+
+        if [[ -n "$current" ]]; then
+            remote_sudo_exec "$site" "sed -i 's|^.*\\b${SERVER_NAME}\\b.*\$|${cosmos_ip} ${SERVER_NAME}|' /etc/hosts"
+        else
+            remote_sudo_exec "$site" "echo '${cosmos_ip} ${SERVER_NAME}' >> /etc/hosts"
+        fi
+        ok "$site maps $SERVER_NAME to $cosmos_ip"
+    done
+}
+
+preflight_clients() {
+    step "Client preflight"
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name datadir scratch
+        site_name="$(site_var "$site" SITE_NAME)"
+        datadir="$(site_var "$site" DATADIR)"
+        scratch="$(site_scratch "$site")"
+        info "Checking $site_name"
+        remote_exec "$site" "command -v docker >/dev/null && command -v nvidia-smi >/dev/null && test -d '$datadir/$site_name/data_unilateral' && test -d '$datadir/$site_name/metadata_unilateral'"
+        remote_exec "$site" "rm -rf '$scratch' && mkdir -p '$scratch' && chmod 777 '$scratch'" \
+            || remote_sudo_exec "$site" "rm -rf '$scratch' && mkdir -p '$scratch' && chmod 777 '$scratch'"
+        ok "$site_name preflight passed"
+    done
+}
+
+pre_pull_images() {
+    step "Pulling $DOCKER_IMAGE on clients"
+    for site in "${CLIENT_SITES[@]}"; do
+        local gpu
+        gpu="$(site_var "$site" GPU)"
+        remote_exec "$site" "docker pull '$DOCKER_IMAGE' && docker run --rm --gpus='$gpu' '$DOCKER_IMAGE' nvidia-smi -L >/dev/null"
+        ok "$site image/GPU check passed"
+    done
+}
+
+server_startup_dir() {
+    echo "$DEPLOY_BASE/$SERVER_NAME/startup"
+}
+
+admin_startup_dir() {
+    echo "$DEPLOY_BASE/$ADMIN_USER/startup"
+}
+
+server_log() {
+    echo "$(server_startup_dir)/nohup.out"
+}
+
+start_server() {
+    local startup
+    startup="$(server_startup_dir)"
+    [[ -d "$startup" ]] || { err "Missing server startup dir: $startup"; exit 1; }
+    (cd "$startup" && ./docker.sh --no_pull --start_server)
+    sleep 15
+}
+
+start_clients() {
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name deploy_dir datadir scratch gpu
+        site_name="$(site_var "$site" SITE_NAME)"
+        deploy_dir="$(site_var "$site" DEPLOY_DIR)"
+        datadir="$(site_var "$site" DATADIR)"
+        scratch="$(site_scratch "$site")"
+        gpu="$(site_var "$site" GPU)"
+        remote_exec "$site" \
+            "cd '$deploy_dir/$site_name/startup' && ./docker.sh --no_pull --data_dir '$datadir' --scratch_dir '$scratch' --GPU '$gpu' --model_name '$MODEL_NAME' --start_client"
+        ok "Started $site_name"
+    done
+}
+
+wait_for_registration() {
+    local max_wait=600 elapsed=0 log_file
+    log_file="$(server_log)"
+    while [[ $elapsed -lt $max_wait ]]; do
+        local all_registered=true
+        for site in "${CLIENT_SITES[@]}"; do
+            local site_name
+            site_name="$(site_var "$site" SITE_NAME)"
+            grep -q "New client ${site_name}@" "$log_file" 2>/dev/null || all_registered=false
+        done
+        if [[ "$all_registered" == true ]]; then
+            ok "All clients registered"
+            sleep 5
+            return 0
+        fi
+        sleep 10
+        elapsed=$((elapsed + 10))
+    done
+    err "Timed out waiting for clients to register"
+    return 1
+}
+
+prepare_admin_job() {
+    local warm_start="$1" rounds="$2" admin_startup
+    admin_startup="$(admin_startup_dir)"
+    [[ -d "$admin_startup" ]] || { err "Missing admin startup dir: $admin_startup"; exit 1; }
+    (cd "$admin_startup" && ./prepare_odelia_job.sh \
+        --job "$JOB_NAME" \
+        --warm-start "$warm_start" \
+        --num-rounds "$rounds" \
+        --min-clients "$CLIENT_COUNT" \
+        --min-responses "$CLIENT_COUNT")
+}
+
+submit_job() {
+    local warm_start="$1" job_path="/fl_admin/local/mediswarm_jobs/${JOB_NAME}_${warm_start}"
+    local admin_startup expect_script
+    admin_startup="$(admin_startup_dir)"
+    expect_script="$(mktemp /tmp/mediswarm_warm_continue_XXXXXX.exp)"
+    cat > "$expect_script" <<EXPECT_EOF
+#!/usr/bin/env expect
+set timeout 120
+spawn ./docker.sh --no_pull
+expect "User Name: "
+send "$ADMIN_USER\r"
+expect "> "
+send "submit_job $job_path\r"
+expect "> "
+send "list_jobs\r"
+expect "> "
+send "bye\r"
+expect eof
+EXPECT_EOF
+    chmod +x "$expect_script"
+    (cd "$admin_startup" && expect -f "$expect_script")
+    rm -f "$expect_script"
+}
+
+log_start_line() {
+    local log_file
+    log_file="$(server_log)"
+    if [[ -f "$log_file" ]]; then
+        wc -l < "$log_file"
+    else
+        echo 0
+    fi
+}
+
+phase_lines() {
+    local start_line="$1"
+    tail -n +"$((start_line + 1))" "$(server_log)" 2>/dev/null || true
+}
+
+wait_for_negative_continue() {
+    local start_line="$1" max_attempts=$((TIMEOUT_MINUTES * 2)) attempt=0
+    while [[ $attempt -lt $max_attempts ]]; do
+        local lines
+        lines="$(phase_lines "$start_line")"
+        if echo "$lines" | grep -q "WARM_START_REQUIRED_MISSING"; then
+            if echo "$lines" | grep -E "WARM_START_REQUIRED_MISSING.*pruning|pruning.*WARM_START_REQUIRED_MISSING" >/dev/null; then
+                err "Warm-start missing error was pruned/tolerated"
+                return 1
+            fi
+            if echo "$lines" | grep -q "Server runner finished\\."; then
+                ok "Negative continue aborted with WARM_START_REQUIRED_MISSING"
+                return 0
+            fi
+        fi
+        sleep 30
+        attempt=$((attempt + 1))
+    done
+    err "Timed out waiting for negative continue failure"
+    return 1
+}
+
+wait_for_success() {
+    local phase="$1" start_line="$2" max_attempts=$((TIMEOUT_MINUTES * 2)) attempt=0
+    while [[ $attempt -lt $max_attempts ]]; do
+        local lines
+        lines="$(phase_lines "$start_line")"
+        if echo "$lines" | grep -q "WARM_START_REQUIRED_MISSING"; then
+            err "$phase failed with WARM_START_REQUIRED_MISSING"
+            return 1
+        fi
+        if echo "$lines" | grep -q "FATAL_SYSTEM_ERROR\\|ABORT_RUN"; then
+            err "$phase hit fatal server error"
+            echo "$lines" | grep -i "FATAL\\|ABORT\\|ERROR\\|EXCEPTION" | tail -20 >&2
+            return 1
+        fi
+        if echo "$lines" | grep -q "Server runner finished\\."; then
+            ok "$phase completed"
+            return 0
+        fi
+        sleep 30
+        attempt=$((attempt + 1))
+    done
+    err "Timed out waiting for $phase"
+    return 1
+}
+
+save_phase_logs() {
+    local phase="$1" phase_dir="$RESULTS_DIR/$phase"
+    mkdir -p "$phase_dir"
+    cp "$(server_log)" "$phase_dir/server_nohup.out" 2>/dev/null || true
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name deploy_dir
+        site_name="$(site_var "$site" SITE_NAME)"
+        deploy_dir="$(site_var "$site" DEPLOY_DIR)"
+        remote_download "$site" "$deploy_dir/$site_name/startup/nohup.out" "$phase_dir/${site_name}_nohup.out" \
+            >/dev/null 2>&1 || true
+    done
+}
+
+assert_latest_globals() {
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name scratch
+        site_name="$(site_var "$site" SITE_NAME)"
+        scratch="$(site_scratch "$site")"
+        remote_exec "$site" "test -s '$scratch/mediswarm_latest_global.pt'" || {
+            err "Missing latest global checkpoint for $site_name"
+            return 1
+        }
+        ok "$site_name has latest global checkpoint"
+    done
+}
+
+assert_log_contains() {
+    local phase="$1" pattern="$2"
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name log_file
+        site_name="$(site_var "$site" SITE_NAME)"
+        log_file="$RESULTS_DIR/$phase/${site_name}_nohup.out"
+        grep -q "$pattern" "$log_file" || {
+            err "$phase log for $site_name does not contain: $pattern"
+            return 1
+        }
+    done
+}
+
+collect_latest_globals() {
+    local phase="$1" checkpoint_dir="$RESULTS_DIR/$phase/checkpoints"
+    rm -rf "$checkpoint_dir"
+    mkdir -p "$checkpoint_dir"
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name scratch app_dir
+        site_name="$(site_var "$site" SITE_NAME)"
+        scratch="$(site_scratch "$site")"
+        app_dir="$checkpoint_dir/app_${site_name}"
+        mkdir -p "$app_dir"
+        remote_download "$site" "$scratch/mediswarm_latest_global.pt" "$app_dir/FL_global_model.pt"
+    done
+    echo "$checkpoint_dir"
+}
+
+evaluate_phase() {
+    local phase="$1" checkpoint_dir="$2" output_dir="$RESULTS_DIR/$phase/evaluation"
+    mkdir -p "$EVAL_SCRATCH_DIR" "$output_dir"
+    docker run --rm \
+        --gpus="$EVAL_GPU" \
+        --net=host \
+        --ipc=host \
+        -v "$EVAL_DATA_DIR:/data/:ro" \
+        -v "$EVAL_SCRATCH_DIR:/scratch/" \
+        -v "$checkpoint_dir:/workspace/:ro" \
+        -v "$output_dir:/output/" \
+        --env SITE_NAME="$EVAL_SITE_NAME" \
+        --env DATA_DIR=/data \
+        --env SCRATCH_DIR=/scratch \
+        --env MODEL_NAME="$MODEL_NAME" \
+        --env TORCH_HOME=/torch_home \
+        --env CONFIG=unilateral \
+        "$DOCKER_IMAGE" \
+        python3 /MediSwarm/scripts/evaluation/predict.py \
+            --workspace /workspace \
+            --model-name "$MODEL_NAME" \
+            --output-dir /output \
+            --split test \
+        2>&1 | tee "$output_dir/predict_stdout.log"
+    echo "$output_dir"
+}
+
+latest_job_id_from_phase() {
+    local phase="$1" log_file="$RESULTS_DIR/$phase/server_nohup.out"
+    grep 'Server runner finished\.' "$log_file" 2>/dev/null \
+        | tail -1 \
+        | grep -oP 'run=\K[0-9a-f-]+' \
+        || true
+}
+
+record_phase() {
+    local phase="$1" status="$2" checkpoint_dir="${3:-}" eval_dir="${4:-}" job_id
+    job_id="$(latest_job_id_from_phase "$phase")"
+    jq -n \
+        --arg phase "$phase" \
+        --arg status "$status" \
+        --arg job_id "$job_id" \
+        --arg checkpoint_dir "$checkpoint_dir" \
+        --arg eval_dir "$eval_dir" \
+        --arg docker_image "$DOCKER_IMAGE" \
+        --arg git_sha "$GIT_SHA" \
+        '{phase:$phase,status:$status,job_id:$job_id,checkpoint_dir:$checkpoint_dir,evaluation_dir:$eval_dir,docker_image:$docker_image,git_sha:$git_sha}' \
+        > "$RESULTS_DIR/${phase}_result.json"
+}
+
+run_phase() {
+    local phase="$1" warm_start="$2" rounds="$3" expectation="$4"
+    local start_line checkpoint_dir="" eval_dir=""
+
+    step "Phase: $phase"
+    stop_all
+    start_server
+    start_clients
+    wait_for_registration
+    prepare_admin_job "$warm_start" "$rounds"
+    start_line="$(log_start_line)"
+    submit_job "$warm_start"
+
+    if [[ "$expectation" == "negative" ]]; then
+        wait_for_negative_continue "$start_line"
+        save_phase_logs "$phase"
+        record_phase "$phase" "pass"
+        stop_all
+        return
+    fi
+
+    wait_for_success "$phase" "$start_line"
+    save_phase_logs "$phase"
+    assert_latest_globals
+
+    if [[ "$phase" == "continue" ]]; then
+        assert_log_contains "$phase" "WarmStart: will warm-start from checkpoint /scratch/mediswarm_latest_global.pt (mode=require)"
+    elif [[ "$phase" == "fresh_probe" ]]; then
+        assert_log_contains "$phase" "WarmStart: warm_start_mode=fresh; initializing fresh and ignoring any local checkpoint"
+    fi
+
+    stop_all
+
+    if [[ "$expectation" == "eval" ]]; then
+        checkpoint_dir="$(collect_latest_globals "$phase")"
+        eval_dir="$(evaluate_phase "$phase" "$checkpoint_dir")"
+    fi
+
+    record_phase "$phase" "pass" "$checkpoint_dir" "$eval_dir"
+}
+
+write_summary() {
+    jq -s \
+        --arg run_id "$RUN_ID" \
+        --arg docker_image "$DOCKER_IMAGE" \
+        --arg git_sha "$GIT_SHA" \
+        --arg project_file "$PROJECT_FILE" \
+        --arg results_dir "$RESULTS_DIR" \
+        '{run_id:$run_id,docker_image:$docker_image,git_sha:$git_sha,project_file:$project_file,results_dir:$results_dir,phases:.}' \
+        "$RESULTS_DIR"/*_result.json \
+        > "$RESULTS_DIR/summary.json"
+    ok "Summary written to $RESULTS_DIR/summary.json"
+}
+
+for cmd in docker expect jq sshpass unzip; do
+    command -v "$cmd" >/dev/null 2>&1 || { err "Missing required command: $cmd"; exit 1; }
+done
+
+if [[ "$CLIENT_COUNT" -ne 2 ]]; then
+    err "This wrapper expects exactly two clients; got $CLIENT_COUNT"
+    exit 1
+fi
+if [[ ! -d "$EVAL_DATA_DIR/$EVAL_SITE_NAME" ]]; then
+    err "Missing eval site directory: $EVAL_DATA_DIR/$EVAL_SITE_NAME"
+    exit 1
+fi
+
+step "Warm-continue RSH/MHA test"
+info "Run ID: $RUN_ID"
+info "Docker image: $DOCKER_IMAGE"
+info "Results: $RESULTS_DIR"
+
+build_and_push
+preflight_clients
+deploy_kits
+fix_remote_dns
+pre_pull_images
+
+run_phase "negative_continue" "continue" 2 "negative"
+run_phase "fresh" "fresh" 2 "eval"
+run_phase "continue" "continue" 2 "eval"
+run_phase "fresh_probe" "fresh" 1 "no_eval"
+
+write_summary
+stop_all
+ok "Warm-continue full-eval test completed"

--- a/scripts/deploy/run_warm_continue_test.sh
+++ b/scripts/deploy/run_warm_continue_test.sh
@@ -31,6 +31,10 @@ Options:
   --skip-build      Reuse existing Docker image/startup kits.
   --skip-push       Do not push the built Docker image before pulling on clients.
   --timeout MIN     Per-phase wait timeout in minutes (default: 240).
+
+Environment:
+  EVAL_DEVICE       Prediction device for Cosmos eval: cpu, auto, cuda, cuda:0 (default: cpu).
+  EVAL_GPU          Docker --gpus value when EVAL_DEVICE is not cpu (default: device=0).
 EOF
 }
 
@@ -110,6 +114,7 @@ ADMIN_USER="${ADMIN_USER:-jiefu.zhu@tu-dresden.de}"
 EVAL_SITE_NAME="${EVAL_SITE_NAME:-UKA_1}"
 EVAL_DATA_DIR="${EVAL_DATA_DIR:-/mnt/sda1/ODELIA_Challenge_unilateral}"
 EVAL_SCRATCH_DIR="${EVAL_SCRATCH_DIR:-/mnt/scratch/deploy_test_eval}"
+EVAL_DEVICE="${EVAL_DEVICE:-cpu}"
 EVAL_GPU="${EVAL_GPU:-device=0}"
 CLIENT_COUNT="${#CLIENT_SITES[@]}"
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
@@ -606,9 +611,15 @@ evaluate_phase() {
     local phase="$1"
     local checkpoint_dir="$2"
     local output_dir="$RESULTS_DIR/$phase/evaluation"
+    local gpu_args=()
     mkdir -p "$EVAL_SCRATCH_DIR" "$output_dir"
+
+    if [[ "${EVAL_DEVICE,,}" != "cpu" && "${EVAL_GPU,,}" != "none" ]]; then
+        gpu_args=(--gpus="$EVAL_GPU")
+    fi
+
     docker run --rm \
-        --gpus="$EVAL_GPU" \
+        "${gpu_args[@]}" \
         --net=host \
         --ipc=host \
         -v "$EVAL_DATA_DIR:/data/:ro" \
@@ -621,13 +632,16 @@ evaluate_phase() {
         --env MODEL_NAME="$MODEL_NAME" \
         --env TORCH_HOME=/torch_home \
         --env CONFIG=unilateral \
+        --env PREDICT_DEVICE="$EVAL_DEVICE" \
+        --env MEDISWARM_ALLOW_CPU_MODEL=1 \
         "$DOCKER_IMAGE" \
         python3 /MediSwarm/scripts/evaluation/predict.py \
             --workspace /workspace \
             --model-name "$MODEL_NAME" \
             --output-dir /output \
             --split test \
-        2>&1 | tee "$output_dir/predict_stdout.log"
+            --device "$EVAL_DEVICE" \
+        2>&1 | tee "$output_dir/predict_stdout.log" >&2
     echo "$output_dir"
 }
 

--- a/scripts/deploy/run_warm_continue_test.sh
+++ b/scripts/deploy/run_warm_continue_test.sh
@@ -77,6 +77,11 @@ resolve_path() {
 
 CONF_FILE="$(resolve_path "$CONF_FILE")"
 PROJECT_FILE="$(resolve_path "$PROJECT_FILE")"
+if [[ "$PROJECT_FILE" != "$REPO_ROOT/"* ]]; then
+    err "--project must point to a file under the repository root: $PROJECT_FILE"
+    exit 1
+fi
+PROJECT_FILE_FOR_BUILD="${PROJECT_FILE#$REPO_ROOT/}"
 
 if [[ ! -f "$CONF_FILE" ]]; then
     err "Config file not found: $CONF_FILE"
@@ -259,7 +264,7 @@ build_and_push() {
 
     step "Building Docker image and startup kits"
     bash "$REPO_ROOT/scripts/build/buildDockerImageAndStartupKits.sh" \
-        -p "$PROJECT_FILE" \
+        -p "$PROJECT_FILE_FOR_BUILD" \
         --use-docker-cache
 
     if [[ "$SKIP_PUSH" == true ]]; then

--- a/scripts/deploy/run_warm_continue_test.sh
+++ b/scripts/deploy/run_warm_continue_test.sh
@@ -471,12 +471,12 @@ phase_lines() {
 }
 
 wait_for_negative_continue() {
-    local start_line="$1" max_attempts=$((TIMEOUT_MINUTES * 2)) attempt=0
+    local phase="$1" start_line="$2" max_attempts=$((TIMEOUT_MINUTES * 2)) attempt=0
     while [[ $attempt -lt $max_attempts ]]; do
         local lines
         lines="$(phase_lines "$start_line")"
         if echo "$lines" | grep -q "WARM_START_REQUIRED_MISSING"; then
-            if echo "$lines" | grep -E "WARM_START_REQUIRED_MISSING.*pruning|pruning.*WARM_START_REQUIRED_MISSING" >/dev/null; then
+            if echo "$lines" | grep -Ei "WARM_START_REQUIRED_MISSING.*(prun|tolerat)|(prun|tolerat).*WARM_START_REQUIRED_MISSING" >/dev/null; then
                 err "Warm-start missing error was pruned/tolerated"
                 return 1
             fi
@@ -484,6 +484,30 @@ wait_for_negative_continue() {
                 ok "Negative continue aborted with WARM_START_REQUIRED_MISSING"
                 return 0
             fi
+        fi
+        if echo "$lines" | grep -q "Server runner finished\\."; then
+            save_phase_logs "$phase"
+            if echo "$lines" | grep -Ei "WARM_START_REQUIRED_MISSING.*(prun|tolerat)|(prun|tolerat).*WARM_START_REQUIRED_MISSING" >/dev/null; then
+                err "Warm-start missing error was pruned/tolerated"
+                return 1
+            fi
+
+            local all_clients_logged_error=true
+            for site in "${CLIENT_SITES[@]}"; do
+                local site_name log_file
+                site_name="$(site_var "$site" SITE_NAME)"
+                log_file="$RESULTS_DIR/$phase/${site_name}_nohup.out"
+                if ! grep -q "WARM_START_REQUIRED_MISSING" "$log_file"; then
+                    all_clients_logged_error=false
+                    warn "$site_name log did not contain WARM_START_REQUIRED_MISSING"
+                fi
+            done
+            if [[ "$all_clients_logged_error" == true ]]; then
+                ok "Negative continue aborted after clients reported WARM_START_REQUIRED_MISSING"
+                return 0
+            fi
+            err "Negative continue finished without WARM_START_REQUIRED_MISSING in all client logs"
+            return 1
         fi
         sleep 30
         attempt=$((attempt + 1))
@@ -640,7 +664,7 @@ run_phase() {
     submit_job "$warm_start"
 
     if [[ "$expectation" == "negative" ]]; then
-        wait_for_negative_continue "$start_line"
+        wait_for_negative_continue "$phase" "$start_line"
         save_phase_logs "$phase"
         record_phase "$phase" "pass"
         stop_all

--- a/scripts/deploy/run_warm_continue_test.sh
+++ b/scripts/deploy/run_warm_continue_test.sh
@@ -120,7 +120,9 @@ mkdir -p "$RESULTS_DIR"
 declare -A PASS_CACHE=()
 
 site_var() {
-    local site="$1" var="$2" name="${site}_${var}"
+    local site="$1"
+    local var="$2"
+    local name="${site}_${var}"
     echo "${!name-}"
 }
 
@@ -224,7 +226,8 @@ find_latest_prod() {
 }
 
 clean_local_deploy_dir() {
-    local dir_name="$1" target="$DEPLOY_BASE/$dir_name"
+    local dir_name="$1"
+    local target="$DEPLOY_BASE/$dir_name"
     [[ -e "$target" ]] || return 0
     rm -rf "$target" 2>/dev/null \
         || sudo rm -rf "$target" 2>/dev/null \
@@ -303,11 +306,19 @@ deploy_kits() {
 }
 
 fix_remote_dns() {
-    local cosmos_ip
-    cosmos_ip="$(tailscale ip -4 2>/dev/null)" || {
-        err "Cannot determine Cosmos Tailscale IP"
-        exit 1
-    }
+    local cosmos_ip="${COSMOS_HOST_IP:-}"
+    if [[ -z "$cosmos_ip" ]]; then
+        local first_host
+        first_host="$(site_var "${CLIENT_SITES[0]}" HOST)"
+        cosmos_ip="$(ip route get "$first_host" 2>/dev/null \
+            | awk '{for (i=1; i<=NF; i++) if ($i == "src") {print $(i+1); exit}}')"
+    fi
+    if [[ -z "$cosmos_ip" ]]; then
+        cosmos_ip="$(tailscale ip -4 2>/dev/null)" || {
+            err "Cannot determine Cosmos client-reachable IP"
+            exit 1
+        }
+    fi
 
     step "Ensuring $SERVER_NAME resolves to Cosmos ($cosmos_ip) on clients"
     for site in "${CLIENT_SITES[@]}"; do
@@ -507,7 +518,8 @@ wait_for_success() {
 }
 
 save_phase_logs() {
-    local phase="$1" phase_dir="$RESULTS_DIR/$phase"
+    local phase="$1"
+    local phase_dir="$RESULTS_DIR/$phase"
     mkdir -p "$phase_dir"
     cp "$(server_log)" "$phase_dir/server_nohup.out" 2>/dev/null || true
     for site in "${CLIENT_SITES[@]}"; do
@@ -546,7 +558,8 @@ assert_log_contains() {
 }
 
 collect_latest_globals() {
-    local phase="$1" checkpoint_dir="$RESULTS_DIR/$phase/checkpoints"
+    local phase="$1"
+    local checkpoint_dir="$RESULTS_DIR/$phase/checkpoints"
     rm -rf "$checkpoint_dir"
     mkdir -p "$checkpoint_dir"
     for site in "${CLIENT_SITES[@]}"; do
@@ -561,7 +574,9 @@ collect_latest_globals() {
 }
 
 evaluate_phase() {
-    local phase="$1" checkpoint_dir="$2" output_dir="$RESULTS_DIR/$phase/evaluation"
+    local phase="$1"
+    local checkpoint_dir="$2"
+    local output_dir="$RESULTS_DIR/$phase/evaluation"
     mkdir -p "$EVAL_SCRATCH_DIR" "$output_dir"
     docker run --rm \
         --gpus="$EVAL_GPU" \
@@ -588,7 +603,8 @@ evaluate_phase() {
 }
 
 latest_job_id_from_phase() {
-    local phase="$1" log_file="$RESULTS_DIR/$phase/server_nohup.out"
+    local phase="$1"
+    local log_file="$RESULTS_DIR/$phase/server_nohup.out"
     grep 'Server runner finished\.' "$log_file" 2>/dev/null \
         | tail -1 \
         | grep -oP 'run=\K[0-9a-f-]+' \

--- a/scripts/evaluation/predict.py
+++ b/scripts/evaluation/predict.py
@@ -163,6 +163,10 @@ def _parse_args() -> argparse.Namespace:
         help="Batch size for prediction (default: 1).",
     )
     parser.add_argument(
+        "--device", type=str, default=os.environ.get("PREDICT_DEVICE", "auto"),
+        help="Device for prediction: auto, cpu, cuda, or cuda:<index> (default: auto).",
+    )
+    parser.add_argument(
         "--num-classes", type=int, default=3,
         help="Number of output classes (default: 3).",
     )
@@ -511,11 +515,19 @@ def setup_dataloader(
 def main():
     args = _parse_args()
 
-    if not torch.cuda.is_available():
-        logger.error("CUDA GPU required for prediction.")
+    requested_device = args.device.lower()
+    if requested_device == "auto":
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        device = torch.device(requested_device)
+
+    if device.type == "cuda" and not torch.cuda.is_available():
+        logger.error("CUDA device requested for prediction, but CUDA is not available.")
         sys.exit(1)
 
-    device = torch.device("cuda")
+    if device.type == "cpu":
+        os.environ.setdefault("MEDISWARM_ALLOW_CPU_MODEL", "1")
+    logger.info(f"Using prediction device: {device}")
 
     # Resolve model name
     model_name = args.model_name or os.environ.get("MODEL_NAME", "MST")
@@ -620,7 +632,8 @@ def main():
 
             # Free GPU memory between models
             del model
-            torch.cuda.empty_cache()
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
 
         except Exception as e:
             logger.error(f"Failed to evaluate {label}: {e}")
@@ -701,6 +714,15 @@ def main():
         json.dump(all_results, f, indent=2, default=str)
     logger.info(f"Results saved to: {results_file}")
     logger.info(f"Output directory: {output_dir}")
+
+    failed = [r for r in all_results if r.get("status") == "error"]
+    if failed or not successful:
+        logger.error(
+            "Prediction completed with %d failed checkpoint(s) and %d successful result(s).",
+            len(failed),
+            len(successful),
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_admin_warm_start_job.py
+++ b/tests/unit_tests/test_admin_warm_start_job.py
@@ -16,12 +16,28 @@ def _import_patcher():
 
 CONFIG_TEMPLATE = """components = [
   {
+    id = "swarm_client"
+    args {
+      min_responses_required = 5
+    }
+  }
+  {
     id = "persistor"
     path = "warm_continue.WarmStartablePTFileModelPersistor"
     args {
       # WARM-CONTINUE
       source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
       latest_global_path = "/scratch/mediswarm_latest_global.pt"
+    }
+  }
+]
+"""
+
+SERVER_CONFIG_TEMPLATE = """workflows = [
+  {
+    args {
+      num_rounds = 20
+      min_clients = 5  # tolerate drops
     }
   }
 ]
@@ -58,6 +74,31 @@ def test_patch_config_replaces_existing_mode():
     assert 'warm_start_mode = "auto"' not in patched
 
 
+def test_patch_config_can_patch_min_responses_required():
+    patcher = _import_patcher()
+
+    patched = patcher.patch_config_text(CONFIG_TEMPLATE, "fresh", min_responses_required=2)
+
+    assert "min_responses_required = 2" in patched
+    assert "min_responses_required = 5" not in patched
+
+
+def test_patch_server_config_can_patch_rounds_and_min_clients():
+    patcher = _import_patcher()
+
+    patched = patcher.patch_server_config_text(SERVER_CONFIG_TEMPLATE, num_rounds=2, min_clients=2)
+
+    assert "num_rounds = 2" in patched
+    assert "min_clients = 2  # tolerate drops" in patched
+
+
+def test_patch_numeric_assignment_rejects_missing_key():
+    patcher = _import_patcher()
+
+    with pytest.raises(ValueError, match="numeric assignment"):
+        patcher.patch_numeric_assignment(CONFIG_TEMPLATE, "num_rounds", 2)
+
+
 def test_patch_config_rejects_invalid_mode():
     patcher = _import_patcher()
 
@@ -71,9 +112,22 @@ def test_patch_job_dir_smoke_prepares_admin_local_continue_job(tmp_path):
     config_dir = job_dir / "app" / "config"
     config_dir.mkdir(parents=True)
     config_path = config_dir / "config_fed_client.conf"
+    server_config_path = config_dir / "config_fed_server.conf"
     config_path.write_text(CONFIG_TEMPLATE)
+    server_config_path.write_text(SERVER_CONFIG_TEMPLATE)
 
-    patched_config = patcher.patch_job_dir(job_dir, "continue")
+    patched_config = patcher.patch_job_dir(
+        job_dir,
+        "continue",
+        num_rounds=2,
+        min_clients=2,
+        min_responses_required=2,
+    )
 
     assert patched_config == config_path
-    assert 'warm_start_mode = "require"' in config_path.read_text()
+    patched_client = config_path.read_text()
+    patched_server = server_config_path.read_text()
+    assert 'warm_start_mode = "require"' in patched_client
+    assert "min_responses_required = 2" in patched_client
+    assert "num_rounds = 2" in patched_server
+    assert "min_clients = 2" in patched_server

--- a/tests/unit_tests/test_admin_warm_start_job.py
+++ b/tests/unit_tests/test_admin_warm_start_job.py
@@ -1,0 +1,79 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PATCHER_PATH = REPO_ROOT / "scripts" / "admin" / "patch_warm_start_job.py"
+
+
+def _import_patcher():
+    spec = importlib.util.spec_from_file_location("patch_warm_start_job_under_test", str(PATCHER_PATH))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CONFIG_TEMPLATE = """components = [
+  {
+    id = "persistor"
+    path = "warm_continue.WarmStartablePTFileModelPersistor"
+    args {
+      # WARM-CONTINUE
+      source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"
+      latest_global_path = "/scratch/mediswarm_latest_global.pt"
+    }
+  }
+]
+"""
+
+
+def test_patch_config_inserts_fresh_mode_before_source_checkpoint():
+    patcher = _import_patcher()
+
+    patched = patcher.patch_config_text(CONFIG_TEMPLATE, "fresh")
+
+    assert 'warm_start_mode = "fresh"' in patched
+    assert patched.index('warm_start_mode = "fresh"') < patched.index("source_ckpt_file_full_name")
+
+
+def test_patch_config_maps_continue_to_require():
+    patcher = _import_patcher()
+
+    patched = patcher.patch_config_text(CONFIG_TEMPLATE, "continue")
+
+    assert 'warm_start_mode = "require"' in patched
+
+
+def test_patch_config_replaces_existing_mode():
+    patcher = _import_patcher()
+    existing = CONFIG_TEMPLATE.replace(
+        'source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"',
+        'warm_start_mode = "auto"\n      source_ckpt_file_full_name = "/scratch/mediswarm_latest_global.pt"',
+    )
+
+    patched = patcher.patch_config_text(existing, "continue")
+
+    assert 'warm_start_mode = "require"' in patched
+    assert 'warm_start_mode = "auto"' not in patched
+
+
+def test_patch_config_rejects_invalid_mode():
+    patcher = _import_patcher()
+
+    with pytest.raises(ValueError, match="Invalid warm-start mode"):
+        patcher.patch_config_text(CONFIG_TEMPLATE, "resume")
+
+
+def test_patch_job_dir_smoke_prepares_admin_local_continue_job(tmp_path):
+    patcher = _import_patcher()
+    job_dir = tmp_path / "mediswarm_jobs" / "ODELIA_ternary_classification_continue"
+    config_dir = job_dir / "app" / "config"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config_fed_client.conf"
+    config_path.write_text(CONFIG_TEMPLATE)
+
+    patched_config = patcher.patch_job_dir(job_dir, "continue")
+
+    assert patched_config == config_path
+    assert 'warm_start_mode = "require"' in config_path.read_text()

--- a/tests/unit_tests/test_warm_continue.py
+++ b/tests/unit_tests/test_warm_continue.py
@@ -23,9 +23,13 @@ def _install_warm_continue_nvflare_mocks(monkeypatch):
         def __init__(self, **kwargs):
             self.source_ckpt_file_full_name = kwargs.get("source_ckpt_file_full_name")
             self.logger = _Logger()
+            self.panics = []
 
         def handle_event(self, event, fl_ctx):
             return None
+
+        def load_model(self, fl_ctx):
+            return "loaded"
 
         def log_info(self, fl_ctx, message):
             self.logger.info(message)
@@ -33,11 +37,16 @@ def _install_warm_continue_nvflare_mocks(monkeypatch):
         def log_warning(self, fl_ctx, message):
             self.logger.messages.append(("warning", message))
 
+        def system_panic(self, reason, fl_ctx):
+            self.panics.append(reason)
+
     modules = {
         "nvflare": types.ModuleType("nvflare"),
         "nvflare.apis": types.ModuleType("nvflare.apis"),
         "nvflare.apis.event_type": types.ModuleType("nvflare.apis.event_type"),
+        "nvflare.apis.fl_constant": types.ModuleType("nvflare.apis.fl_constant"),
         "nvflare.apis.fl_context": types.ModuleType("nvflare.apis.fl_context"),
+        "nvflare.apis.workspace": types.ModuleType("nvflare.apis.workspace"),
         "nvflare.app_common": types.ModuleType("nvflare.app_common"),
         "nvflare.app_common.app_event_type": types.ModuleType("nvflare.app_common.app_event_type"),
         "nvflare.app_opt": types.ModuleType("nvflare.app_opt"),
@@ -45,7 +54,9 @@ def _install_warm_continue_nvflare_mocks(monkeypatch):
         "nvflare.app_opt.pt.file_model_persistor": types.ModuleType("nvflare.app_opt.pt.file_model_persistor"),
     }
     modules["nvflare.apis.event_type"].EventType = object
+    modules["nvflare.apis.fl_constant"].FLContextKey = SimpleNamespace(APP_ROOT="__app_root__")
     modules["nvflare.apis.fl_context"].FLContext = object
+    modules["nvflare.apis.workspace"].WorkspaceConstants = SimpleNamespace(CUSTOM_FOLDER_NAME="custom")
     modules["nvflare.app_common.app_event_type"].AppEventType = SimpleNamespace(
         GLOBAL_BEST_MODEL_AVAILABLE="GLOBAL_BEST_MODEL_AVAILABLE"
     )
@@ -206,14 +217,19 @@ def test_require_present_checkpoint_warm_starts(warm_continue, tmp_path):
     assert persistor.source_ckpt_file_full_name == str(checkpoint)
 
 
-def test_require_missing_checkpoint_raises_clear_sentinel(warm_continue, tmp_path):
+def test_require_missing_checkpoint_panics_during_load_model(warm_continue, tmp_path):
     missing = tmp_path / "missing.pt"
 
-    with pytest.raises(FileNotFoundError, match="WARM_START_REQUIRED_MISSING"):
-        warm_continue.WarmStartablePTFileModelPersistor(
-            warm_start_mode="require",
-            source_ckpt_file_full_name=str(missing),
-        )
+    persistor = warm_continue.WarmStartablePTFileModelPersistor(
+        warm_start_mode="require",
+        source_ckpt_file_full_name=str(missing),
+    )
+
+    assert persistor.source_ckpt_file_full_name == str(missing)
+    assert persistor.load_model(SimpleNamespace(get_prop=lambda key: None)) is None
+    assert len(persistor.panics) == 1
+    assert "WARM_START_REQUIRED_MISSING" in persistor.panics[0]
+    assert str(missing) in persistor.panics[0]
 
 
 def test_continue_negative_path_uses_expected_require_error_string(warm_continue, tmp_path):

--- a/tests/unit_tests/test_warm_continue.py
+++ b/tests/unit_tests/test_warm_continue.py
@@ -26,10 +26,17 @@ def _install_warm_continue_nvflare_mocks(monkeypatch):
             self.panics = []
 
         def handle_event(self, event, fl_ctx):
+            if event == "GLOBAL_BEST_MODEL_AVAILABLE" and getattr(self, "_best_ckpt_save_path", None):
+                Path(self._best_ckpt_save_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(self._best_ckpt_save_path).write_bytes(b"best global")
             return None
 
         def load_model(self, fl_ctx):
             return "loaded"
+
+        def save_model(self, ml, fl_ctx):
+            Path(self._ckpt_save_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(self._ckpt_save_path).write_bytes(b"latest global")
 
         def log_info(self, fl_ctx, message):
             self.logger.info(message)
@@ -248,6 +255,30 @@ def test_invalid_warm_start_mode_raises(warm_continue):
             warm_start_mode="resume",
             source_ckpt_file_full_name=None,
         )
+
+
+def test_latest_global_save_is_mirrored_for_future_continue(warm_continue, tmp_path):
+    mirror = tmp_path / "scratch" / "mediswarm_latest_global.pt"
+    run_ckpt = tmp_path / "run" / "FL_global_model.pt"
+    persistor = warm_continue.WarmStartablePTFileModelPersistor(latest_global_path=str(mirror))
+    persistor._ckpt_save_path = str(run_ckpt)
+
+    persistor.save_model(ml=object(), fl_ctx=SimpleNamespace())
+
+    assert mirror.read_bytes() == b"latest global"
+    assert ("info", f"WarmStart: mirrored latest global -> {mirror}") in persistor.logger.messages
+
+
+def test_best_global_event_is_still_mirrored(warm_continue, tmp_path):
+    mirror = tmp_path / "scratch" / "mediswarm_latest_global.pt"
+    best_ckpt = tmp_path / "run" / "best_FL_global_model.pt"
+    persistor = warm_continue.WarmStartablePTFileModelPersistor(latest_global_path=str(mirror))
+    persistor._best_ckpt_save_path = str(best_ckpt)
+
+    persistor.handle_event("GLOBAL_BEST_MODEL_AVAILABLE", SimpleNamespace())
+
+    assert mirror.read_bytes() == b"best global"
+    assert ("info", f"WarmStart: mirrored best global -> {mirror}") in persistor.logger.messages
 
 
 def _make_controller_with_report(module, fl_context_cls, error):

--- a/tests/unit_tests/test_warm_continue.py
+++ b/tests/unit_tests/test_warm_continue.py
@@ -1,0 +1,296 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_CUSTOM_DIR = REPO_ROOT / "application" / "jobs" / "_shared" / "custom"
+
+
+class _Logger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(("info", message))
+
+
+def _install_warm_continue_nvflare_mocks(monkeypatch):
+    class DummyPTFileModelPersistor:
+        def __init__(self, **kwargs):
+            self.source_ckpt_file_full_name = kwargs.get("source_ckpt_file_full_name")
+            self.logger = _Logger()
+
+        def handle_event(self, event, fl_ctx):
+            return None
+
+        def log_info(self, fl_ctx, message):
+            self.logger.info(message)
+
+        def log_warning(self, fl_ctx, message):
+            self.logger.messages.append(("warning", message))
+
+    modules = {
+        "nvflare": types.ModuleType("nvflare"),
+        "nvflare.apis": types.ModuleType("nvflare.apis"),
+        "nvflare.apis.event_type": types.ModuleType("nvflare.apis.event_type"),
+        "nvflare.apis.fl_context": types.ModuleType("nvflare.apis.fl_context"),
+        "nvflare.app_common": types.ModuleType("nvflare.app_common"),
+        "nvflare.app_common.app_event_type": types.ModuleType("nvflare.app_common.app_event_type"),
+        "nvflare.app_opt": types.ModuleType("nvflare.app_opt"),
+        "nvflare.app_opt.pt": types.ModuleType("nvflare.app_opt.pt"),
+        "nvflare.app_opt.pt.file_model_persistor": types.ModuleType("nvflare.app_opt.pt.file_model_persistor"),
+    }
+    modules["nvflare.apis.event_type"].EventType = object
+    modules["nvflare.apis.fl_context"].FLContext = object
+    modules["nvflare.app_common.app_event_type"].AppEventType = SimpleNamespace(
+        GLOBAL_BEST_MODEL_AVAILABLE="GLOBAL_BEST_MODEL_AVAILABLE"
+    )
+    modules["nvflare.app_opt.pt.file_model_persistor"].PTFileModelPersistor = DummyPTFileModelPersistor
+
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def _install_controller_nvflare_mocks(monkeypatch):
+    class FakeFLContext:
+        def __init__(self, identity=None, props=None, peer_context=None):
+            self.identity = identity
+            self.props = props or {}
+            self.peer_context = peer_context
+
+        def get_peer_context(self):
+            return self.peer_context
+
+        def get_identity_name(self):
+            return self.identity
+
+        def get_prop(self, key):
+            return self.props.get(key)
+
+        def set_prop(self, *args, **kwargs):
+            return None
+
+    class FakeClientStatus:
+        def __init__(self):
+            self.last_report_time = None
+            self.num_reports = 0
+            self.status = None
+            self.last_progress_time = None
+
+    class FakeGatherer:
+        pass
+
+    class FakeSwarmClientController:
+        pass
+
+    class FakeSwarmServerController:
+        pass
+
+    def status_report_from_dict(report):
+        return SimpleNamespace(
+            error=report.get("error"),
+            timestamp=report.get("timestamp"),
+            last_round=report.get("last_round", 0),
+            action=report.get("action", "train"),
+            all_done=report.get("all_done", False),
+        )
+
+    modules = {
+        "nvflare": types.ModuleType("nvflare"),
+        "nvflare.apis": types.ModuleType("nvflare.apis"),
+        "nvflare.apis.fl_context": types.ModuleType("nvflare.apis.fl_context"),
+        "nvflare.apis.shareable": types.ModuleType("nvflare.apis.shareable"),
+        "nvflare.app_common": types.ModuleType("nvflare.app_common"),
+        "nvflare.app_common.app_constant": types.ModuleType("nvflare.app_common.app_constant"),
+        "nvflare.app_common.app_event_type": types.ModuleType("nvflare.app_common.app_event_type"),
+        "nvflare.app_common.ccwf": types.ModuleType("nvflare.app_common.ccwf"),
+        "nvflare.app_common.ccwf.common": types.ModuleType("nvflare.app_common.ccwf.common"),
+        "nvflare.app_common.ccwf.server_ctl": types.ModuleType("nvflare.app_common.ccwf.server_ctl"),
+        "nvflare.app_common.ccwf.swarm_client_ctl": types.ModuleType("nvflare.app_common.ccwf.swarm_client_ctl"),
+        "nvflare.app_common.ccwf.swarm_server_ctl": types.ModuleType("nvflare.app_common.ccwf.swarm_server_ctl"),
+    }
+    modules["nvflare.apis.fl_context"].FLContext = FakeFLContext
+    modules["nvflare.apis.shareable"].ReturnCode = SimpleNamespace(OK="OK", EXECUTION_EXCEPTION="EXECUTION_EXCEPTION")
+    modules["nvflare.apis.shareable"].make_reply = lambda rc: {"return_code": rc}
+    modules["nvflare.app_common.app_constant"].AppConstants = SimpleNamespace(
+        CURRENT_ROUND="current_round",
+        TRAINING_RESULT="training_result",
+        AGGREGATION_ACCEPTED="aggregation_accepted",
+    )
+    modules["nvflare.app_common.app_event_type"].AppEventType = SimpleNamespace(
+        BEFORE_CONTRIBUTION_ACCEPT="before_contribution_accept",
+        AFTER_CONTRIBUTION_ACCEPT="after_contribution_accept",
+    )
+    modules["nvflare.app_common.ccwf.common"].Constant = SimpleNamespace(STATUS_REPORTS="status_reports")
+    modules["nvflare.app_common.ccwf.common"].status_report_from_dict = status_report_from_dict
+    modules["nvflare.app_common.ccwf.server_ctl"].ClientStatus = FakeClientStatus
+    modules["nvflare.app_common.ccwf.swarm_client_ctl"].Gatherer = FakeGatherer
+    modules["nvflare.app_common.ccwf.swarm_client_ctl"].SwarmClientController = FakeSwarmClientController
+    modules["nvflare.app_common.ccwf.swarm_server_ctl"].SwarmServerController = FakeSwarmServerController
+
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    return FakeFLContext
+
+
+def _import_module(module_name, path):
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, str(path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def warm_continue(monkeypatch):
+    _install_warm_continue_nvflare_mocks(monkeypatch)
+    return _import_module("warm_continue_under_test", SHARED_CUSTOM_DIR / "warm_continue.py")
+
+
+@pytest.fixture
+def fault_tolerant_ccwf(monkeypatch):
+    fl_context_cls = _install_controller_nvflare_mocks(monkeypatch)
+    module = _import_module("fault_tolerant_ccwf_under_test", SHARED_CUSTOM_DIR / "fault_tolerant_ccwf.py")
+    return module, fl_context_cls
+
+
+def test_auto_missing_absolute_checkpoint_starts_fresh(warm_continue, tmp_path):
+    missing = tmp_path / "missing.pt"
+    persistor = warm_continue.WarmStartablePTFileModelPersistor(
+        warm_start_mode="auto",
+        source_ckpt_file_full_name=str(missing),
+    )
+
+    assert persistor.source_ckpt_file_full_name is None
+
+
+def test_auto_present_checkpoint_warm_starts(warm_continue, tmp_path):
+    checkpoint = tmp_path / "latest.pt"
+    checkpoint.write_bytes(b"checkpoint")
+
+    persistor = warm_continue.WarmStartablePTFileModelPersistor(
+        warm_start_mode="auto",
+        source_ckpt_file_full_name=str(checkpoint),
+    )
+
+    assert persistor.source_ckpt_file_full_name == str(checkpoint)
+
+
+def test_fresh_ignores_present_checkpoint(warm_continue, tmp_path):
+    checkpoint = tmp_path / "latest.pt"
+    checkpoint.write_bytes(b"checkpoint")
+
+    persistor = warm_continue.WarmStartablePTFileModelPersistor(
+        warm_start_mode="fresh",
+        source_ckpt_file_full_name=str(checkpoint),
+    )
+
+    assert persistor.source_ckpt_file_full_name is None
+
+
+def test_require_present_checkpoint_warm_starts(warm_continue, tmp_path):
+    checkpoint = tmp_path / "latest.pt"
+    checkpoint.write_bytes(b"checkpoint")
+
+    persistor = warm_continue.WarmStartablePTFileModelPersistor(
+        warm_start_mode="require",
+        source_ckpt_file_full_name=str(checkpoint),
+    )
+
+    assert persistor.source_ckpt_file_full_name == str(checkpoint)
+
+
+def test_require_missing_checkpoint_raises_clear_sentinel(warm_continue, tmp_path):
+    missing = tmp_path / "missing.pt"
+
+    with pytest.raises(FileNotFoundError, match="WARM_START_REQUIRED_MISSING"):
+        warm_continue.WarmStartablePTFileModelPersistor(
+            warm_start_mode="require",
+            source_ckpt_file_full_name=str(missing),
+        )
+
+
+def test_continue_negative_path_uses_expected_require_error_string(warm_continue, tmp_path):
+    missing = tmp_path / "missing.pt"
+
+    with pytest.raises(FileNotFoundError) as exc:
+        warm_continue.resolve_source_checkpoint(str(missing), "require")
+
+    assert "WARM_START_REQUIRED_MISSING" in str(exc.value)
+    assert str(missing) in str(exc.value)
+
+
+def test_invalid_warm_start_mode_raises(warm_continue):
+    with pytest.raises(ValueError, match="Invalid warm_start_mode"):
+        warm_continue.WarmStartablePTFileModelPersistor(
+            warm_start_mode="resume",
+            source_ckpt_file_full_name=None,
+        )
+
+
+def _make_controller_with_report(module, fl_context_cls, error):
+    reports_key = module.Constant.STATUS_REPORTS
+    peer_ctx = fl_context_cls(
+        identity="site1",
+        props={
+            reports_key: {
+                "wf": {
+                    "error": error,
+                    "timestamp": 1,
+                    "last_round": 2,
+                    "action": "train",
+                    "all_done": False,
+                }
+            }
+        },
+    )
+    fl_ctx = fl_context_cls(peer_context=peer_ctx)
+
+    controller = module.FaultTolerantSwarmServerController.__new__(module.FaultTolerantSwarmServerController)
+    controller.workflow_id = "wf"
+    controller.min_clients = 2
+    controller.asked_to_stop = False
+    controller.client_statuses = {
+        "site1": module.ClientStatus(),
+        "site2": module.ClientStatus(),
+        "site3": module.ClientStatus(),
+    }
+    controller.log_debug = lambda *args, **kwargs: None
+    controller.log_info = lambda *args, **kwargs: None
+    controller.log_warning = lambda *args, **kwargs: None
+    panics = []
+    controller.system_panic = lambda message, ctx: panics.append(message)
+    return controller, fl_ctx, panics
+
+
+def test_warm_start_required_missing_aborts_instead_of_pruning(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    controller, fl_ctx, panics = _make_controller_with_report(
+        module,
+        fl_context_cls,
+        "WARM_START_REQUIRED_MISSING: required warm-start checkpoint missing: /scratch/mediswarm_latest_global.pt",
+    )
+
+    controller._update_client_status(fl_ctx)
+
+    assert controller.asked_to_stop is True
+    assert "site1" in controller.client_statuses
+    assert len(panics) == 1
+    assert "non-tolerable warm-start failure" in panics[0]
+
+
+def test_transient_error_is_still_pruned_when_min_clients_remain(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    controller, fl_ctx, panics = _make_controller_with_report(module, fl_context_cls, "MODEL_UNRECOGNIZED")
+
+    controller._update_client_status(fl_ctx)
+
+    assert controller.asked_to_stop is False
+    assert "site1" not in controller.client_statuses
+    assert panics == []


### PR DESCRIPTION
## Summary
- add explicit `warm_start_mode` handling for `auto`, `fresh`, and strict `require`
- make `WARM_START_REQUIRED_MISSING` abort instead of being pruned by fault tolerance
- add an admin startup-kit helper to prepare fresh or continue ODELIA jobs under `/fl_admin/local/mediswarm_jobs`
- default checked-in ODELIA/challenge configs to `auto` for backward compatibility

## Impact
Admins can now choose fresh start or strict continuation before submitting a job. Continue mode reuses client-local `/scratch/mediswarm_latest_global.pt` checkpoints and fails clearly if any client is missing the checkpoint, avoiding accidental fresh restarts.

## Validation
- `bash -n kit_admin_tools/prepare_odelia_job.sh scripts/build/_injectLiveSyncIntoStartupKits.sh`
- `python3 -m compileall -q application/jobs/_shared/custom/warm_continue.py application/jobs/_shared/custom/fault_tolerant_ccwf.py scripts/admin/patch_warm_start_job.py tests/unit_tests/test_warm_continue.py tests/unit_tests/test_admin_warm_start_job.py`
- `/tmp/mediswarm-pytest-venv/bin/python -m pytest tests/unit_tests/test_warm_continue.py tests/unit_tests/test_admin_warm_start_job.py -q`