### PR TITLE
STAMP: survival & regression task support in the deploy test (#271)

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/stamp_predict.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_predict.py
@@ -149,6 +149,59 @@ def compute_classification_metrics(
     }
 
 
+def compute_regression_metrics(y_true: List[float], y_pred: List[float]) -> Dict[str, Any]:
+    """Compute MSE, MAE, and (with >=2 samples) R^2 for a regression task (#271)."""
+    import numpy as np
+    from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+    y_true_arr = np.asarray(y_true, dtype=float)
+    y_pred_arr = np.asarray(y_pred, dtype=float)
+    n = int(y_true_arr.shape[0])
+    return {
+        "mse": float(mean_squared_error(y_true_arr, y_pred_arr)) if n else None,
+        "mae": float(mean_absolute_error(y_true_arr, y_pred_arr)) if n else None,
+        "r2": float(r2_score(y_true_arr, y_pred_arr)) if n >= 2 else None,
+        "num_samples": n,
+    }
+
+
+def compute_survival_metrics(
+    times: List[float], events: List[int], risks: List[float]
+) -> Dict[str, Any]:
+    """Harrell's concordance index for survival (#271).
+
+    A higher predicted ``risk`` should correspond to a shorter observed
+    ``time``. A pair (i, j) is comparable when patient i had an event and
+    ``time[i] < time[j]``; concordant when ``risk[i] > risk[j]`` (ties = 0.5).
+    ``c_index`` is None when there are no comparable pairs.
+    """
+    import numpy as np
+
+    times_arr = np.asarray(times, dtype=float)
+    events_arr = np.asarray(events, dtype=int)
+    risks_arr = np.asarray(risks, dtype=float)
+    n = int(times_arr.shape[0])
+
+    concordant = 0.0
+    comparable = 0.0
+    for i in range(n):
+        if events_arr[i] != 1:
+            continue
+        for j in range(n):
+            if times_arr[i] < times_arr[j]:
+                comparable += 1.0
+                if risks_arr[i] > risks_arr[j]:
+                    concordant += 1.0
+                elif risks_arr[i] == risks_arr[j]:
+                    concordant += 0.5
+
+    return {
+        "c_index": float(concordant / comparable) if comparable > 0 else None,
+        "num_comparable_pairs": int(comparable),
+        "num_samples": n,
+    }
+
+
 # --------------------------------------------------------------------------- #
 #  STAMP-dependent runtime (torch + STAMP required)                           #
 # --------------------------------------------------------------------------- #
@@ -199,14 +252,15 @@ def _unpack_batch(batch):
 
 
 def run_inference(model, dataloader, device):
-    """Run the model over a dataloader, returning (y_true, y_prob) lists.
+    """Run the model over a dataloader; return (targets, outputs) as CPU tensors.
 
-    Mirrors ``STAMPPredictionCallback._write_predictions``: forward → softmax.
+    Task-agnostic collection (interpreted per task by evaluate_checkpoint):
+    forward pass mirrors ``STAMPPredictionCallback._write_predictions``.
     """
     import torch
 
-    y_true: List[int] = []
-    y_prob: List[List[float]] = []
+    targets_all: List[Any] = []
+    outputs_all: List[Any] = []
     with torch.no_grad():
         for batch in dataloader:
             bags, targets = _unpack_batch(batch)
@@ -214,23 +268,43 @@ def run_inference(model, dataloader, device):
                 continue
             bags = bags.to(device)
             try:
-                logits = model(bags)
+                out = model(bags)
             except Exception:  # noqa: BLE001 — some STAMP models use kwargs
-                logits = model(features=bags)
-            probs = torch.softmax(logits, dim=-1).cpu()
-            targets_cpu = targets.cpu()
-            for i in range(probs.shape[0]):
-                gt = targets_cpu[i]
-                if gt.dim() != 0:
-                    # survival/regression targets are not a scalar class index
-                    continue
-                y_true.append(int(gt.item()))
-                y_prob.append([float(x) for x in probs[i].tolist()])
-    return y_true, y_prob
+                out = model(features=bags)
+            out = out.detach().cpu()
+            tgt = targets.detach().cpu() if hasattr(targets, "detach") else targets
+            for i in range(out.shape[0]):
+                outputs_all.append(out[i])
+                targets_all.append(tgt[i])
+    return targets_all, outputs_all
+
+
+def _to_scalar(x) -> float:
+    """Squeeze a tensor/number to a single float (first element if a vector)."""
+    if hasattr(x, "numel"):
+        return float(x.item() if x.numel() == 1 else x.reshape(-1)[0].item())
+    if isinstance(x, (list, tuple)):
+        return float(x[0])
+    return float(x)
+
+
+def _survival_target(t):
+    """Extract (time, event) from a survival target; None if the shape is unrecognized."""
+    try:
+        if hasattr(t, "numel") and t.numel() >= 2:
+            flat = t.reshape(-1)
+            return float(flat[0].item()), int(round(float(flat[1].item())))
+        if isinstance(t, (list, tuple)) and len(t) >= 2:
+            return float(t[0]), int(round(float(t[1])))
+    except Exception:  # noqa: BLE001
+        return None
+    return None
 
 
 def evaluate_checkpoint(checkpoint: Dict[str, str], dataloader, env: Dict[str, Any], device) -> Dict[str, Any]:
-    """Evaluate one checkpoint on the eval dataloader; return a result record."""
+    """Evaluate one checkpoint on the eval dataloader; dispatch metrics by task."""
+    import torch
+
     task = env.get("task", "classification")
     record: Dict[str, Any] = {
         "site": checkpoint["site"],
@@ -239,16 +313,42 @@ def evaluate_checkpoint(checkpoint: Dict[str, str], dataloader, env: Dict[str, A
         "task": task,
     }
     model = build_and_load_model(checkpoint["path"], device)
-    y_true, y_prob = run_inference(model, dataloader, device)
-    record["num_samples"] = len(y_true)
+    targets, outputs = run_inference(model, dataloader, device)
+    record["num_samples"] = len(targets)
+    if not targets:
+        record["error"] = "no_eval_samples"
+        return record
 
     if task == "classification":
+        y_true: List[int] = []
+        y_prob: List[List[float]] = []
+        for tgt, out in zip(targets, outputs):
+            if getattr(tgt, "dim", lambda: 1)() != 0:
+                continue  # survival/regression target, not a scalar class index
+            y_true.append(int(tgt.item()))
+            y_prob.append([float(x) for x in torch.softmax(out, dim=-1).tolist()])
         if not y_true:
             record["error"] = "no_scalar_class_targets"
             return record
         record.update(compute_classification_metrics(y_true, y_prob))
+    elif task == "regression":
+        y_true_r = [_to_scalar(t) for t in targets]
+        y_pred_r = [_to_scalar(o) for o in outputs]
+        record.update(compute_regression_metrics(y_true_r, y_pred_r))
+    elif task == "survival":
+        times: List[float] = []
+        events: List[int] = []
+        risks: List[float] = []
+        for tgt, out in zip(targets, outputs):
+            te = _survival_target(tgt)
+            if te is None:
+                record["error"] = "survival_target_shape_unrecognized"
+                return record
+            times.append(te[0])
+            events.append(te[1])
+            risks.append(_to_scalar(out))
+        record.update(compute_survival_metrics(times, events, risks))
     else:
-        # #271 will add survival (c-index) / regression metrics.
         record["note"] = f"metric_not_implemented_for_task:{task}"
     return record
 
@@ -315,16 +415,19 @@ def main() -> int:
     out_path.write_text(json.dumps(payload, indent=2))
     logger.info("Wrote results to %s", out_path)
 
-    # Success if at least one checkpoint produced a usable metric.
-    scored = [r for r in results if r.get("auroc") is not None or r.get("accuracy") is not None]
+    # Success if at least one checkpoint produced a usable, task-appropriate metric.
+    metric_keys = ("accuracy", "auroc", "mse", "mae", "c_index")
+
+    def _scored(r: Dict[str, Any]) -> bool:
+        return any(r.get(k) is not None for k in metric_keys)
+
+    scored = [r for r in results if _scored(r)]
     if not scored:
         logger.error("No checkpoint produced a usable metric")
         return 1
     for r in scored:
-        logger.info(
-            "  %s/%s: accuracy=%s auroc=%s (n=%s)",
-            r["site"], r["checkpoint"], r.get("accuracy"), r.get("auroc"), r.get("num_samples"),
-        )
+        summary = {k: r.get(k) for k in metric_keys if r.get(k) is not None}
+        logger.info("  %s/%s: %s (n=%s)", r["site"], r["checkpoint"], summary, r.get("num_samples"))
     return 0
 
 

--- a/application/jobs/STAMP_classification/app/scripts/create_synthetic_dataset/create_synthetic_stamp_dataset.py
+++ b/application/jobs/STAMP_classification/app/scripts/create_synthetic_dataset/create_synthetic_stamp_dataset.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
 """Create synthetic STAMP-compatible datasets for integration testing.
 
-Generates 2 sites x 15 patients (5 per class for 3 classes) with:
+Generates 2 sites x 15 patients (5 per latent class for 3 classes) with:
 - H5 feature files matching STAMP 2.4.0's expected format
   (tile-level: 'feats' shape (N_tiles, dim_input), 'coords' shape (N_tiles, 2))
-- Clinical CSV tables with PATIENT and ground truth columns
+- Clinical CSV tables whose ground-truth column(s) depend on the task (#271):
+    classification -> a single categorical `Diagnosis` column
+    survival       -> continuous `Time` + binary `Event` columns
+    regression     -> a single continuous `Target` column
 
-Each class has a distinct feature distribution (mean shift) so models
-can learn during short integration test runs.
+Every task derives its label(s) from the same latent class that shifts the
+features, so a model can still learn during short integration-test runs.
 
 Usage:
-    python create_synthetic_stamp_dataset.py <output_folder>
+    python create_synthetic_stamp_dataset.py <output_folder>              # classification
+    python create_synthetic_stamp_dataset.py <output_folder> --task survival
+    python create_synthetic_stamp_dataset.py <output_folder> --task regression
 
-Output structure:
+Output structure (unchanged across tasks; only clini_table.csv columns differ):
     <output_folder>/
         client_A/
             features/
                 P_000.h5 ... P_014.h5
             clini_table.csv
         client_B/
-            features/
-                P_000.h5 ... P_014.h5
-            clini_table.csv
+            ...
 """
 
+import argparse
 import csv
 import os
 import pathlib
 import shutil
-import sys
 
 import h5py
 import numpy as np
@@ -45,7 +48,11 @@ DIM_INPUT = 1024  # Standard STAMP feature dimension (e.g., UNI, CTransPath)
 TILE_COUNT_RANGE = (20, 60)  # Random number of tiles per patient
 COORD_RANGE = (0, 50000)  # Micron coordinate range (realistic WSI coords)
 PATIENT_LABEL = "PATIENT"
-GROUND_TRUTH_LABEL = "Diagnosis"
+GROUND_TRUTH_LABEL = "Diagnosis"        # classification
+TIME_LABEL = "Time"                     # survival
+EVENT_LABEL = "Event"                   # survival (1 = event observed, 0 = censored)
+REGRESSION_LABEL = "Target"             # regression
+TASKS = ("classification", "survival", "regression")
 
 # Class-specific mean shifts in feature space so a model can learn
 # Each class gets a distinct offset added to random normal features
@@ -104,23 +111,70 @@ def create_h5_feature_file(
 # ---------------------------------------------------------------------------
 
 
+def _class_index(class_label: str) -> int:
+    """Map 'class_0'/'class_1'/'class_2' -> 0/1/2."""
+    return CLASSES.index(class_label)
+
+
+def build_label_columns(
+    task: str,
+    patient_ids: list,
+    class_labels: list,
+    rng: np.random.RandomState,
+) -> tuple:
+    """Return (fieldnames, rows) for the task's clinical table.
+
+    Labels are derived from the latent class so they correlate with the
+    class-shifted features and remain learnable:
+      - classification: Diagnosis = the categorical class
+      - survival: Time increases with class index; Event ~ 70% observed
+      - regression: Target increases linearly with class index
+    """
+    if task == "classification":
+        fieldnames = [PATIENT_LABEL, GROUND_TRUTH_LABEL]
+        rows = [
+            {PATIENT_LABEL: pid, GROUND_TRUTH_LABEL: lbl}
+            for pid, lbl in zip(patient_ids, class_labels)
+        ]
+    elif task == "survival":
+        fieldnames = [PATIENT_LABEL, TIME_LABEL, EVENT_LABEL]
+        rows = []
+        for pid, lbl in zip(patient_ids, class_labels):
+            idx = _class_index(lbl)
+            time = round(float(10.0 + 15.0 * idx + rng.normal(0.0, 2.0)), 3)
+            time = max(time, 0.1)
+            event = int(rng.random() < 0.7)  # ~30% censored
+            rows.append({PATIENT_LABEL: pid, TIME_LABEL: time, EVENT_LABEL: event})
+    elif task == "regression":
+        fieldnames = [PATIENT_LABEL, REGRESSION_LABEL]
+        rows = []
+        for pid, lbl in zip(patient_ids, class_labels):
+            idx = _class_index(lbl)
+            target = round(float(2.0 * idx + rng.normal(0.0, 0.3)), 4)
+            rows.append({PATIENT_LABEL: pid, REGRESSION_LABEL: target})
+    else:
+        raise ValueError(f"Unknown task: {task} (expected one of {TASKS})")
+    return fieldnames, rows
+
+
 def create_clini_table(
     filepath: pathlib.Path,
     patient_ids: list,
     class_labels: list,
+    task: str = "classification",
+    rng: np.random.RandomState = None,
 ) -> None:
-    """Create a STAMP-compatible clinical CSV table.
+    """Create a STAMP-compatible clinical CSV table for the given task.
 
-    Columns: PATIENT, Diagnosis
     This is the minimal table needed by STAMP's load_patient_level_data().
     """
+    if rng is None:
+        rng = np.random.RandomState(SEED)
+    fieldnames, rows = build_label_columns(task, patient_ids, class_labels, rng)
     with open(filepath, "w", newline="") as f:
-        writer = csv.DictWriter(
-            f, fieldnames=[PATIENT_LABEL, GROUND_TRUTH_LABEL]
-        )
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
-        for pid, label in zip(patient_ids, class_labels):
-            writer.writerow({PATIENT_LABEL: pid, GROUND_TRUTH_LABEL: label})
+        writer.writerows(rows)
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +194,7 @@ def generate_site_data(
     output_folder: pathlib.Path,
     site: str,
     rng: np.random.RandomState,
+    task: str = "classification",
 ) -> None:
     """Generate all data for a single site."""
     site_dir = output_folder / site
@@ -155,22 +210,26 @@ def generate_site_data(
         patient_ids.append(patient_id)
         class_labels.append(class_label)
 
-        # Create H5 feature file
+        # Create H5 feature file (class-shifted so any task is learnable)
         h5_path = feature_dir / f"{patient_id}.h5"
         create_h5_feature_file(h5_path, rng, class_label)
 
-    # Create clinical table
+    # Create clinical table (columns depend on the task)
     clini_path = site_dir / "clini_table.csv"
-    create_clini_table(clini_path, patient_ids, class_labels)
+    create_clini_table(clini_path, patient_ids, class_labels, task=task, rng=rng)
 
-    print(f"  {site}: {len(patient_ids)} patients, {len(CLASSES)} classes")
+    print(f"  {site}: {len(patient_ids)} patients, task={task}")
     print(f"    Features: {feature_dir}")
     print(f"    Clinical table: {clini_path}")
 
 
-def main(output_folder: pathlib.Path) -> None:
-    """Generate complete synthetic STAMP dataset."""
+def main(output_folder: pathlib.Path, task: str = "classification") -> None:
+    """Generate complete synthetic STAMP dataset for the given task."""
+    if task not in TASKS:
+        raise ValueError(f"Unknown task: {task} (expected one of {TASKS})")
+
     print(f"Creating synthetic STAMP dataset in: {output_folder}")
+    print(f"  Task: {task}")
     print(f"  Sites: {SITES}")
     print(f"  Patients per site: {NUM_PATIENTS_PER_SITE}")
     print(f"  Classes: {CLASSES}")
@@ -182,18 +241,31 @@ def main(output_folder: pathlib.Path) -> None:
     create_folder_structure(output_folder)
 
     for site in SITES:
-        generate_site_data(output_folder, site, rng)
+        generate_site_data(output_folder, site, rng, task=task)
 
     print()
     print("Synthetic STAMP dataset created successfully.")
     print(f"Patient label: {PATIENT_LABEL}")
-    print(f"Ground truth label: {GROUND_TRUTH_LABEL}")
+    if task == "classification":
+        print(f"Ground truth label: {GROUND_TRUTH_LABEL}")
+    elif task == "survival":
+        print(f"Survival labels: {TIME_LABEL} (time), {EVENT_LABEL} (event)")
+    elif task == "regression":
+        print(f"Regression label: {REGRESSION_LABEL}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create a synthetic STAMP dataset.")
+    parser.add_argument("output_folder", type=pathlib.Path, help="Output directory.")
+    parser.add_argument(
+        "--task",
+        choices=TASKS,
+        default="classification",
+        help="Task type governing the clinical-table label column(s) (default: classification).",
+    )
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <output_folder>")
-        sys.exit(1)
-
-    output_folder = pathlib.Path(sys.argv[1])
-    main(output_folder)
+    args = _parse_args()
+    main(args.output_folder, task=args.task)

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -71,25 +71,31 @@ TEST_MODELS=()
 EVALUATE=false          # run the post-training evaluation step (#270)
 EVAL_SITE_ARG=""        # site whose data to evaluate on (default: first client site)
 EVAL_DATA_DIR_ARG=""    # host path to eval data on this (server) machine
+TASK="classification"   # STAMP task: classification | survival | regression (#271)
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --conf)          CONF_FILE="$2"; shift ;;
         --timeout)       TIMEOUT_MINUTES="$2"; shift ;;
         --models)        MODELS_ARG="$2"; shift ;;
+        --task)          TASK="$2"; shift ;;
         --evaluate)      EVALUATE=true ;;
         --eval-site)     EVAL_SITE_ARG="$2"; shift ;;
         --eval-data-dir) EVAL_DATA_DIR_ARG="$2"; shift ;;
         -h|--help)
             echo "Usage: $0 --conf CONF_FILE [--timeout MINUTES] [--models MODEL1,MODEL2,...]"
+            echo "          [--task classification|survival|regression]"
             echo "          [--evaluate [--eval-site SITE] [--eval-data-dir DIR]]"
             echo ""
             echo "  --conf           Path to site configuration file (required)"
             echo "  --timeout        Per-model training timeout in minutes (default: 120)"
             echo "  --models         Comma-separated STAMP models to test"
             echo "                   (default: vit,mlp,trans_mil,linear,barspoon)"
+            echo "  --task           STAMP task type (default: classification). The site"
+            echo "                   data must be generated for this task, e.g."
+            echo "                   create_synthetic_stamp_dataset.py <dir> --task survival (#271)."
             echo "  --evaluate       After training, collect global checkpoints and run"
-            echo "                   stamp_predict.py to record AUROC/accuracy (#270)."
+            echo "                   stamp_predict.py to record task metrics (#270)."
             echo "  --eval-site      Site whose data (on this machine) to evaluate on"
             echo "                   (default: first client site; needs its data locally)"
             echo "  --eval-data-dir  Host dir mounted as /data for evaluation"
@@ -162,6 +168,12 @@ resolve_test_models() {
 
 resolve_test_models
 
+# ── Validate task (#271) ───────────────────────────────────────────────────
+case "$TASK" in
+    classification|survival|regression) ;;
+    *) err "Invalid --task: $TASK (expected classification|survival|regression)"; exit 1 ;;
+esac
+
 # ── Load configuration ─────────────────────────────────────────────────────
 # shellcheck source=/dev/null
 source "$CONF_FILE"
@@ -206,12 +218,10 @@ setup_stamp_env() {
     cat <<EOF
 export STAMP_CLINI_TABLE="/data/${site_name}/clini_table.csv"
 export STAMP_FEATURE_DIR="/data/${site_name}/features"
-export STAMP_GROUND_TRUTH_LABEL="Diagnosis"
 export STAMP_PATIENT_LABEL="PATIENT"
-export STAMP_TASK="classification"
+export STAMP_TASK="${TASK}"
 export STAMP_MODEL_NAME="${model_name}"
 export STAMP_DIM_INPUT="1024"
-export STAMP_NUM_CLASSES="3"
 export STAMP_BAG_SIZE="64"
 export STAMP_BATCH_SIZE="8"
 export STAMP_MAX_EPOCHS="2"
@@ -223,6 +233,22 @@ export STAMP_EPOCHS_PER_ROUND="2"
 export STAMP_EPOCHS_REFERENCE_DATASET_SIZE="15"
 export STAMP_EPOCHS_MAX_CAP="4"
 EOF
+    # Task-specific label columns — must match create_synthetic_stamp_dataset.py (#271).
+    case "$TASK" in
+        classification)
+            echo 'export STAMP_GROUND_TRUTH_LABEL="Diagnosis"'
+            echo 'export STAMP_NUM_CLASSES="3"'
+            ;;
+        survival)
+            echo 'export STAMP_TIME_LABEL="Time"'
+            echo 'export STAMP_STATUS_LABEL="Event"'
+            echo 'export STAMP_NUM_CLASSES="1"'
+            ;;
+        regression)
+            echo 'export STAMP_GROUND_TRUTH_LABEL="Target"'
+            echo 'export STAMP_NUM_CLASSES="1"'
+            ;;
+    esac
 }
 
 # ── Helper functions ──────────────────────────────────────────────────────

--- a/tests/unit_tests/test_create_synthetic_stamp_dataset.py
+++ b/tests/unit_tests/test_create_synthetic_stamp_dataset.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for the STAMP synthetic-data generator's task support (#271).
+
+Only the pure label-column logic (build_label_columns) is tested here — it
+needs numpy but not the H5 writing path. The generator module imports h5py at
+module load, so the whole test file is skipped when h5py is unavailable.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("h5py")  # generator imports h5py at module level
+np = pytest.importorskip("numpy")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GEN_DIR = (
+    REPO_ROOT
+    / "application" / "jobs" / "STAMP_classification" / "app" / "scripts" / "create_synthetic_dataset"
+)
+
+
+@pytest.fixture(scope="module")
+def gen():
+    p = str(GEN_DIR)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+    sys.modules.pop("create_synthetic_stamp_dataset", None)
+    import create_synthetic_stamp_dataset as g  # noqa: E402
+    return g
+
+
+def _labels(gen, task):
+    pids = ["P_000", "P_001", "P_002"]
+    classes = ["class_0", "class_1", "class_2"]
+    rng = np.random.RandomState(0)
+    return gen.build_label_columns(task, pids, classes, rng)
+
+
+def test_classification_columns(gen):
+    fields, rows = _labels(gen, "classification")
+    assert fields == ["PATIENT", "Diagnosis"]
+    assert [r["Diagnosis"] for r in rows] == ["class_0", "class_1", "class_2"]
+
+
+def test_survival_columns(gen):
+    fields, rows = _labels(gen, "survival")
+    assert fields == ["PATIENT", "Time", "Event"]
+    # time increases with class index; all positive
+    times = [r["Time"] for r in rows]
+    assert all(t > 0 for t in times)
+    assert times[0] < times[2]
+    assert all(r["Event"] in (0, 1) for r in rows)
+
+
+def test_regression_columns(gen):
+    fields, rows = _labels(gen, "regression")
+    assert fields == ["PATIENT", "Target"]
+    targets = [r["Target"] for r in rows]
+    assert all(isinstance(t, float) for t in targets)
+    assert targets[0] < targets[2]  # increases with class index
+
+
+def test_unknown_task_raises(gen):
+    with pytest.raises(ValueError):
+        _labels(gen, "clustering")
+
+
+def test_main_rejects_unknown_task(gen, tmp_path):
+    with pytest.raises(ValueError):
+        gen.main(tmp_path, task="nonsense")

--- a/tests/unit_tests/test_stamp_predict.py
+++ b/tests/unit_tests/test_stamp_predict.py
@@ -152,3 +152,60 @@ def test_compute_metrics_rejects_1d_prob(sp):
     pytest.importorskip("sklearn")
     with pytest.raises(ValueError):
         sp.compute_classification_metrics([0, 1], [0.2, 0.8])
+
+
+# --------------------------------------------------------------------------- #
+#  compute_regression_metrics (#271)
+# --------------------------------------------------------------------------- #
+
+def test_compute_regression_perfect(sp):
+    pytest.importorskip("sklearn")
+    y = [1.0, 2.0, 3.0, 4.0]
+    m = sp.compute_regression_metrics(y, y)
+    assert m["mse"] == 0.0
+    assert m["mae"] == 0.0
+    assert m["r2"] == 1.0
+    assert m["num_samples"] == 4
+
+
+def test_compute_regression_with_error(sp):
+    pytest.importorskip("sklearn")
+    m = sp.compute_regression_metrics([1.0, 2.0, 3.0], [1.5, 2.5, 2.0])
+    assert m["mse"] > 0
+    assert m["mae"] > 0
+    assert m["r2"] is not None
+
+
+# --------------------------------------------------------------------------- #
+#  compute_survival_metrics — Harrell c-index (#271, pure numpy)
+# --------------------------------------------------------------------------- #
+
+def test_survival_cindex_perfect(sp):
+    # higher risk -> shorter time == perfectly concordant
+    m = sp.compute_survival_metrics(times=[1, 2, 3], events=[1, 1, 1], risks=[3.0, 2.0, 1.0])
+    assert m["c_index"] == 1.0
+    assert m["num_comparable_pairs"] == 3
+
+
+def test_survival_cindex_worst(sp):
+    m = sp.compute_survival_metrics(times=[1, 2, 3], events=[1, 1, 1], risks=[1.0, 2.0, 3.0])
+    assert m["c_index"] == 0.0
+
+
+def test_survival_cindex_ties_half(sp):
+    m = sp.compute_survival_metrics(times=[1, 2], events=[1, 1], risks=[5.0, 5.0])
+    assert m["c_index"] == 0.5  # one comparable pair, tie counts 0.5
+
+
+def test_survival_cindex_censoring_excludes_pairs(sp):
+    # patient 0 censored (event=0) -> not comparable as the earlier-time case
+    m = sp.compute_survival_metrics(times=[1, 2, 3], events=[0, 1, 1], risks=[9.0, 2.0, 1.0])
+    # only i=1 (t=2, event) vs j=2 (t=3) is comparable
+    assert m["num_comparable_pairs"] == 1
+    assert m["c_index"] == 1.0  # risk1=2 > risk2=1
+
+
+def test_survival_cindex_no_comparable_pairs(sp):
+    m = sp.compute_survival_metrics(times=[5, 5], events=[0, 0], risks=[1.0, 2.0])
+    assert m["c_index"] is None
+    assert m["num_comparable_pairs"] == 0


### PR DESCRIPTION
Closes #271. (Replaces #382, which GitHub auto-closed when the #270 base branch was deleted on merge — same commits, now retargeted to `main`.)

Extends the STAMP deploy test beyond classification to survival and regression:
- `create_synthetic_stamp_dataset.py`: `--task {classification,survival,regression}` (labels: Diagnosis / Time+Event / Target); classification path unchanged.
- `stamp_predict.py`: `compute_regression_metrics` (MSE/MAE/R²) + `compute_survival_metrics` (Harrell c-index); task-agnostic `run_inference` + per-task `evaluate_checkpoint`.
- `run_stamp_deploy_test.sh`: `--task` flag + task-aware `setup_stamp_env`.
- 25 unit tests. Offline-verified (bash -n, shellcheck 0, flake8). Live survival/regression inference deferred to a deploy window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)