### PR TITLE
STAMP: add post-training evaluation to the deploy test (#270)

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/stamp_predict.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_predict.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+STAMP post-training evaluation / prediction (issue #270).
+
+The STAMP equivalent of ``scripts/evaluation/predict.py``: load a federated
+global checkpoint produced by the swarm run (``FL_global_model.pt`` /
+``best_FL_global_model.pt``, written by NVFlare's ``PTFileModelPersistor``),
+run inference on a held-out split of the evaluation site's data, and record
+task-appropriate metrics to a JSON file.
+
+The deploy test (``scripts/deploy/run_stamp_deploy_test.sh``) collects the
+per-client checkpoints into a staging workspace laid out as
+``<workspace>/app_<SITE>/FL_global_model.pt`` and runs this script inside the
+STAMP Docker image with the evaluation site's STAMP_* environment.
+
+Only ``classification`` metrics (AUROC + accuracy) are implemented here.
+``survival`` / ``regression`` metrics are left for #271, which extends the
+deploy test to those tasks; for those tasks this script records the sample
+count and a ``metric_not_implemented`` note rather than failing.
+
+Usage (inside the STAMP image):
+    python3 stamp_predict.py --workspace /workspace --output-dir /output
+    python3 stamp_predict.py --checkpoint /workspace/app_RUMC_1/best_FL_global_model.pt \\
+        --output-dir /output
+
+Configuration is read from the same STAMP_* environment variables the training
+uses (STAMP_CLINI_TABLE, STAMP_FEATURE_DIR, STAMP_MODEL_NAME, STAMP_TASK, ...).
+The held-out split reproduces training's stratified val partition (STAMP_SEED).
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("stamp_predict")
+
+# NVFlare PTFileModelPersistor filenames, best first.
+CHECKPOINT_NAMES = ["best_FL_global_model.pt", "FL_global_model.pt"]
+
+# Make the STAMP custom dir (this file's dir) and _shared importable when run
+# as a plain script inside the image, so ``import stamp_training`` works.
+_THIS_DIR = Path(__file__).resolve().parent
+for _p in (str(_THIS_DIR),):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# --------------------------------------------------------------------------- #
+#  Pure helpers (no torch / STAMP needed — unit-testable standalone)          #
+# --------------------------------------------------------------------------- #
+
+def discover_checkpoints(workspace: str, best_only: bool = False) -> List[Dict[str, str]]:
+    """Find swarm global checkpoints under a staging workspace.
+
+    Matches ``<workspace>/**/app_<SITE>/{best_,}FL_global_model.pt`` (the layout
+    produced by ``collect_checkpoints()`` in the deploy test, and by NVFlare job
+    workspaces). De-duplicates on (site, filename), preferring ``best_`` first.
+
+    Returns a list of ``{"site", "name", "path"}`` dicts.
+    """
+    patterns = ["**/app_*/best_FL_global_model.pt"]
+    if not best_only:
+        patterns.append("**/app_*/FL_global_model.pt")
+
+    found: List[Dict[str, str]] = []
+    seen = set()
+    root = Path(workspace)
+    for pattern in patterns:
+        for ckpt_path in sorted(root.glob(pattern)):
+            app_dir = ckpt_path.parent.name  # e.g. "app_RUMC_1"
+            site = app_dir[4:] if app_dir.startswith("app_") else app_dir
+            key = (site, ckpt_path.name)
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append({"site": site, "name": ckpt_path.name, "path": str(ckpt_path)})
+    return found
+
+
+def extract_state_dict(ckpt: Any) -> Dict[str, Any]:
+    """Pull the model state dict out of a loaded checkpoint object.
+
+    Handles the three shapes PTFileModelPersistor / Lightning produce:
+    ``{"model": sd}``, ``{"state_dict": sd}``, or a bare state dict.
+    """
+    if isinstance(ckpt, dict):
+        model_val = ckpt.get("model")
+        if isinstance(model_val, dict):
+            return model_val
+        sd_val = ckpt.get("state_dict")
+        if isinstance(sd_val, dict):
+            return sd_val
+        return ckpt
+    raise ValueError(f"Unexpected checkpoint format (type={type(ckpt).__name__})")
+
+
+def compute_classification_metrics(
+    y_true: List[int], y_prob: List[List[float]]
+) -> Dict[str, Any]:
+    """Compute accuracy + (macro OVR) AUROC from ground truth and probabilities.
+
+    ``y_prob[i]`` is the per-class probability vector for sample ``i``. AUROC is
+    ``None`` when it is undefined (fewer than two classes present in ``y_true``).
+    """
+    import numpy as np
+    from sklearn.metrics import accuracy_score, roc_auc_score
+
+    y_true_arr = np.asarray(y_true)
+    y_prob_arr = np.asarray(y_prob, dtype=float)
+    if y_prob_arr.ndim != 2:
+        raise ValueError(f"y_prob must be 2-D (n_samples, n_classes); got shape {y_prob_arr.shape}")
+
+    n_classes = int(y_prob_arr.shape[1])
+    y_pred = y_prob_arr.argmax(axis=1)
+    accuracy = float(accuracy_score(y_true_arr, y_pred))
+
+    auroc: Optional[float] = None
+    classes_present = sorted(set(int(v) for v in y_true_arr.tolist()))
+    if len(classes_present) < 2:
+        logger.warning(
+            "AUROC undefined — only %d class(es) present in the eval labels", len(classes_present)
+        )
+    else:
+        try:
+            if n_classes == 2:
+                auroc = float(roc_auc_score(y_true_arr, y_prob_arr[:, 1]))
+            else:
+                auroc = float(
+                    roc_auc_score(
+                        y_true_arr,
+                        y_prob_arr,
+                        multi_class="ovr",
+                        average="macro",
+                        labels=list(range(n_classes)),
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001 — metric is best-effort
+            logger.warning("Could not compute AUROC: %s", exc)
+
+    return {
+        "accuracy": accuracy,
+        "auroc": auroc,
+        "num_samples": int(y_true_arr.shape[0]),
+        "num_classes": n_classes,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  STAMP-dependent runtime (torch + STAMP required)                           #
+# --------------------------------------------------------------------------- #
+
+def load_eval_dataloader(env: Dict[str, Any]):
+    """Build the held-out validation dataloader for the eval site's data.
+
+    Reuses the training pipeline (``load_stamp_data`` + ``create_stamp_training_model``)
+    so the split matches training's seeded stratified val partition. The freshly
+    built model is discarded — only its ``valid_dl`` is used, with the *global*
+    checkpoint loaded into a separate model for inference.
+    """
+    from stamp_training import create_stamp_training_model, load_stamp_data
+
+    patient_to_data, feature_type = load_stamp_data(env)
+    _model, _train_dl, valid_dl = create_stamp_training_model(env, patient_to_data, feature_type)
+    return valid_dl
+
+
+def build_and_load_model(checkpoint_path: str, device):
+    """Instantiate the STAMP model (env-driven) and load a global checkpoint."""
+    import torch
+
+    from stamp_model_wrapper import create_stamp_model
+
+    model = create_stamp_model()
+    ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+    state_dict = extract_state_dict(ckpt)
+    result = model.load_state_dict(state_dict, strict=False)
+    missing = getattr(result, "missing_keys", [])
+    unexpected = getattr(result, "unexpected_keys", [])
+    if missing:
+        logger.warning("load_state_dict: %d missing key(s), e.g. %s", len(missing), missing[:3])
+    if unexpected:
+        logger.warning("load_state_dict: %d unexpected key(s), e.g. %s", len(unexpected), unexpected[:3])
+    return model.to(device).eval()
+
+
+def _unpack_batch(batch):
+    """Return (bags, targets) from a STAMP dataloader batch (tuple or dict)."""
+    if isinstance(batch, (list, tuple)):
+        return batch[0], batch[1]
+    if isinstance(batch, dict):
+        bags = batch.get("bags", batch.get("features"))
+        targets = batch.get("targets", batch.get("labels"))
+        return bags, targets
+    raise ValueError(f"Unexpected batch type: {type(batch).__name__}")
+
+
+def run_inference(model, dataloader, device):
+    """Run the model over a dataloader, returning (y_true, y_prob) lists.
+
+    Mirrors ``STAMPPredictionCallback._write_predictions``: forward → softmax.
+    """
+    import torch
+
+    y_true: List[int] = []
+    y_prob: List[List[float]] = []
+    with torch.no_grad():
+        for batch in dataloader:
+            bags, targets = _unpack_batch(batch)
+            if bags is None or targets is None:
+                continue
+            bags = bags.to(device)
+            try:
+                logits = model(bags)
+            except Exception:  # noqa: BLE001 — some STAMP models use kwargs
+                logits = model(features=bags)
+            probs = torch.softmax(logits, dim=-1).cpu()
+            targets_cpu = targets.cpu()
+            for i in range(probs.shape[0]):
+                gt = targets_cpu[i]
+                if gt.dim() != 0:
+                    # survival/regression targets are not a scalar class index
+                    continue
+                y_true.append(int(gt.item()))
+                y_prob.append([float(x) for x in probs[i].tolist()])
+    return y_true, y_prob
+
+
+def evaluate_checkpoint(checkpoint: Dict[str, str], dataloader, env: Dict[str, Any], device) -> Dict[str, Any]:
+    """Evaluate one checkpoint on the eval dataloader; return a result record."""
+    task = env.get("task", "classification")
+    record: Dict[str, Any] = {
+        "site": checkpoint["site"],
+        "checkpoint": checkpoint["name"],
+        "path": checkpoint["path"],
+        "task": task,
+    }
+    model = build_and_load_model(checkpoint["path"], device)
+    y_true, y_prob = run_inference(model, dataloader, device)
+    record["num_samples"] = len(y_true)
+
+    if task == "classification":
+        if not y_true:
+            record["error"] = "no_scalar_class_targets"
+            return record
+        record.update(compute_classification_metrics(y_true, y_prob))
+    else:
+        # #271 will add survival (c-index) / regression metrics.
+        record["note"] = f"metric_not_implemented_for_task:{task}"
+    return record
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", type=str, help="Staging dir containing app_<SITE>/FL_global_model.pt files.")
+    group.add_argument("--checkpoint", type=str, help="Path to a single checkpoint file.")
+    parser.add_argument("--output-dir", type=str, required=True, help="Directory for the results JSON.")
+    parser.add_argument(
+        "--best-only",
+        action="store_true",
+        help="With --workspace, only evaluate best_FL_global_model.pt.",
+    )
+    parser.add_argument("--results-name", type=str, default="stamp_eval_results.json", help="Results JSON filename.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    import torch
+
+    from stamp_training import load_stamp_environment
+
+    env = load_stamp_environment()
+    logger.info("STAMP eval — task=%s model=%s site=%s", env.get("task"), env.get("model_name"), env.get("site_name"))
+
+    if args.checkpoint:
+        ckpt_path = Path(args.checkpoint)
+        app_dir = ckpt_path.parent.name
+        site = app_dir[4:] if app_dir.startswith("app_") else env.get("site_name", "unknown")
+        checkpoints = [{"site": site, "name": ckpt_path.name, "path": str(ckpt_path)}]
+    else:
+        checkpoints = discover_checkpoints(args.workspace, best_only=args.best_only)
+
+    if not checkpoints:
+        logger.error("No checkpoints found to evaluate")
+        return 1
+
+    logger.info("Found %d checkpoint(s): %s", len(checkpoints), [c["path"] for c in checkpoints])
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    dataloader = load_eval_dataloader(env)
+
+    results: List[Dict[str, Any]] = []
+    for ckpt in checkpoints:
+        logger.info("Evaluating %s (%s)", ckpt["name"], ckpt["site"])
+        try:
+            results.append(evaluate_checkpoint(ckpt, dataloader, env, device))
+        except Exception as exc:  # noqa: BLE001 — record per-checkpoint failure, keep going
+            logger.exception("Evaluation failed for %s", ckpt["path"])
+            results.append({**ckpt, "error": str(exc)})
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / args.results_name
+    payload = {
+        "task": env.get("task"),
+        "model_name": env.get("model_name"),
+        "eval_site": env.get("site_name"),
+        "results": results,
+    }
+    out_path.write_text(json.dumps(payload, indent=2))
+    logger.info("Wrote results to %s", out_path)
+
+    # Success if at least one checkpoint produced a usable metric.
+    scored = [r for r in results if r.get("auroc") is not None or r.get("accuracy") is not None]
+    if not scored:
+        logger.error("No checkpoint produced a usable metric")
+        return 1
+    for r in scored:
+        logger.info(
+            "  %s/%s: accuracy=%s auroc=%s (n=%s)",
+            r["site"], r["checkpoint"], r.get("accuracy"), r.get("auroc"), r.get("num_samples"),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -27,7 +27,9 @@
 #   - Can run one or more STAMP models against STAMP_classification
 #   - Exports STAMP_* environment variables on remote hosts before docker.sh
 #   - Uses stamp_swarm container name prefix (not odelia_swarm)
-#   - Has no evaluation step (STAMP has no predict.py equivalent yet)
+#   - Optional post-training evaluation via --evaluate (#270): collects the
+#     global checkpoints and runs stamp_predict.py to record AUROC/accuracy.
+#     Needs the eval site's data staged on this machine (see --eval-data-dir).
 #   - Has no retry loop (simpler for initial testing)
 #
 # Usage:
@@ -66,19 +68,32 @@ TIMEOUT_MINUTES=120   # 2 hours for a quick 2-round test
 MODELS_ARG=""
 ALL_STAMP_MODELS=(vit mlp trans_mil linear barspoon)
 TEST_MODELS=()
+EVALUATE=false          # run the post-training evaluation step (#270)
+EVAL_SITE_ARG=""        # site whose data to evaluate on (default: first client site)
+EVAL_DATA_DIR_ARG=""    # host path to eval data on this (server) machine
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --conf)         CONF_FILE="$2"; shift ;;
-        --timeout)      TIMEOUT_MINUTES="$2"; shift ;;
-        --models)       MODELS_ARG="$2"; shift ;;
+        --conf)          CONF_FILE="$2"; shift ;;
+        --timeout)       TIMEOUT_MINUTES="$2"; shift ;;
+        --models)        MODELS_ARG="$2"; shift ;;
+        --evaluate)      EVALUATE=true ;;
+        --eval-site)     EVAL_SITE_ARG="$2"; shift ;;
+        --eval-data-dir) EVAL_DATA_DIR_ARG="$2"; shift ;;
         -h|--help)
             echo "Usage: $0 --conf CONF_FILE [--timeout MINUTES] [--models MODEL1,MODEL2,...]"
+            echo "          [--evaluate [--eval-site SITE] [--eval-data-dir DIR]]"
             echo ""
-            echo "  --conf      Path to site configuration file (required)"
-            echo "  --timeout   Per-model training timeout in minutes (default: 120)"
-            echo "  --models    Comma-separated STAMP models to test"
-            echo "              (default: vit,mlp,trans_mil,linear,barspoon)"
+            echo "  --conf           Path to site configuration file (required)"
+            echo "  --timeout        Per-model training timeout in minutes (default: 120)"
+            echo "  --models         Comma-separated STAMP models to test"
+            echo "                   (default: vit,mlp,trans_mil,linear,barspoon)"
+            echo "  --evaluate       After training, collect global checkpoints and run"
+            echo "                   stamp_predict.py to record AUROC/accuracy (#270)."
+            echo "  --eval-site      Site whose data (on this machine) to evaluate on"
+            echo "                   (default: first client site; needs its data locally)"
+            echo "  --eval-data-dir  Host dir mounted as /data for evaluation"
+            echo "                   (default: the eval site's DATADIR from the conf)"
             exit 0
             ;;
         *)
@@ -170,6 +185,13 @@ mkdir -p "$RESULTS_DIR"
 
 # Job to run
 JOB_NAME="${DEFAULT_JOB:-STAMP_classification}"
+
+# ── Evaluation configuration (#270) ────────────────────────────────────────
+# Evaluation runs on THIS (server) machine and needs the eval site's data
+# locally (mounted as /data). CLI flags override; conf may set EVAL_SITE /
+# EVAL_DATA_DIR. Default eval site = first client site.
+EVAL_SITE="${EVAL_SITE_ARG:-${EVAL_SITE:-${CLIENT_SITES[0]:-}}}"
+EVAL_SCRATCH_DIR="${EVAL_SCRATCH_DIR:-$RESULTS_DIR/eval_scratch}"
 
 # ── STAMP environment variables ──────────────────────────────────────────
 # These are exported on each remote host BEFORE calling docker.sh.
@@ -685,27 +707,172 @@ wait_for_completion() {
     return 1
 }
 
+# ── Collect global checkpoints from client machines (#270) ─────────────────
+collect_checkpoints() {
+    local model_name="$1"
+
+    step "Collecting global checkpoints for $model_name" >&2
+
+    # Find the job ID of the run that finished, from the server log.
+    resolve_server_startup_dir
+    local server_log="${_server_startup_dir}/nohup.out"
+    local job_id=""
+    if [[ -f "$server_log" ]]; then
+        job_id=$(grep 'Server runner finished\.' "$server_log" | tail -1 \
+            | grep -oP 'run=\K[0-9a-f-]+' || true)
+    fi
+    if [[ -n "$job_id" ]]; then
+        info "  Job ID from server log: $job_id" >&2
+    else
+        warn "  Could not determine job ID — falling back to glob" >&2
+    fi
+
+    local staging_dir="$RESULTS_DIR/${model_name}_checkpoints"
+    rm -rf "$staging_dir"
+    mkdir -p "$staging_dir"
+
+    local found_any=false
+    for site in "${CLIENT_SITES[@]}"; do
+        local site_name host deploy_dir user pass
+        site_name=$(site_var "$site" SITE_NAME)
+        host=$(site_var "$site" HOST)
+        deploy_dir=$(site_var "$site" DEPLOY_DIR)
+        user=$(site_var "$site" USER)
+        pass=$(site_var "$site" PASS)
+        local remote_base="$deploy_dir/$site_name"
+
+        local search_cmd
+        if [[ -n "$job_id" ]]; then
+            search_cmd="ls -1 '$remote_base/$job_id/app_${site_name}/FL_global_model.pt' '$remote_base/$job_id/app_${site_name}/best_FL_global_model.pt' 2>/dev/null || true"
+        else
+            search_cmd="find '$remote_base' -maxdepth 3 \( -name 'FL_global_model.pt' -o -name 'best_FL_global_model.pt' \) 2>/dev/null || true"
+        fi
+
+        local remote_files
+        remote_files=$(sshpass -p "$pass" ssh $SSH_OPTS "$user@$host" "$search_cmd" 2>/dev/null || true)
+        if [[ -z "$remote_files" ]]; then
+            info "  No checkpoints found on $site_name" >&2
+            continue
+        fi
+
+        local local_app_dir="$staging_dir/app_${site_name}"
+        mkdir -p "$local_app_dir"
+        while IFS= read -r remote_file; do
+            [[ -z "$remote_file" ]] && continue
+            local basename_file
+            basename_file=$(basename "$remote_file")
+            if sshpass -p "$pass" scp $SSH_OPTS "$user@$host:$remote_file" "$local_app_dir/$basename_file" 2>/dev/null; then
+                ok "  Collected $basename_file from $site_name" >&2
+                found_any=true
+            else
+                warn "  Failed to SCP $remote_file from $site_name" >&2
+            fi
+        done <<< "$remote_files"
+    done
+
+    if [[ "$found_any" == true ]]; then
+        echo "$staging_dir"
+        return 0
+    fi
+    err "No checkpoints collected for $model_name" >&2
+    return 1
+}
+
+# ── Evaluate the global model with stamp_predict.py (#270) ─────────────────
+# Runs on THIS machine; needs the eval site's data staged locally. Echoes the
+# eval status (pass|fail|skipped). Non-fatal: a skip/fail never fails the run.
+evaluate_model() {
+    local model_name="$1"
+
+    step "Evaluating $model_name" >&2
+
+    if [[ -z "$EVAL_SITE" ]]; then
+        warn "  No eval site resolved — skipping evaluation" >&2
+        echo "skipped"; return 0
+    fi
+
+    local eval_site_name eval_data_dir
+    eval_site_name=$(site_var "$EVAL_SITE" SITE_NAME 2>/dev/null || echo "$EVAL_SITE")
+    eval_data_dir="${EVAL_DATA_DIR_ARG:-$(site_var "$EVAL_SITE" DATADIR 2>/dev/null || true)}"
+
+    if [[ -z "$eval_data_dir" || ! -d "$eval_data_dir" ]]; then
+        warn "  Eval data not available on this machine ('$eval_data_dir') — skipping evaluation" >&2
+        warn "  (evaluation runs here; stage $eval_site_name's data locally or pass --eval-data-dir)" >&2
+        echo "skipped"; return 0
+    fi
+
+    local checkpoint_dir
+    if ! checkpoint_dir=$(collect_checkpoints "$model_name"); then
+        err "  Cannot evaluate $model_name — no checkpoints collected" >&2
+        echo "fail"; return 0
+    fi
+
+    mkdir -p "$EVAL_SCRATCH_DIR"
+    local eval_output_dir="$RESULTS_DIR/${model_name}_evaluation"
+    mkdir -p "$eval_output_dir"
+
+    # STAMP_* env for the eval site (same layout: /data/<site>/...).
+    local envfile="$eval_output_dir/stamp_env.list"
+    setup_stamp_env "$eval_site_name" "$model_name" | sed 's/^export //; s/"//g' > "$envfile"
+
+    info "  Running stamp_predict.py in $DOCKER_IMAGE on $eval_site_name data (CPU unless EVAL_GPU set)" >&2
+    local rc=0
+    docker run --rm \
+        ${EVAL_GPU:+--gpus="$EVAL_GPU"} \
+        --net=host --ipc=host \
+        -v "$eval_data_dir:/data/:ro" \
+        -v "$EVAL_SCRATCH_DIR:/scratch/" \
+        -v "$checkpoint_dir:/workspace/:ro" \
+        -v "$eval_output_dir:/output/" \
+        --env-file "$envfile" \
+        --env SITE_NAME="$eval_site_name" \
+        --env SCRATCH_DIR=/scratch \
+        --env MEDISWARM_VERSION="$VERSION" \
+        "$DOCKER_IMAGE" \
+        python3 /MediSwarm/application/jobs/STAMP_classification/app/custom/stamp_predict.py \
+            --workspace /workspace --output-dir /output \
+        > "$eval_output_dir/stamp_predict_stdout.log" 2>&1 || rc=$?
+
+    EVAL_RESULTS_FILE="$eval_output_dir/stamp_eval_results.json"
+    if [[ $rc -eq 0 && -f "$EVAL_RESULTS_FILE" ]]; then
+        ok "  Evaluation completed for $model_name" >&2
+        echo "pass"; return 0
+    fi
+    err "  Evaluation failed for $model_name (exit $rc); see $eval_output_dir/stamp_predict_stdout.log" >&2
+    echo "fail"; return 0
+}
+
 # ── Record result ─────────────────────────────────────────────────────────
 record_result() {
     local model_name="$1"
     local job_name="$2"
-    local train_status="$3"   # pass or fail
+    local train_status="$3"       # pass or fail
     local duration_seconds="$4"
+    local eval_status="${5:-skipped}"   # pass, fail, or skipped
 
     local result_file="$RESULTS_DIR/deploy_test_stamp_${model_name}.json"
     local timestamp
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Embed the eval metrics JSON if present, else null.
+    local eval_metrics="null"
+    local eval_results_file="$RESULTS_DIR/${model_name}_evaluation/stamp_eval_results.json"
+    if [[ "$eval_status" != "skipped" && -f "$eval_results_file" ]]; then
+        eval_metrics=$(cat "$eval_results_file")
+    fi
 
     cat > "$result_file" <<EOF
 {
     "model_name": "$model_name",
     "job_name": "$job_name",
     "training_status": "$train_status",
+    "evaluation_status": "$eval_status",
     "duration_seconds": $duration_seconds,
     "timestamp": "$timestamp",
     "docker_image": "$DOCKER_IMAGE",
     "version": "$VERSION",
-    "client_sites": $(printf '%s\n' "${CLIENT_SITES[@]}" | jq -R . | jq -s .)
+    "client_sites": $(printf '%s\n' "${CLIENT_SITES[@]}" | jq -R . | jq -s .),
+    "evaluation_metrics": $eval_metrics
 }
 EOF
 
@@ -777,19 +944,26 @@ run_single_model() {
         fi
     done
 
-    # 7. Stop all containers
+    # 7. Evaluate the trained global model (#270) — before stop_all, so the
+    #    client checkpoints are still collectable from the remote workspaces.
+    local eval_status="skipped"
+    if [[ "$EVALUATE" == true && "$train_status" == "pass" ]]; then
+        eval_status=$(evaluate_model "$model_name")
+    fi
+
+    # 8. Stop all containers
     stop_all
 
-    # 8. Record result
+    # 9. Record result
     local end_time
     end_time=$(date +%s)
     local duration=$(( end_time - start_time ))
 
-    record_result "$model_name" "$job_name" "$train_status" "$duration"
+    record_result "$model_name" "$job_name" "$train_status" "$duration" "$eval_status"
 
     echo ""
     if [[ "$train_status" == "pass" ]]; then
-        ok "PASSED: $model_name in ${duration}s"
+        ok "PASSED: $model_name in ${duration}s (evaluation: $eval_status)"
     else
         err "FAILED: $model_name in ${duration}s"
     fi

--- a/tests/unit_tests/test_stamp_predict.py
+++ b/tests/unit_tests/test_stamp_predict.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for stamp_predict.py (issue #270) — the pure, dependency-light
+helpers that don't need torch or STAMP installed:
+
+- discover_checkpoints(): globbing + app_<SITE> parsing + best-first de-dup
+- extract_state_dict(): the three checkpoint shapes PTFileModelPersistor/
+  Lightning produce
+- compute_classification_metrics(): accuracy + AUROC (needs numpy + sklearn;
+  importorskip when absent)
+
+The torch/STAMP runtime (inference, model build, dataloader) is exercised by
+the deploy-test 2-node run, not here.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP_CUSTOM_DIR = REPO_ROOT / "application" / "jobs" / "STAMP_classification" / "app" / "custom"
+
+
+@pytest.fixture(scope="module")
+def sp():
+    """Import stamp_predict from the STAMP custom dir (module-level imports are stdlib only)."""
+    p = str(STAMP_CUSTOM_DIR)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+    sys.modules.pop("stamp_predict", None)
+    import stamp_predict  # noqa: E402
+    return stamp_predict
+
+
+# --------------------------------------------------------------------------- #
+#  discover_checkpoints
+# --------------------------------------------------------------------------- #
+
+def _make_ckpt(root: Path, site: str, name: str) -> Path:
+    d = root / f"app_{site}"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / name
+    f.write_bytes(b"stub")
+    return f
+
+
+def test_discover_checkpoints_finds_all_sites(sp, tmp_path):
+    _make_ckpt(tmp_path, "RUMC_1", "FL_global_model.pt")
+    _make_ckpt(tmp_path, "RUMC_1", "best_FL_global_model.pt")
+    _make_ckpt(tmp_path, "MHA_1", "FL_global_model.pt")
+
+    found = sp.discover_checkpoints(str(tmp_path))
+    sites = sorted({c["site"] for c in found})
+    assert sites == ["MHA_1", "RUMC_1"]
+    # RUMC_1 has both files → 2 records; MHA_1 has 1 → total 3
+    assert len(found) == 3
+    assert all(c["name"] in sp.CHECKPOINT_NAMES for c in found)
+
+
+def test_discover_checkpoints_best_only(sp, tmp_path):
+    _make_ckpt(tmp_path, "RUMC_1", "FL_global_model.pt")
+    _make_ckpt(tmp_path, "RUMC_1", "best_FL_global_model.pt")
+
+    found = sp.discover_checkpoints(str(tmp_path), best_only=True)
+    assert len(found) == 1
+    assert found[0]["name"] == "best_FL_global_model.pt"
+
+
+def test_discover_checkpoints_nested_and_dedup(sp, tmp_path):
+    # deep NVFlare-style layout: prod/server/job_id/app_SITE/
+    nested = tmp_path / "prod_00" / "server" / "job-abc"
+    _make_ckpt(nested, "USZ_1", "best_FL_global_model.pt")
+    found = sp.discover_checkpoints(str(tmp_path))
+    assert [c["site"] for c in found] == ["USZ_1"]
+    # de-dup on (site, name)
+    assert len({(c["site"], c["name"]) for c in found}) == len(found)
+
+
+def test_discover_checkpoints_empty(sp, tmp_path):
+    assert sp.discover_checkpoints(str(tmp_path)) == []
+
+
+# --------------------------------------------------------------------------- #
+#  extract_state_dict
+# --------------------------------------------------------------------------- #
+
+def test_extract_state_dict_model_key(sp):
+    sd = {"layer.weight": 1}
+    assert sp.extract_state_dict({"model": sd}) is sd
+
+
+def test_extract_state_dict_state_dict_key(sp):
+    sd = {"layer.weight": 1}
+    assert sp.extract_state_dict({"state_dict": sd}) is sd
+
+
+def test_extract_state_dict_bare(sp):
+    sd = {"layer.weight": 1, "layer.bias": 2}
+    assert sp.extract_state_dict(sd) == sd
+
+
+def test_extract_state_dict_model_key_prefers_over_state_dict(sp):
+    model_sd = {"a": 1}
+    assert sp.extract_state_dict({"model": model_sd, "state_dict": {"b": 2}}) is model_sd
+
+
+def test_extract_state_dict_rejects_non_dict(sp):
+    with pytest.raises(ValueError):
+        sp.extract_state_dict([1, 2, 3])
+
+
+# --------------------------------------------------------------------------- #
+#  compute_classification_metrics (needs numpy + sklearn)
+# --------------------------------------------------------------------------- #
+
+def test_compute_metrics_perfect_binary(sp):
+    pytest.importorskip("sklearn")
+    y_true = [0, 0, 1, 1]
+    y_prob = [[0.9, 0.1], [0.8, 0.2], [0.2, 0.8], [0.1, 0.9]]
+    m = sp.compute_classification_metrics(y_true, y_prob)
+    assert m["accuracy"] == 1.0
+    assert m["auroc"] == 1.0
+    assert m["num_samples"] == 4
+    assert m["num_classes"] == 2
+
+
+def test_compute_metrics_multiclass(sp):
+    pytest.importorskip("sklearn")
+    y_true = [0, 1, 2, 0]
+    y_prob = [
+        [0.7, 0.2, 0.1],
+        [0.1, 0.8, 0.1],
+        [0.2, 0.2, 0.6],
+        [0.6, 0.3, 0.1],
+    ]
+    m = sp.compute_classification_metrics(y_true, y_prob)
+    assert m["accuracy"] == 1.0
+    assert 0.0 <= m["auroc"] <= 1.0
+    assert m["num_classes"] == 3
+
+
+def test_compute_metrics_single_class_auroc_none(sp):
+    pytest.importorskip("sklearn")
+    y_true = [1, 1, 1]
+    y_prob = [[0.3, 0.7], [0.4, 0.6], [0.2, 0.8]]
+    m = sp.compute_classification_metrics(y_true, y_prob)
+    assert m["auroc"] is None          # undefined with one class
+    assert m["accuracy"] == 1.0
+
+
+def test_compute_metrics_rejects_1d_prob(sp):
+    pytest.importorskip("sklearn")
+    with pytest.raises(ValueError):
+        sp.compute_classification_metrics([0, 1], [0.2, 0.8])


### PR DESCRIPTION
Closes #270 (the foundation for the STAMP deploy-test stack — #271 / #275 build on this eval).

## What
Gives the STAMP deploy test a real quality check instead of only asserting that training completes, mirroring ODELIA's `evaluate_model()` / `collect_checkpoints()`.

- **`application/jobs/STAMP_classification/app/custom/stamp_predict.py`** (new) — the STAMP analogue of `scripts/evaluation/predict.py`. Loads a federated global checkpoint (`FL_global_model.pt` / `best_FL_global_model.pt`), rebuilds the model via `stamp_model_wrapper.create_stamp_model`, runs inference on the eval site's **seeded held-out val split** (reusing `stamp_training.load_stamp_data` + `create_stamp_training_model`, and the `_write_predictions` softmax path), and writes **AUROC + accuracy** to `stamp_eval_results.json`. Classification only; survival/regression record a `metric_not_implemented` note for #271.
- **`scripts/deploy/run_stamp_deploy_test.sh`** — add `collect_checkpoints()` (SCP the global checkpoints from each client workspace) and `evaluate_model()` (run `stamp_predict.py` in the image), **gated behind an opt-in `--evaluate` flag**; record `evaluation_status` + embedded `evaluation_metrics` in the results JSON. **Default behavior unchanged** (no `--evaluate` → identical to before, so existing runs/CI stay green).
- **`tests/unit_tests/test_stamp_predict.py`** — 13 tests for the pure, dependency-light helpers.

## Design notes
- Checkpoints land on **clients** (CCWF swarm, same as ODELIA), so collection is a direct SCP mirror.
- Evaluation runs on the server machine and needs the eval site's data staged locally (`--eval-data-dir`, default = the eval site's `DATADIR`). If it's not present, eval is **skipped** gracefully (never fails the run) — matching ODELIA's resilience.
- CPU by default (avoids the Cosmos GPU `no kernel image` issue); opt into GPU via `EVAL_GPU`.

## Verification
Offline: `bash -n` ✓, `shellcheck -S warning` (0 warnings) ✓, `flake8` ✓, **13/13 unit tests** ✓.
**Deferred:** the live 2-node run (`run_stamp_deploy_test.sh --conf … --evaluate`) — it needs the DL0/DL2 deploy machines and would start an NVFlare server, which must not disrupt the currently-running production server. To be run in a deploy window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)