### PR TITLE
Deploy: --restart=unless-stopped for server/client containers

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -1010,7 +1010,7 @@ docker_cln_sh: |
 
   elif [ -n "$START_CLIENT" ]; then
       _start_live_sync swarm
-      docker run -d -t --restart=on-failure:5 \
+      docker run -d -t --restart=unless-stopped \
       --health-cmd="nvidia-smi > /dev/null 2>&1 || exit 1" \
       --health-interval=120s --health-start-period=180s --health-retries=3 \
       $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=swarm $DOCKER_IMAGE \
@@ -1090,7 +1090,7 @@ docker_svr_sh: |
   echo "Starting docker with $DOCKER_IMAGE as $CONTAINER_NAME"
   # Run docker with appropriate parameters
   if [ -n "$START_SERVER" ]; then
-      docker run -d -t --restart=on-failure:5 --name=$CONTAINER_NAME \
+      docker run -d -t --restart=unless-stopped --name=$CONTAINER_NAME \
       -v $DIR/..:/startupkit/ -w /startupkit/startup/ \
       --ipc=host $NETARG $DOCKER_IMAGE \
       /bin/bash -c "nohup ./start.sh >> nohup.out 2>&1 && chmod a+r nohup.out && /bin/bash"

--- a/docs/ROLLOUT_v1.5.0.md
+++ b/docs/ROLLOUT_v1.5.0.md
@@ -13,7 +13,7 @@ from here without re-deriving context.
 | All-site startup kits | ✅ built (see paths below) |
 | Run quorum `8 / 7 / 7` | ✅ set via `prepare_odelia_job.sh` flags at job-prep time (**no rebuild** — byoc) |
 | Partner email | ✅ drafted (below) — **not yet sent** |
-| Server node (dl3 = Cosmos) | ✅ **running** since 2026-07-02 12:11 — container `odelia_swarm_server_flserver_be9ef04` (`on-failure:5`; must be restarted manually after a host reboot: `cd <server kit>/startup && ./docker.sh --no_pull --start_server`) |
+| Server node (dl3 = Cosmos) | ✅ **running** since 2026-07-02 12:11 — container `odelia_swarm_server_flserver_be9ef04`. Kits built after #393 launch with `--restart=unless-stopped`, so the server (and clients) auto-restart after a host reboot. **Containers created before #393** are still `on-failure:5` and must either be recreated from a new kit or patched once in place: `docker update --restart unless-stopped <container>` (else restart manually after a reboot: `cd <server kit>/startup && ./docker.sh --no_pull --start_server`). |
 | Live-sync SSH keys for UKA / UMCU / VHIO | ⏳ UMCU: key already authorized, needs only the host-key refresh (§4); UKA / VHIO pending pubkeys |
 | Run | ⛔ scheduled tomorrow / this weekend |
 


### PR DESCRIPTION
Closes #393.

Changes `--restart=on-failure:5` -> `--restart=unless-stopped` for both the server (master_template.yml:1093) and client (:1013), so containers auto-restart after a host reboot — the root cause of the 2026-07-05 outage (on-failure does not survive a reboot). Updates the ROLLOUT runbook.

**Verification:** YAML parses. Takes effect on newly-built kits; existing containers need a one-time `docker update --restart unless-stopped`. A reboot smoke-test is deferred to the build/deploy window (Cosmos/dl occupied by STAMP eval).