### PR TITLE
CI: cache MEVIS image build + unit-test pip deps

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Build Docker image for real project (MEVIS)
         run: |
           chmod +x scripts/build/buildDockerImageAndStartupKits.sh
-          ./scripts/build/buildDockerImageAndStartupKits.sh -p application/provision/project_MEVIS_test.yml
+          ./scripts/build/buildDockerImageAndStartupKits.sh -p application/provision/project_MEVIS_test.yml --use-docker-cache
 
       - name: Show workspace path for MEVIS project
         run: |

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -7,6 +7,16 @@ on:
     branches:
       - main
       - dev
+    # Skip the 60-min single-GPU validation for pure-docs PRs — nothing under
+    # these paths affects training/build. A PR that also touches code/config
+    # still runs it. (validate-swarm is not a required check, so skipping here
+    # cannot block a merge.) True step parallelization is intentionally NOT done:
+    # the self-hosted runner has one shared GPU + a global serialization guard,
+    # so splitting GPU steps into parallel jobs only adds checkout/build overhead
+    # without speedup. The real wins are Docker/pip caching + skipping irrelevant PRs.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -32,6 +32,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Cache the pip download dir; key derived from this workflow file, whose
+          # inline `pip install` lines are the effective dependency manifest.
+          cache: 'pip'
+          cache-dependency-path: .github/workflows/unit-tests.yaml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Part of #396.

- pr-test.yaml: MEVIS build now passes `--use-docker-cache` (matches dummy/STAMP builds) instead of a full 5.2 GB rebuild.
- unit-tests.yaml: enable actions/setup-python pip caching.

GPU integration-step parallelization is left as a follow-up on the same issue. **Verification:** both workflows parse; CI-run timing comparison deferred to a runner.