### PR TITLE
STAMP: federated-vs-local baseline comparison (#275)

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/stamp_predict.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_predict.py
@@ -203,6 +203,55 @@ def compute_survival_metrics(
 
 
 # --------------------------------------------------------------------------- #
+#  Federated-vs-local comparison (#275)                                       #
+# --------------------------------------------------------------------------- #
+
+# Primary metric per task, in priority order, and its optimization direction.
+PRIMARY_METRICS = {
+    "classification": ("auroc", "accuracy"),
+    "regression": ("mse", "mae"),
+    "survival": ("c_index",),
+}
+HIGHER_IS_BETTER = {"auroc": True, "accuracy": True, "c_index": True, "r2": True, "mse": False, "mae": False}
+
+
+def compare_federated_vs_local(
+    federated: Dict[str, Any], local: Dict[str, Any], task: str, tolerance: float = 0.0
+) -> Dict[str, Any]:
+    """Compare a federated metric record against a local-baseline record (#275).
+
+    Picks the first task-primary metric present in *both* records. ``delta`` is
+    signed so that positive always means "federated is better" regardless of the
+    metric's direction. ``regression_detected`` is True when the federated model
+    is worse than local by more than ``tolerance`` — the swarm-learning value
+    proposition is that federation should be at least as good as any single site.
+    """
+    metric = None
+    for key in PRIMARY_METRICS.get(task, ()):
+        if federated.get(key) is not None and local.get(key) is not None:
+            metric = key
+            break
+    if metric is None:
+        return {"comparable": False, "task": task}
+
+    fed_val = float(federated[metric])
+    local_val = float(local[metric])
+    higher_better = HIGHER_IS_BETTER.get(metric, True)
+    delta = (fed_val - local_val) if higher_better else (local_val - fed_val)
+    return {
+        "comparable": True,
+        "task": task,
+        "metric": metric,
+        "higher_is_better": higher_better,
+        "federated": fed_val,
+        "local": local_val,
+        "delta": float(delta),
+        "federated_at_least_as_good": bool(delta >= -tolerance),
+        "regression_detected": bool(delta < -tolerance),
+    }
+
+
+# --------------------------------------------------------------------------- #
 #  STAMP-dependent runtime (torch + STAMP required)                           #
 # --------------------------------------------------------------------------- #
 
@@ -365,7 +414,31 @@ def _parse_args() -> argparse.Namespace:
         help="With --workspace, only evaluate best_FL_global_model.pt.",
     )
     parser.add_argument("--results-name", type=str, default="stamp_eval_results.json", help="Results JSON filename.")
+    parser.add_argument(
+        "--baseline",
+        type=str,
+        default=None,
+        help="Local-only checkpoint to evaluate on the same split for a federated-vs-local "
+        "comparison (#275), e.g. a local-training best_model.ckpt.",
+    )
+    parser.add_argument(
+        "--regression-tolerance",
+        type=float,
+        default=0.0,
+        help="Tolerance for the federated-vs-local regression check (#275).",
+    )
     return parser.parse_args()
+
+
+def _best_result(results: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Pick the representative federated result: prefer best_FL_global_model.pt."""
+    scored = [r for r in results if any(r.get(k) is not None for k in ("auroc", "accuracy", "mse", "mae", "c_index"))]
+    if not scored:
+        return None
+    for r in scored:
+        if r.get("checkpoint") == "best_FL_global_model.pt":
+            return r
+    return scored[0]
 
 
 def main() -> int:
@@ -403,6 +476,25 @@ def main() -> int:
             logger.exception("Evaluation failed for %s", ckpt["path"])
             results.append({**ckpt, "error": str(exc)})
 
+    # Federated-vs-local baseline comparison (#275): evaluate the local
+    # checkpoint on the SAME split, then compare the best federated result.
+    baseline_record = None
+    comparison = None
+    if args.baseline:
+        logger.info("Evaluating local baseline checkpoint: %s", args.baseline)
+        bl_path = Path(args.baseline)
+        bl_ckpt = {"site": "local_baseline", "name": bl_path.name, "path": str(bl_path)}
+        try:
+            baseline_record = evaluate_checkpoint(bl_ckpt, dataloader, env, device)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Local baseline evaluation failed")
+            baseline_record = {**bl_ckpt, "error": str(exc)}
+        fed_best = _best_result(results)
+        if fed_best is not None and baseline_record is not None:
+            comparison = compare_federated_vs_local(
+                fed_best, baseline_record, env.get("task", "classification"), tolerance=args.regression_tolerance
+            )
+
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / args.results_name
@@ -411,9 +503,17 @@ def main() -> int:
         "model_name": env.get("model_name"),
         "eval_site": env.get("site_name"),
         "results": results,
+        "baseline": baseline_record,
+        "federated_vs_local": comparison,
     }
     out_path.write_text(json.dumps(payload, indent=2))
     logger.info("Wrote results to %s", out_path)
+    if comparison and comparison.get("comparable"):
+        logger.info(
+            "Federated vs local (%s): federated=%.4f local=%.4f delta=%+.4f regression=%s",
+            comparison["metric"], comparison["federated"], comparison["local"],
+            comparison["delta"], comparison["regression_detected"],
+        )
 
     # Success if at least one checkpoint produced a usable, task-appropriate metric.
     metric_keys = ("accuracy", "auroc", "mse", "mae", "c_index")

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -72,6 +72,7 @@ EVALUATE=false          # run the post-training evaluation step (#270)
 EVAL_SITE_ARG=""        # site whose data to evaluate on (default: first client site)
 EVAL_DATA_DIR_ARG=""    # host path to eval data on this (server) machine
 TASK="classification"   # STAMP task: classification | survival | regression (#271)
+COMPARE_LOCAL=false     # also train a local-only baseline and compare (#275)
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -80,6 +81,7 @@ while [[ $# -gt 0 ]]; do
         --models)        MODELS_ARG="$2"; shift ;;
         --task)          TASK="$2"; shift ;;
         --evaluate)      EVALUATE=true ;;
+        --compare-local) COMPARE_LOCAL=true ;;
         --eval-site)     EVAL_SITE_ARG="$2"; shift ;;
         --eval-data-dir) EVAL_DATA_DIR_ARG="$2"; shift ;;
         -h|--help)
@@ -96,6 +98,8 @@ while [[ $# -gt 0 ]]; do
             echo "                   create_synthetic_stamp_dataset.py <dir> --task survival (#271)."
             echo "  --evaluate       After training, collect global checkpoints and run"
             echo "                   stamp_predict.py to record task metrics (#270)."
+            echo "  --compare-local  With --evaluate: also train a local-only baseline on the"
+            echo "                   eval site and compare federated vs local (#275)."
             echo "  --eval-site      Site whose data (on this machine) to evaluate on"
             echo "                   (default: first client site; needs its data locally)"
             echo "  --eval-data-dir  Host dir mounted as /data for evaluation"
@@ -841,6 +845,41 @@ evaluate_model() {
     local envfile="$eval_output_dir/stamp_env.list"
     setup_stamp_env "$eval_site_name" "$model_name" | sed 's/^export //; s/"//g' > "$envfile"
 
+    # Local-only baseline (#275): train on the eval site's data and evaluate that
+    # checkpoint on the SAME split as the federated model. Best-effort — a failure
+    # here just omits the comparison, it never fails the deploy test.
+    local baseline_args=()
+    if [[ "$COMPARE_LOCAL" == true ]]; then
+        local baseline_ckpt="$EVAL_SCRATCH_DIR/local_baseline_${model_name}.ckpt"
+        rm -f "$baseline_ckpt"
+        info "  Training local-only baseline for $model_name on $eval_site_name data" >&2
+        docker run --rm \
+            ${EVAL_GPU:+--gpus="$EVAL_GPU"} \
+            --net=host --ipc=host \
+            -v "$eval_data_dir:/data/:ro" \
+            -v "$EVAL_SCRATCH_DIR:/scratch/" \
+            --env-file "$envfile" \
+            --env SITE_NAME="$eval_site_name" \
+            --env SCRATCH_DIR=/scratch \
+            --env TRAINING_MODE=local_training \
+            --env MEDISWARM_VERSION="$VERSION" \
+            -w /MediSwarm/application/jobs/STAMP_classification/app/custom \
+            "$DOCKER_IMAGE" \
+            python3 main.py \
+            > "$eval_output_dir/local_training_stdout.log" 2>&1 \
+            || warn "  Local baseline training failed (see local_training_stdout.log) — comparison omitted" >&2
+        # Local training writes best_model.ckpt under /scratch/runs/<site>/STAMP_*/.
+        local produced
+        produced=$(find "$EVAL_SCRATCH_DIR/runs/$eval_site_name" -name best_model.ckpt 2>/dev/null | sort | tail -1)
+        if [[ -n "$produced" && -f "$produced" ]]; then
+            cp "$produced" "$baseline_ckpt"
+            baseline_args=(--baseline "/scratch/local_baseline_${model_name}.ckpt")
+            ok "  Local baseline checkpoint ready for comparison" >&2
+        else
+            warn "  No local baseline checkpoint produced — comparison omitted" >&2
+        fi
+    fi
+
     info "  Running stamp_predict.py in $DOCKER_IMAGE on $eval_site_name data (CPU unless EVAL_GPU set)" >&2
     local rc=0
     docker run --rm \
@@ -856,7 +895,7 @@ evaluate_model() {
         --env MEDISWARM_VERSION="$VERSION" \
         "$DOCKER_IMAGE" \
         python3 /MediSwarm/application/jobs/STAMP_classification/app/custom/stamp_predict.py \
-            --workspace /workspace --output-dir /output \
+            --workspace /workspace --output-dir /output "${baseline_args[@]}" \
         > "$eval_output_dir/stamp_predict_stdout.log" 2>&1 || rc=$?
 
     EVAL_RESULTS_FILE="$eval_output_dir/stamp_eval_results.json"

--- a/tests/unit_tests/test_stamp_predict.py
+++ b/tests/unit_tests/test_stamp_predict.py
@@ -209,3 +209,68 @@ def test_survival_cindex_no_comparable_pairs(sp):
     m = sp.compute_survival_metrics(times=[5, 5], events=[0, 0], risks=[1.0, 2.0])
     assert m["c_index"] is None
     assert m["num_comparable_pairs"] == 0
+
+
+# --------------------------------------------------------------------------- #
+#  compare_federated_vs_local (#275)
+# --------------------------------------------------------------------------- #
+
+def test_compare_classification_federated_better(sp):
+    fed = {"auroc": 0.90, "accuracy": 0.8}
+    local = {"auroc": 0.80, "accuracy": 0.7}
+    c = sp.compare_federated_vs_local(fed, local, "classification")
+    assert c["comparable"] is True
+    assert c["metric"] == "auroc"
+    assert c["delta"] == pytest.approx(0.10)
+    assert c["federated_at_least_as_good"] is True
+    assert c["regression_detected"] is False
+
+
+def test_compare_classification_regression_detected(sp):
+    fed = {"auroc": 0.70}
+    local = {"auroc": 0.85}
+    c = sp.compare_federated_vs_local(fed, local, "classification")
+    assert c["delta"] == pytest.approx(-0.15)
+    assert c["federated_at_least_as_good"] is False
+    assert c["regression_detected"] is True
+
+
+def test_compare_regression_lower_is_better(sp):
+    # mse: lower is better, so a lower federated mse => positive delta (better)
+    fed = {"mse": 0.20}
+    local = {"mse": 0.50}
+    c = sp.compare_federated_vs_local(fed, local, "regression")
+    assert c["metric"] == "mse"
+    assert c["higher_is_better"] is False
+    assert c["delta"] == pytest.approx(0.30)
+    assert c["regression_detected"] is False
+
+
+def test_compare_survival_cindex(sp):
+    c = sp.compare_federated_vs_local({"c_index": 0.75}, {"c_index": 0.60}, "survival")
+    assert c["metric"] == "c_index"
+    assert c["delta"] == pytest.approx(0.15)
+
+
+def test_compare_tolerance_absorbs_small_regression(sp):
+    fed = {"auroc": 0.78}
+    local = {"auroc": 0.80}
+    c = sp.compare_federated_vs_local(fed, local, "classification", tolerance=0.05)
+    # 0.02 drop is within tolerance -> not flagged
+    assert c["regression_detected"] is False
+    assert c["federated_at_least_as_good"] is True
+
+
+def test_compare_incomparable_when_metric_missing(sp):
+    c = sp.compare_federated_vs_local({"accuracy": 0.8}, {"auroc": 0.9}, "classification")
+    # federated has no auroc and local has no accuracy overlap on the top metric...
+    # auroc present only in local, accuracy present only in fed -> no shared metric
+    assert c["comparable"] is False
+
+
+def test_compare_falls_back_to_accuracy(sp):
+    # no auroc in either, but accuracy in both -> compares on accuracy
+    c = sp.compare_federated_vs_local({"accuracy": 0.9}, {"accuracy": 0.8}, "classification")
+    assert c["comparable"] is True
+    assert c["metric"] == "accuracy"
+    assert c["delta"] == pytest.approx(0.10)


### PR DESCRIPTION
Closes #275. **Stacked on #271 (PR #382) → #270 (PR #379)** — retargets down the stack as each merges.

## What
Validates the core swarm-learning value proposition — the federated model should be at least as good as any single site's local-only model.

- **`stamp_predict.py`**: `compare_federated_vs_local()` — task-aware, direction-aware (signed `delta` where **positive always means federated is better**, whether the metric is higher- or lower-better; `regression_detected` when federated is worse than local beyond a tolerance). New `--baseline <ckpt>` evaluates a local checkpoint on the **same held-out split** as the federated model and writes `baseline` + `federated_vs_local` into the results JSON. Apples-to-apples by construction (same `evaluate_checkpoint`, same dataloader).
- **`run_stamp_deploy_test.sh`**: `--compare-local` trains a local-only baseline on the eval site's data, locates its `best_model.ckpt`, and passes it as `--baseline`. **Best-effort** — any failure omits the comparison and never fails the deploy test.
- **Tests**: +7 comparison tests (higher/lower-is-better, regression detection, tolerance, metric fallback). **32 unit tests total.**

## Verification
Offline: `bash -n` ✓, `shellcheck` (0) ✓, `flake8` ✓, **32/32 unit tests** ✓.
**Deferred:** the live local-training + comparison run — validated in a deploy window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)