### PR TITLE
Harden warm-continue validation (continuity + abort-recovery) + fix best-model key_metric

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
@@ -159,7 +159,7 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        key_metric = "accuracy"
+        key_metric = "val/AUC_ROC"
       }
     }
     {

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -162,7 +162,7 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        key_metric = "accuracy"
+        key_metric = "val/AUC_ROC"
       }
     }
     {

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -162,7 +162,7 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        key_metric = "accuracy"
+        key_metric = "val/AUC_ROC"
       }
     }
     {

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -163,7 +163,7 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        key_metric = "accuracy"
+        key_metric = "val/AUC_ROC"
       }
     }
     {

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -161,7 +161,7 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        key_metric = "accuracy"
+        key_metric = "val/AUC_ROC"
       }
     }
     {

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -163,7 +163,7 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        key_metric = "accuracy"
+        key_metric = "val/AUC_ROC"
       }
     }
     {

--- a/assets/readme/README.operator.md
+++ b/assets/readme/README.operator.md
@@ -121,3 +121,30 @@ submit_job /fl_admin/local/mediswarm_jobs/ODELIA_ternary_classification_continue
 `WARM_START_REQUIRED_MISSING` instead of silently starting fresh. `fresh` ignores old local checkpoints without
 deleting them. Direct `submit_job MediSwarm/application/jobs/...` remains supported and keeps automatic warm-start
 behavior.
+
+The direct-submit "automatic warm-start" is `warm_start_mode = "auto"` (the shipped default in the challenge job
+configs): the first run of a chain finds no mirror and initializes fresh, and every later run warm-starts from
+`/scratch/mediswarm_latest_global.pt` if it is present. Use `--warm-start fresh` to force a clean start, and
+`--warm-start continue` (strict `require`) to *insist* on resuming.
+
+### Recover an aborted run
+
+If a run aborts part-way (a node crash, a VPN drop, an operator `abort_job`), the latest aggregated global has
+already been mirrored to `/scratch/mediswarm_latest_global.pt` on each client at the end of every round, so progress
+is not lost. To resume:
+
+1. Confirm each client still has the mirror (it lives on the host `--scratch_dir`, so it survives a container
+   restart). From the admin host you can pull every site's mirror with `scripts/collect_swarm_globals.sh`.
+2. Re-start the clients and the server using the **same `--scratch_dir`** as the aborted run.
+3. Prepare and submit a continue job:
+   ```bash
+   ./prepare_odelia_job.sh --job <JOB> --warm-start continue
+   submit_job /fl_admin/local/mediswarm_jobs/<JOB>_continue
+   ```
+4. Confirm each client logs `WarmStart: will warm-start from checkpoint /scratch/mediswarm_latest_global.pt`
+   (followed by `Loading checkpoint from …`). If a client is missing the mirror, the strict continue aborts with
+   `WARM_START_REQUIRED_MISSING` rather than silently restarting — fix that client's `--scratch_dir` and retry.
+
+> **`/scratch` space & persistence.** The mirror is overwritten every round and is as large as the global model
+> (≈690 MB for `challenge_1DivideAndConquer`). Make sure each client's `--scratch_dir` has room for it and is on a
+> **persistent** host mount (not a tmpfs wiped on reboot), or a `continue` will not find it.

--- a/docs/SWARM_FAILURE_MODES.md
+++ b/docs/SWARM_FAILURE_MODES.md
@@ -62,6 +62,7 @@ Most of these are now caught automatically by the pre-run checks in the startup-
 - **Root cause:** the site's VPN tunnel drops (observed: a ~2.5 h GoodAccess outage for the Aachen node). Host stays up; only the VPN path to the server is down.
 - **Detection:** site shows `cannot send to 'server': target_unreachable` continuously; the pre-run check warns if the server `host:port` is not reachable at start.
 - **Fix / prevention:** stabilise the VPN (keepalive / dead-peer-detection / dedicated gateway; raise with the VPN provider). The 24 h timeouts give a long window for a brief drop to self-heal before the run aborts.
+- **Recovery:** if any abort mode (F1/F5/F6) does fire, the run can be resumed without losing progress — each client mirrors the latest global to `/scratch/mediswarm_latest_global.pt` every round. See [Recover an aborted run](../assets/readme/README.operator.md#recover-an-aborted-run).
 
 ## F7 — Shared-memory (`/dev/shm`) bus error
 - **Symptom:** `ERROR: Unexpected bus error … insufficient shared memory (shm)` / `DataLoader worker … killed by signal: Bus error`.

--- a/scripts/deploy/run_warm_continue_test.sh
+++ b/scripts/deploy/run_warm_continue_test.sh
@@ -443,7 +443,11 @@ prepare_admin_job() {
 }
 
 submit_job() {
-    local warm_start="$1" job_path="/fl_admin/local/mediswarm_jobs/${JOB_NAME}_${warm_start}"
+    # NB: keep these on separate lines -- `local a="$1" b="...$a..."` expands $a before
+    # the assignment lands, which under `set -u` aborts when no outer `warm_start` is in
+    # scope (e.g. when called from run_abort_recovery_phase rather than run_phase).
+    local warm_start="$1"
+    local job_path="/fl_admin/local/mediswarm_jobs/${JOB_NAME}_${warm_start}"
     local admin_startup expect_script
     admin_startup="$(admin_startup_dir)"
     expect_script="$(mktemp /tmp/mediswarm_warm_continue_XXXXXX.exp)"

--- a/scripts/deploy/run_warm_continue_test.sh
+++ b/scripts/deploy/run_warm_continue_test.sh
@@ -128,6 +128,7 @@ fi
 mkdir -p "$RESULTS_DIR"
 
 declare -A PASS_CACHE=()
+declare -A MIRROR_MD5=()   # "phase:site" -> md5 of that client's /scratch/mediswarm_latest_global.pt
 
 site_var() {
     local site="$1"
@@ -591,6 +592,88 @@ assert_log_contains() {
     done
 }
 
+mirror_md5() {
+    # md5 of a client's mirrored global, or empty if absent
+    local site="$1" scratch
+    scratch="$(site_scratch "$site")"
+    remote_exec "$site" "md5sum '$scratch/mediswarm_latest_global.pt' 2>/dev/null | awk '{print \$1}'" 2>/dev/null || true
+}
+
+clear_mirrors() {
+    # delete every client's mirror so the next run's resume point is unambiguously the
+    # global produced by THAT run (not a leftover mirror from a previous phase)
+    local site site_name scratch
+    for site in "${CLIENT_SITES[@]}"; do
+        site_name="$(site_var "$site" SITE_NAME)"
+        scratch="$(site_scratch "$site")"
+        remote_exec "$site" "rm -f '$scratch/mediswarm_latest_global.pt'" >/dev/null 2>&1 || true
+        info "$site_name mirror cleared"
+    done
+}
+
+record_mirror_hashes() {
+    # snapshot every client's current mirror md5 under MIRROR_MD5["$phase:$site"]
+    local phase="$1" site site_name h
+    for site in "${CLIENT_SITES[@]}"; do
+        site_name="$(site_var "$site" SITE_NAME)"
+        h="$(mirror_md5 "$site")"
+        MIRROR_MD5["$phase:$site"]="$h"
+        info "$site_name mirror md5 [$phase]: ${h:-<none>}"
+    done
+}
+
+assert_mirror_unchanged_since() {
+    # each client's CURRENT mirror md5 must equal the one snapshotted for <ref_phase>;
+    # proves the mirror survived a client restart / crash and is byte-identical to what
+    # the reference run produced -- i.e. a continue loads exactly the prior run's global.
+    local ref_phase="$1" site site_name cur ref
+    for site in "${CLIENT_SITES[@]}"; do
+        site_name="$(site_var "$site" SITE_NAME)"
+        ref="${MIRROR_MD5["$ref_phase:$site"]:-}"
+        cur="$(mirror_md5 "$site")"
+        if [[ -z "$ref" || -z "$cur" ]]; then
+            err "$site_name continuity check missing a hash (ref[$ref_phase]=${ref:-<none>}, cur=${cur:-<none>})"
+            return 1
+        fi
+        if [[ "$cur" != "$ref" ]]; then
+            err "$site_name mirror changed since $ref_phase (continuity broken): $ref -> $cur"
+            return 1
+        fi
+        ok "$site_name mirror unchanged since $ref_phase ($cur) -- continuity holds"
+    done
+}
+
+mirror_hashes_json() {
+    # {"<site_name>": "<md5>", ...} from MIRROR_MD5 for a given phase
+    local phase="$1" site site_name h obj='{}'
+    for site in "${CLIENT_SITES[@]}"; do
+        site_name="$(site_var "$site" SITE_NAME)"
+        h="${MIRROR_MD5["$phase:$site"]:-}"
+        obj="$(echo "$obj" | jq --arg k "$site_name" --arg v "$h" '. + {($k):$v}')"
+    done
+    echo "$obj"
+}
+
+wait_for_mirror() {
+    # poll until EVERY client has a non-empty mirror (a round's global has been saved+mirrored)
+    local max_attempts=$((TIMEOUT_MINUTES * 4)) attempt=0 site scratch all
+    while [[ $attempt -lt $max_attempts ]]; do
+        all=true
+        for site in "${CLIENT_SITES[@]}"; do
+            scratch="$(site_scratch "$site")"
+            remote_exec "$site" "test -s '$scratch/mediswarm_latest_global.pt'" >/dev/null 2>&1 || all=false
+        done
+        if [[ "$all" == true ]]; then
+            ok "All clients mirrored a global (a round completed) -- safe to abort mid-run"
+            return 0
+        fi
+        sleep 15
+        attempt=$((attempt + 1))
+    done
+    err "Timed out waiting for a mirrored global before the abort"
+    return 1
+}
+
 collect_latest_globals() {
     local phase="$1"
     local checkpoint_dir="$RESULTS_DIR/$phase/checkpoints"
@@ -655,7 +738,8 @@ latest_job_id_from_phase() {
 }
 
 record_phase() {
-    local phase="$1" status="$2" checkpoint_dir="${3:-}" eval_dir="${4:-}" job_id
+    local phase="$1" status="$2" checkpoint_dir="${3:-}" eval_dir="${4:-}" extra="${5:-}" job_id
+    [[ -n "$extra" ]] || extra='{}'
     job_id="$(latest_job_id_from_phase "$phase")"
     jq -n \
         --arg phase "$phase" \
@@ -665,7 +749,8 @@ record_phase() {
         --arg eval_dir "$eval_dir" \
         --arg docker_image "$DOCKER_IMAGE" \
         --arg git_sha "$GIT_SHA" \
-        '{phase:$phase,status:$status,job_id:$job_id,checkpoint_dir:$checkpoint_dir,evaluation_dir:$eval_dir,docker_image:$docker_image,git_sha:$git_sha}' \
+        --argjson extra "$extra" \
+        '{phase:$phase,status:$status,job_id:$job_id,checkpoint_dir:$checkpoint_dir,evaluation_dir:$eval_dir,docker_image:$docker_image,git_sha:$git_sha} + $extra' \
         > "$RESULTS_DIR/${phase}_result.json"
 }
 
@@ -678,6 +763,13 @@ run_phase() {
     start_server
     start_clients
     wait_for_registration
+
+    # Continuity (P1): before a continue submits, the mirror it is about to load must be
+    # byte-identical to what the fresh run produced and have survived the client restart.
+    if [[ "$phase" == "continue" ]]; then
+        assert_mirror_unchanged_since "fresh"
+    fi
+
     prepare_admin_job "$warm_start" "$rounds"
     start_line="$(log_start_line)"
     submit_job "$warm_start"
@@ -693,6 +785,7 @@ run_phase() {
     wait_for_success "$phase" "$start_line"
     save_phase_logs "$phase"
     assert_latest_globals
+    record_mirror_hashes "$phase"
 
     if [[ "$phase" == "continue" ]]; then
         assert_log_contains "$phase" "WarmStart: will warm-start from checkpoint /scratch/mediswarm_latest_global.pt (mode=require)"
@@ -707,7 +800,60 @@ run_phase() {
         eval_dir="$(evaluate_phase "$phase" "$checkpoint_dir")"
     fi
 
-    record_phase "$phase" "pass" "$checkpoint_dir" "$eval_dir"
+    local extra='{}'
+    if [[ "$phase" == "continue" ]]; then
+        extra="$(jq -n --argjson m "$(mirror_hashes_json "fresh")" \
+            '{continuity_verified:true, reference_phase:"fresh", fresh_mirror_md5:$m}')"
+    fi
+    record_phase "$phase" "pass" "$checkpoint_dir" "$eval_dir" "$extra"
+}
+
+run_abort_recovery_phase() {
+    # The real #347 scenario: a run CRASHES mid-flight; a strict (require) continue must
+    # resume from the last mirrored global instead of restarting. (The other phases only
+    # chain two cleanly-completed runs.)
+    local phase="abort_recovery" start_line
+    step "Phase: $phase (crash mid-run, then resume from the last mirror)"
+
+    # 1. Start a fresh run with enough rounds that we can abort it mid-way.
+    stop_all
+    start_server
+    start_clients
+    wait_for_registration
+    clear_mirrors   # so the resume point is THIS run's global, not a leftover from a prior phase
+    prepare_admin_job "fresh" 3
+    start_line="$(log_start_line)"
+    submit_job "fresh"
+
+    # 2. As soon as every client has mirrored a round's global, snapshot it and simulate a crash.
+    wait_for_mirror
+    record_mirror_hashes "$phase"
+    save_phase_logs "$phase"
+    warn "Aborting the run mid-flight (docker rm -f all NVFlare containers) to simulate a crash"
+    stop_all
+
+    # 3. The mirror must survive the crash on the host /scratch mount.
+    assert_latest_globals
+    assert_mirror_unchanged_since "$phase"
+
+    # 4. Resume: a strict continue must load the surviving mirror and finish cleanly.
+    start_server
+    start_clients
+    wait_for_registration
+    assert_mirror_unchanged_since "$phase"   # mirror still intact after the client restart
+    prepare_admin_job "continue" 1
+    start_line="$(log_start_line)"
+    submit_job "continue"
+    wait_for_success "$phase" "$start_line"
+    save_phase_logs "$phase"
+    assert_latest_globals
+    assert_log_contains "$phase" "WarmStart: will warm-start from checkpoint /scratch/mediswarm_latest_global.pt (mode=require)"
+    stop_all
+
+    record_phase "$phase" "pass" "" "" \
+        "$(jq -n --argjson m "$(mirror_hashes_json "$phase")" \
+            '{resumed_from_crash:true, pre_abort_mirror_md5:$m}')"
+    ok "Abort-recovery: a crashed run resumed from the last mirrored global"
 }
 
 write_summary() {
@@ -751,6 +897,7 @@ run_phase "negative_continue" "continue" 2 "negative"
 run_phase "fresh" "fresh" 2 "eval"
 run_phase "continue" "continue" 2 "eval"
 run_phase "fresh_probe" "fresh" 1 "no_eval"
+run_abort_recovery_phase
 
 write_summary
 stop_all


### PR DESCRIPTION
## What & why
Follow-up to the merged admin-controlled warm-continue (#361). The 2-node RSH/MHA run validated the *mechanism* but left three gaps; this PR closes them.

### 1. Continuity assertion (test wrapper)
The old test proved a checkpoint *loaded* but never that the weights actually carried over. `run_warm_continue_test.sh` now snapshots each client's mirror md5 after `fresh` and asserts the `continue` run's mirror is **byte-identical** and survived the client restart (recorded in `summary.json`).

### 2. Abort-recovery phase (the real #347 scenario)
The old phases only chained two *cleanly-completed* runs. New `run_abort_recovery_phase`: start a fresh run, wait until a round is mirrored, **crash it mid-flight** (`docker rm -f`), then a strict `require` continue must resume from the surviving `/scratch/mediswarm_latest_global.pt`. `clear_mirrors` guarantees the resume point is this run's global, not a leftover.

### 3. Fix best-model-selection metric (Fixes #364)
`IntimeModelSelector.key_metric` was `"accuracy"`, which matches **no** reported metric (`val/AUC_ROC`, `val/ACC`, `val/loss`), so best-model selection silently never fired — affecting `best_FL_global_model.pt`, the best-global mirror path, and challenge eval. Set to `val/AUC_ROC` in the 6 ODELIA challenge jobs. STAMP left as-is (task-dependent metric; tracked separately).

### Docs
Operator "Recover an aborted run" runbook + `/scratch` space/persistence caution (the 1DC mirror is ~690 MB); cross-link from `SWARM_FAILURE_MODES.md`.

## Validation
- `bash -n`, `py_compile`, pyhocon parse (18 configs, 0 fail), `test_warm_continue.py` 11/11 ✅
- Auto/fresh/require + FT `WARM_START_REQUIRED_MISSING`-aborts-not-prunes are already unit-tested (`test_warm_continue.py`) — auto live phases intentionally not added (auto = direct-submit default).
- **Enhanced 2-node RSH/MHA validation running**; `summary.json` (continuity hashes + abort→resume) to be attached.

Refs #347 (warm-continue), #346 (fault-tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
