### PR TITLE
chore: bump NVFlare gitlink + cifar10 nvflare pin (fork CI green, CVE-2026-24178)

### DIFF
--- a/application/jobs/cifar10/requirements.txt
+++ b/application/jobs/cifar10/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.4.0rc
+nvflare~=2.7.2
 torch
 torchvision
 tensorboard


### PR DESCRIPTION
Two NVFlare-hygiene cleanups, both cosmetic / no runtime impact on the production image.

### 1. Bump the `docker_config/NVFlare` gitlink `29866b360` -> `870df683e`
Merge commit of NVFlare_MediSwarm#6, now the tip of `MediSwarm-2.7.2`. Diff is formatting- and test-only:
- black-format `server_ctl.py`, `subprocess_launcher.py`, `test_server_ctl_min_clients.py`
- align the `FlareAgentWithCellPipe` timeout-default tests with the base (360000s slow-VPN value) instead of the stale `60.0`

Keeps the pinned fork commit equal to the fork branch tip, whose pre-merge CI is now fully green (35/35). Resolves the fork-CI red tracked in #374.

### 2. Bump `application/jobs/cifar10/requirements.txt` nvflare pin `~=2.4.0rc` -> `~=2.7.2`
Clears Dependabot **GHSA-jqp3-qrgh-4846 / CVE-2026-24178** (CVSS 9.8, NVFlare Dashboard authz bypass, fixed in 2.7.2).

**Exposure was effectively nil** - the pin sits in a stock CIFAR-10 example job, not the production install path (`Dockerfile_ODELIA` installs the 2.7.2-based fork from source), and the vulnerable Dashboard component is not used in ODELIA (CLI/startup-kit provisioning). This just clears the recurring alert and aligns the example with the fork 2.7.x line.

Generated with [Claude Code](https://claude.com/claude-code)