### PR TITLE
refactor: extract shared deploy-test helpers into deploy_common.sh (#276)

### DIFF
--- a/scripts/deploy/deploy_common.sh
+++ b/scripts/deploy/deploy_common.sh
@@ -1,0 +1,91 @@
+# shellcheck shell=bash
+# ============================================================================
+# deploy_common.sh — shared helpers for the deploy-test orchestrators (#276)
+#
+# Sourced by run_deploy_test.sh (ODELIA) and run_stamp_deploy_test.sh (STAMP).
+# Contains only the byte-identical shared layer: colour/logging helpers and the
+# SSH / workspace-path helpers. Pipeline-specific and structurally-divergent
+# functions (deploy_kits, start_clients, stop_all, wait_for_completion, ...)
+# stay in the respective scripts; parameterising those is a follow-up.
+#
+# Contract — the sourcing script must define before use:
+#   SSH_OPTS       ssh/scp options            (used by remote_exec/remote_copy)
+#   WORKSPACE_DIR  build workspace dir         (used by find_latest_prod)
+#   DEPLOY_BASE    server/admin deploy dir     (used by resolve_server_startup_dir)
+#   SERVER_NAME    server participant name     (optional; defaults to dl3.tud.de)
+# and per-site variables <SITE>_HOST / _USER / _PASS (used by site_var lookups).
+# This file defines no `set` options and runs no code beyond definitions.
+# ============================================================================
+
+# ── Colors ─────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
+err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+step()  { echo -e "\n${BOLD}=== $* ===${NC}" >&2; }
+
+# ── Helper functions ──────────────────────────────────────────────────────
+
+site_var() {
+    local site=$1 var=$2
+    local full_var="${site}_${var}"
+    echo "${!full_var}"
+}
+
+remote_exec() {
+    local site=$1; shift
+    local host user pass
+    host=$(site_var "$site" HOST)
+    user=$(site_var "$site" USER)
+    pass=$(site_var "$site" PASS)
+
+    sshpass -p "$pass" ssh $SSH_OPTS "$user@$host" "$@"
+}
+
+remote_copy() {
+    local site=$1 src=$2 dst=$3
+    local host user pass
+    host=$(site_var "$site" HOST)
+    user=$(site_var "$site" USER)
+    pass=$(site_var "$site" PASS)
+
+    sshpass -p "$pass" scp $SSH_OPTS "$src" "$user@$host:$dst"
+}
+
+find_latest_prod() {
+    if [[ ! -d "$WORKSPACE_DIR" ]]; then
+        err "Workspace not found: $WORKSPACE_DIR"
+        err "Run buildDockerImageAndStartupKits.sh first."
+        exit 1
+    fi
+    ls -d "$WORKSPACE_DIR"/prod_* 2>/dev/null | sort -V | tail -n 1
+}
+
+# ── Resolve the actual server startup directory ─────────────────────────
+# start_server() may use either DEPLOY_BASE or prod_dir.  The wait functions
+# need the same path to find nohup.out.  Call this after start_server().
+_server_startup_dir=""
+
+resolve_server_startup_dir() {
+    local server_name="${SERVER_NAME:-dl3.tud.de}"
+    local candidate="$DEPLOY_BASE/$server_name/startup"
+    if [[ -d "$candidate" ]]; then
+        _server_startup_dir="$candidate"
+    else
+        local prod_dir
+        prod_dir=$(find_latest_prod)
+        candidate="$prod_dir/$server_name/startup"
+        if [[ -d "$candidate" ]]; then
+            _server_startup_dir="$candidate"
+        else
+            _server_startup_dir=""
+        fi
+    fi
+}

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -34,19 +34,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# ── Colors ─────────────────────────────────────────────────────────────────
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
-ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
-warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
-err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-step()  { echo -e "\n${BOLD}=== $* ===${NC}" >&2; }
+# Shared colour/logging + SSH/workspace helpers (#276).
+# shellcheck source=scripts/deploy/deploy_common.sh
+source "$SCRIPT_DIR/deploy_common.sh"
 
 # ── Parse arguments ────────────────────────────────────────────────────────
 RUN_ALL=false
@@ -153,64 +143,8 @@ EVAL_SITE_NAME="UKA_1"
 EVAL_DATA_DIR="/mnt/sda1/ODELIA_Challenge_unilateral"
 EVAL_SCRATCH_DIR="/mnt/scratch/deploy_test_eval"
 
-# ── Helper functions ──────────────────────────────────────────────────────
-
-site_var() {
-    local site=$1 var=$2
-    local full_var="${site}_${var}"
-    echo "${!full_var}"
-}
-
-remote_exec() {
-    local site=$1; shift
-    local host user pass
-    host=$(site_var "$site" HOST)
-    user=$(site_var "$site" USER)
-    pass=$(site_var "$site" PASS)
-
-    sshpass -p "$pass" ssh $SSH_OPTS "$user@$host" "$@"
-}
-
-remote_copy() {
-    local site=$1 src=$2 dst=$3
-    local host user pass
-    host=$(site_var "$site" HOST)
-    user=$(site_var "$site" USER)
-    pass=$(site_var "$site" PASS)
-
-    sshpass -p "$pass" scp $SSH_OPTS "$src" "$user@$host:$dst"
-}
-
-find_latest_prod() {
-    if [[ ! -d "$WORKSPACE_DIR" ]]; then
-        err "Workspace not found: $WORKSPACE_DIR"
-        err "Run buildDockerImageAndStartupKits.sh first."
-        exit 1
-    fi
-    ls -d "$WORKSPACE_DIR"/prod_* 2>/dev/null | sort -V | tail -n 1
-}
-
-# ── Resolve the actual server startup directory ─────────────────────────
-# start_server() may use either DEPLOY_BASE or prod_dir.  The wait functions
-# need the same path to find nohup.out.  Call this after start_server().
-_server_startup_dir=""
-
-resolve_server_startup_dir() {
-    local server_name="${SERVER_NAME:-dl3.tud.de}"
-    local candidate="$DEPLOY_BASE/$server_name/startup"
-    if [[ -d "$candidate" ]]; then
-        _server_startup_dir="$candidate"
-    else
-        local prod_dir
-        prod_dir=$(find_latest_prod)
-        candidate="$prod_dir/$server_name/startup"
-        if [[ -d "$candidate" ]]; then
-            _server_startup_dir="$candidate"
-        else
-            _server_startup_dir=""
-        fi
-    fi
-}
+# site_var / remote_exec / remote_copy / find_latest_prod /
+# resolve_server_startup_dir are provided by deploy_common.sh (#276).
 
 # ── Fix DNS: ensure remote clients can reach the NVFlare server ──────────
 # The NVFlare server name (dl3.tud.de) must resolve to Cosmos's Tailscale IP

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -48,19 +48,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# ── Colors ─────────────────────────────────────────────────────────────────
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
-ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
-warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
-err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-step()  { echo -e "\n${BOLD}=== $* ===${NC}" >&2; }
+# Shared colour/logging + SSH/workspace helpers (#276).
+# shellcheck source=scripts/deploy/deploy_common.sh
+source "$SCRIPT_DIR/deploy_common.sh"
 
 # ── Parse arguments ────────────────────────────────────────────────────────
 CONF_FILE=""
@@ -255,62 +245,8 @@ EOF
     esac
 }
 
-# ── Helper functions ──────────────────────────────────────────────────────
-
-site_var() {
-    local site=$1 var=$2
-    local full_var="${site}_${var}"
-    echo "${!full_var}"
-}
-
-remote_exec() {
-    local site=$1; shift
-    local host user pass
-    host=$(site_var "$site" HOST)
-    user=$(site_var "$site" USER)
-    pass=$(site_var "$site" PASS)
-
-    sshpass -p "$pass" ssh $SSH_OPTS "$user@$host" "$@"
-}
-
-remote_copy() {
-    local site=$1 src=$2 dst=$3
-    local host user pass
-    host=$(site_var "$site" HOST)
-    user=$(site_var "$site" USER)
-    pass=$(site_var "$site" PASS)
-
-    sshpass -p "$pass" scp $SSH_OPTS "$src" "$user@$host:$dst"
-}
-
-find_latest_prod() {
-    if [[ ! -d "$WORKSPACE_DIR" ]]; then
-        err "Workspace not found: $WORKSPACE_DIR"
-        err "Run buildDockerImageAndStartupKits.sh first."
-        exit 1
-    fi
-    ls -d "$WORKSPACE_DIR"/prod_* 2>/dev/null | sort -V | tail -n 1
-}
-
-# ── Resolve server startup directory ───────────────────────────────────
-_server_startup_dir=""
-
-resolve_server_startup_dir() {
-    local server_name="${SERVER_NAME:-dl3.tud.de}"
-    local candidate="$DEPLOY_BASE/$server_name/startup"
-    if [[ -d "$candidate" ]]; then
-        _server_startup_dir="$candidate"
-    else
-        local prod_dir
-        prod_dir=$(find_latest_prod)
-        candidate="$prod_dir/$server_name/startup"
-        if [[ -d "$candidate" ]]; then
-            _server_startup_dir="$candidate"
-        else
-            _server_startup_dir=""
-        fi
-    fi
-}
+# site_var / remote_exec / remote_copy / find_latest_prod /
+# resolve_server_startup_dir are provided by deploy_common.sh (#276).
 
 # ── Fix DNS: ensure remote clients can reach the NVFlare server ──────────
 fix_remote_dns() {


### PR DESCRIPTION
Closes #276 (first, safe increment).

## What
The ODELIA (`run_deploy_test.sh`, 1224 lines) and STAMP (`run_stamp_deploy_test.sh`, 835 lines) orchestrators duplicated a chunk of code verbatim. This extracts the **byte-identical bucket** into `scripts/deploy/deploy_common.sh` and sources it from both:

- colour vars + `info`/`ok`/`warn`/`err`/`step`
- `site_var`, `remote_exec`, `remote_copy`, `find_latest_prod`, `resolve_server_startup_dir`

**Behaviour-preserving by construction** — the code is moved, not rewritten (I diffed each function between the two scripts and only lifted the ones that were byte-identical). `deploy_common.sh` defines no `set` options and runs nothing but definitions; the sourcing scripts already set the vars it needs (`SSH_OPTS`, `WORKSPACE_DIR`, `DEPLOY_BASE`, `SERVER_NAME`, per-site vars).

## Deferred (follow-up)
The structurally-divergent functions stay pipeline-specific for now: `deploy_kits`, `start_server`, `start_clients`, `stop_all`, `wait_for_completion` (differs ~115 lines), `submit_job`, `fix_remote_dns`, `pre_pull_images`. Parameterising those behind hooks is worthwhile but needs a live re-run of **both** deploy tests to prove equivalence — best done in a deploy window.

## Verification
Offline: `bash -n` (all three) ✓; `shellcheck -x` — `deploy_common.sh` 0, `run_stamp_deploy_test.sh` 0, `run_deploy_test.sh` unchanged at its **2 pre-existing** `SKIP_BUILD` warnings (present on `main`) ✓; sourced helpers resolve correctly ✓.
**Deferred:** live deploy-test runs (start a server + use dl0/dl2) — to a deploy window, so the running production server is not disturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)