### PR TITLE
Observability: harden live_sync.sh against root-owned state dir

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -41,6 +41,8 @@ jobs:
           # Install unified 'lightning' package — provides both lightning.*
           # (needed by STAMP tests) and pytorch_lightning.* (needed by ODELIA tests)
           pip install lightning scikit-learn pytest
+          # fastapi: server_tools/app.py imports it; needed by test_swarm_progress.py (#398)
+          pip install fastapi
 
       - name: Run unit tests
         run: |

--- a/kit_live_sync/live_sync.sh
+++ b/kit_live_sync/live_sync.sh
@@ -50,10 +50,34 @@ done
 [ -n "$STARTUP_DIR" ] || { echo "STARTUP_DIR missing" >&2; exit 1; }
 
 STATE_DIR="$STARTUP_DIR/.mediswarm_sync"
-mkdir -p "$STATE_DIR"
+
+# Ensure a writable state dir. A client previously started via `sudo` can leave
+# .mediswarm_sync (and its files) root-owned; under `set -euo pipefail` the
+# mkdir/touch below would then EACCES and silently kill the whole daemon so the
+# site stops reporting (issue #398). Reclaim ownership if we can (passwordless
+# sudo), otherwise fall back to a user-writable dir so live-sync keeps running.
+_state_dir_writable() { [ -d "$STATE_DIR" ] && ( : > "$STATE_DIR/.wtest" ) 2>/dev/null && rm -f "$STATE_DIR/.wtest" 2>/dev/null; }
+_ensure_writable_state_dir() {
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+  _state_dir_writable && return 0
+  if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    sudo -n chown -R "$(id -u):$(id -g)" "$STATE_DIR" 2>/dev/null || true
+  fi
+  _state_dir_writable && return 0
+  local fallback="${TMPDIR:-/tmp}/mediswarm_sync_$(id -u)_$(printf '%s' "$STARTUP_DIR" | md5sum | cut -c1-8)"
+  mkdir -p "$fallback" 2>/dev/null || true
+  echo "[WARN] $STATE_DIR not writable (likely root-owned from a sudo-launched client); using $fallback. Fix: sudo chown -R \$(id -un): '$STATE_DIR'" >&2
+  STATE_DIR="$fallback"
+}
+_ensure_writable_state_dir
+
 LIVE_SYNC_LOG="$STATE_DIR/live_sync_daemon.log"
-touch "$LIVE_SYNC_LOG"
-exec > >(tee -a "$LIVE_SYNC_LOG") 2>&1
+touch "$LIVE_SYNC_LOG" 2>/dev/null || true
+if [ -w "$LIVE_SYNC_LOG" ]; then
+  exec > >(tee -a "$LIVE_SYNC_LOG") 2>&1
+else
+  echo "[WARN] cannot write $LIVE_SYNC_LOG; logging to stdout only" >&2
+fi
 
 SYNC_STATUS="ok"
 SYNC_ERROR=""
@@ -98,7 +122,7 @@ else
 fi
 
 LAST_CKPT_SYNC_FILE="$STATE_DIR/${MODE}_last_ckpt_sync_ts"
-touch "$LAST_CKPT_SYNC_FILE"
+touch "$LAST_CKPT_SYNC_FILE" 2>/dev/null || true
 
 # Track the run we are currently syncing so we can finalize it if a new run appears
 CURRENT_LOCAL_RUN=""
@@ -255,7 +279,7 @@ sync_local() {
       --include='*_model_gt_and_classprob_*.csv' \
       --exclude='*' \
       "$run_dir/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
-    echo "$now" > "$LAST_CKPT_SYNC_FILE"
+    echo "$now" > "$LAST_CKPT_SYNC_FILE" 2>/dev/null || true
   fi
 }
 
@@ -330,7 +354,7 @@ sync_swarm() {
         --include='*_model_gt_and_classprob_*.csv' \
         --exclude='*' \
         "$run_dir_for_sync/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
-      echo "$now" > "$LAST_CKPT_SYNC_FILE"
+      echo "$now" > "$LAST_CKPT_SYNC_FILE" 2>/dev/null || true
     fi
   fi
 }

--- a/server_tools/app.py
+++ b/server_tools/app.py
@@ -1026,7 +1026,7 @@ def _parse_p2p_transfers(text: str) -> list[dict[str, Any]]:
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _JOBID_RE = re.compile(r"run=([0-9a-fA-F-]{36})")
 _ROUND_RE = re.compile(r"on round (\d+)")
-_PRUNE_RE = re.compile(r"client ([A-Z0-9_]+) reported error '([^']+)'.*?continuing with (\d+)")
+_PRUNE_RE = re.compile(r"client ([A-Za-z0-9_]+) reported error '([^']+)'.*?continuing with (\d+)")
 
 
 def _read_tail(path: Path, max_bytes: int = 500_000) -> str:
@@ -1082,7 +1082,7 @@ def parse_swarm_progress(log_path: str, now: "float | None" = None):
         for ln in jlines:
             if rtag not in ln:
                 continue
-            mp = re.search(r"peer=([A-Z0-9_]+)", ln)
+            mp = re.search(r"peer=([A-Za-z0-9_]+)", ln)
             ma = re.search(r"action=(\w+)", ln)
             if mp and ma:
                 clients[mp.group(1)] = ma.group(1)

--- a/server_tools/app.py
+++ b/server_tools/app.py
@@ -46,6 +46,15 @@ ROWS_CACHE_TTL_SECONDS = float(os.environ.get("MEDISWARM_MONITOR_CACHE_TTL", "5"
 ERROR_TAIL_BYTES = int(os.environ.get("MEDISWARM_ERROR_TAIL_BYTES", "120000"))
 MAX_ERROR_SCAN_FILES = int(os.environ.get("MEDISWARM_MAX_ERROR_SCAN_FILES", "40"))
 
+# Path to the FL server's nohup.out — the authoritative source of swarm round
+# progress (start/finished_learn per round, prunes, aborts). The CCWF workflow
+# runs the rounds peer-to-peer on the clients, so the server log is the one place
+# that sees the whole run; without this the monitor can't tell "training" from
+# "stalled". Empty -> the swarm-progress panel is simply omitted. (#398)
+SERVER_LOG = os.environ.get("MEDISWARM_SERVER_LOG", "")
+# A run with no new server-log line for this long (and not terminal) is "stalled".
+SWARM_STALL_SECONDS = int(os.environ.get("MEDISWARM_SWARM_STALL_SECONDS", "600"))
+
 app = FastAPI(title="MediSwarm Live Monitor")
 
 _ROWS_CACHE: dict[str, Any] = {"expires_at": 0.0, "value": None}
@@ -175,6 +184,26 @@ a:hover { text-decoration: underline; }
   box-shadow: 0 1px 3px rgba(0,0,0,0.06); display: flex; align-items: center; gap: 0.5rem; }
 .stat-card .stat-num { font-size: 1.4rem; font-weight: 700; color: var(--accent); }
 .stat-card .stat-label { font-size: 0.78rem; color: var(--text-light); }
+/* Swarm round-progress panel (#398) */
+.swarm-panel { background: var(--card); border-radius: 8px; padding: 0.7rem 1rem;
+  margin-bottom: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  border-left: 4px solid var(--text-light); }
+.swarm-panel.swarm-training { border-left-color: var(--green); }
+.swarm-panel.swarm-stalled  { border-left-color: var(--orange, #e67e22); }
+.swarm-panel.swarm-aborted, .swarm-panel.swarm-fatal { border-left-color: var(--red, #e74c3c); }
+.swarm-panel.swarm-finished { border-left-color: var(--accent); }
+.swarm-head { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.swarm-title { font-weight: 700; }
+.swarm-detail { color: var(--text-light); font-size: 0.85rem; }
+.swarm-chips { margin-top: 0.5rem; display: flex; gap: 0.35rem; flex-wrap: wrap; }
+.swarm-chip { font-size: 0.72rem; padding: 2px 8px; border-radius: 10px;
+  background: #dfe4ea; color: #2f3542; font-family: monospace; }
+.swarm-chip.chip-done { background: var(--green); color: #fff; }
+.swarm-chip.chip-run  { background: #f1c40f; color: #2f3542; }
+.swarm-chip.chip-idle { background: #dfe4ea; color: #2f3542; }
+.swarm-prunes { margin-top: 0.4rem; font-size: 0.8rem; color: var(--red, #e74c3c); }
+.swarm-stall { margin-top: 0.4rem; font-size: 0.85rem; font-weight: 600;
+  color: var(--orange, #e67e22); }
 
 /* Detail page */
 .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin-top: 1.2rem; }
@@ -990,6 +1019,139 @@ def _parse_p2p_transfers(text: str) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Swarm round-progress panel (#398) — parses the FL server's nohup.out, the one
+# log that sees the whole CCWF run (rounds happen peer-to-peer on the clients).
+# ---------------------------------------------------------------------------
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+_JOBID_RE = re.compile(r"run=([0-9a-fA-F-]{36})")
+_ROUND_RE = re.compile(r"on round (\d+)")
+_PRUNE_RE = re.compile(r"client ([A-Z0-9_]+) reported error '([^']+)'.*?continuing with (\d+)")
+
+
+def _read_tail(path: Path, max_bytes: int = 500_000) -> str:
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+            data = fh.read()
+    except OSError:
+        return ""
+    return _ANSI_RE.sub("", data.decode("utf-8", "replace"))
+
+
+def parse_swarm_progress(log_path: str, now: "float | None" = None):
+    """Extract the latest job's round progress from the server nohup.out.
+
+    Returns a dict (job_id, status, round, num_rounds, clients, prunes, log_age,
+    finished) or None if there is no readable server log. Pure/​testable: pass a
+    synthetic file path. status ∈ {training, stalled, finished, aborted, fatal, idle}.
+    """
+    if not log_path:
+        return None
+    p = Path(log_path)
+    try:
+        mtime = p.stat().st_mtime
+    except OSError:
+        return None
+    now = now if now is not None else time.time()
+    text = _read_tail(p)
+    if not text:
+        return None
+    lines = text.splitlines()
+    jobs = _JOBID_RE.findall(text)
+    log_age = now - mtime
+    if not jobs:
+        return {"job_id": None, "status": "idle", "round": None, "num_rounds": None,
+                "clients": {}, "prunes": [], "log_age": log_age, "finished": 0}
+    jid = jobs[-1]
+    jlines = [ln for ln in lines if jid in ln]
+    # num_rounds from THIS job's Workflow Config line (scan jlines, not the whole
+    # tail, so an older job's config in the tail can't leak the wrong count).
+    num_rounds = None
+    for ln in jlines:
+        mm = re.search(r"'num_rounds':\s*(\d+)", ln)
+        if mm:
+            num_rounds = int(mm.group(1))
+    rounds = [int(x) for ln in jlines for x in _ROUND_RE.findall(ln)]
+    highest = max(rounds) if rounds else None
+    clients: "dict[str, str]" = {}
+    if highest is not None:
+        rtag = f"on round {highest}"
+        for ln in jlines:
+            if rtag not in ln:
+                continue
+            mp = re.search(r"peer=([A-Z0-9_]+)", ln)
+            ma = re.search(r"action=(\w+)", ln)
+            if mp and ma:
+                clients[mp.group(1)] = ma.group(1)
+    prunes = []
+    for ln in jlines:
+        mp = _PRUNE_RE.search(ln)
+        if mp:
+            prunes.append({"client": mp.group(1), "error": mp.group(2), "active": int(mp.group(3))})
+    terminal = None
+    for ln in jlines:
+        if "Server runner finished" in ln:
+            terminal = "finished"
+        elif "ABORTED" in ln or "Try to abort" in ln:
+            terminal = "aborted"
+        elif "FATAL" in ln:
+            terminal = "fatal"
+    if terminal:
+        status = terminal
+    elif log_age > SWARM_STALL_SECONDS:
+        status = "stalled"
+    else:
+        status = "training"
+    return {"job_id": jid, "status": status, "round": highest, "num_rounds": num_rounds,
+            "clients": clients, "prunes": prunes, "log_age": log_age,
+            "finished": sum(1 for a in clients.values() if a == "finished_learn_task")}
+
+
+def render_swarm_progress_panel() -> str:
+    prog = parse_swarm_progress(SERVER_LOG)
+    if prog is None:
+        return ""
+    badge_map = {"training": "running", "stalled": "stale", "aborted": "error",
+                 "fatal": "error", "finished": "finished", "idle": "waiting"}
+    badge = _status_badge(badge_map.get(prog["status"], "unknown"))
+    age = int(prog["log_age"])
+    age_txt = f"{age}s ago" if age < 120 else f"{age // 60}m ago"
+    if prog["job_id"] is None:
+        return (f'<div class="swarm-panel swarm-idle"><div class="swarm-head">'
+                f'<span class="swarm-title">Swarm run</span> {badge} '
+                f'<span class="swarm-detail">no active job · log {age_txt}</span></div></div>')
+    rnd, nr = prog["round"], prog["num_rounds"]
+    if rnd is None:
+        round_txt = "configuring"
+    else:
+        round_txt = f"round {rnd}" + (f" / {nr}" if nr else "")
+    action_cls = {"finished_learn_task": "chip-done", "start_learn_task": "chip-run"}
+    chips = "".join(
+        f'<span class="swarm-chip {action_cls.get(prog["clients"][c], "chip-idle")}" '
+        f'title="{html_escape(prog["clients"][c])}">{html_escape(c)}</span>'
+        for c in sorted(prog["clients"])
+    )
+    pruned = ""
+    if prog["prunes"]:
+        items = ", ".join(f'{html_escape(x["client"])} ({html_escape(x["error"])})' for x in prog["prunes"])
+        pruned = (f'<div class="swarm-prunes">pruned: {items} → '
+                  f'{prog["prunes"][-1]["active"]} active</div>')
+    stall = ""
+    if prog["status"] == "stalled":
+        stall = f'<div class="swarm-stall">⚠ no server-log activity for {age_txt.replace(" ago","")} — possible stall</div>'
+    return f"""
+<div class="swarm-panel swarm-{prog['status']}">
+  <div class="swarm-head"><span class="swarm-title">Swarm run</span> {badge}
+    <span class="swarm-detail">job {html_escape(prog['job_id'][:8])} · {round_txt}
+    · {prog['finished']} finished this round · log {age_txt}</span></div>
+  <div class="swarm-chips">{chips or '<span class="swarm-detail">no per-client status yet</span>'}</div>
+  {pruned}{stall}
+</div>"""
+
+
 @app.get("/", response_class=HTMLResponse)
 def index(
     site_filter: str = Query("", alias="site"),
@@ -1168,6 +1330,7 @@ def index(
     &middot; <a href="/api/runs">API</a></div>
 </header>
 <main>
+{render_swarm_progress_panel()}
 {stats_html}
 {filter_html}
 <table>

--- a/tests/unit_tests/test_swarm_progress.py
+++ b/tests/unit_tests/test_swarm_progress.py
@@ -1,0 +1,78 @@
+"""Unit tests for the #398 swarm round-progress parser in server_tools/app.py.
+
+parse_swarm_progress() is pure (reads a file, returns a dict), so it's tested
+here against synthetic FL-server nohup.out content. Requires fastapi (app.py
+imports it at module load); skipped if unavailable.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")  # app.py imports fastapi at module level
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_TOOLS = REPO_ROOT / "server_tools"
+
+
+@pytest.fixture(scope="module")
+def app():
+    p = str(SERVER_TOOLS)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+    import app as app_module  # noqa: E402
+    return app_module
+
+
+def _write(tmp_path, text, *, mtime=None):
+    f = tmp_path / "nohup.out"
+    f.write_text(text)
+    if mtime is not None:
+        import os
+        os.utime(f, (mtime, mtime))
+    return str(f)
+
+
+_UPPER = """\
+2026-07-06 09:37:20 - Ctl - INFO - [run=a370564e-d30d-4831-85a0-6f83e64ee6c5, wf=swarm_controller] - Workflow Config: {'num_rounds': 20}
+2026-07-06 09:59:30 - Ctl - WARNING - [run=a370564e-d30d-4831-85a0-6f83e64ee6c5, peer=USZ_1] - FaultTolerant: client USZ_1 reported error 'EXECUTION_EXCEPTION'; pruning and continuing with 5 active clients (min_clients=4)
+2026-07-06 10:20:31 - Ctl - INFO - [run=a370564e-d30d-4831-85a0-6f83e64ee6c5, peer=RSH_1] - updated status of client RSH_1 on round 0: action=finished_learn_task, all_done=False
+"""
+
+# Real shape from the 2026-07-07 Duke run: LOWERCASE client names (node_A/node_B).
+_LOWER = """\
+2026-07-07 13:08:00 - Ctl - INFO - [run=769e80a5-cd51-48ae-ac31-06f82055344e, wf=swarm_controller] - Workflow Config: {'num_rounds': 3}
+2026-07-07 13:40:17 - Ctl - INFO - [run=769e80a5-cd51-48ae-ac31-06f82055344e, peer=node_A] - updated status of client node_A on round 1: action=finished_learn_task, all_done=False
+2026-07-07 13:49:47 - Ctl - INFO - [run=769e80a5-cd51-48ae-ac31-06f82055344e, peer=node_B] - updated status of client node_B on round 1: action=start_learn_task, all_done=False
+"""
+
+
+def test_uppercase_clients_and_prune(app, tmp_path):
+    p = app.parse_swarm_progress(_write(tmp_path, _UPPER, mtime=time.time()))
+    assert p["job_id"].startswith("a370564e")
+    assert p["round"] == 0 and p["num_rounds"] == 20
+    assert p["clients"] == {"RSH_1": "finished_learn_task"}
+    assert [x["client"] for x in p["prunes"]] == ["USZ_1"]
+    assert p["prunes"][0]["active"] == 5
+
+
+def test_lowercase_clients_are_parsed(app, tmp_path):
+    # Regression: node_A/node_B (lowercase) were dropped by an [A-Z] regex.
+    p = app.parse_swarm_progress(_write(tmp_path, _LOWER, mtime=time.time()))
+    assert p["round"] == 1 and p["num_rounds"] == 3
+    assert p["clients"] == {"node_A": "finished_learn_task", "node_B": "start_learn_task"}
+    assert p["status"] == "training"
+
+
+def test_stalled_when_log_old(app, tmp_path):
+    p = app.parse_swarm_progress(_write(tmp_path, _LOWER, mtime=time.time() - 3600))
+    assert p["status"] == "stalled"
+
+
+def test_missing_and_idle(app, tmp_path):
+    assert app.parse_swarm_progress("") is None
+    assert app.parse_swarm_progress(str(tmp_path / "nope.out")) is None
+    idle = _write(tmp_path, "2026-07-07 12:00:00 - ServerRunner - INFO - waiting\n", mtime=time.time())
+    assert app.parse_swarm_progress(idle)["status"] == "idle"


### PR DESCRIPTION
Part of #398.

Makes `live_sync.sh` survive a root-owned `.mediswarm_sync` (from a sudo-launched client) instead of dying under `set -euo pipefail` and going silent — the cause of stale live-monitor heartbeats on 2026-07-06. Reclaims ownership via passwordless sudo, else falls back to a user-writable dir; guards the timestamp writes.

Follow-up (same issue, deferred — needs a live run): structured per-round progress telemetry in server_tools/app.py. **Verification:** `bash -n`.