### PR TITLE
Fix 3 Duke-IID 2-client validation tooling bugs

### DIFF
--- a/deploy_sites_duke_iid_2client.local.conf.example
+++ b/deploy_sites_duke_iid_2client.local.conf.example
@@ -19,8 +19,15 @@ DL2_PASS_ENV=DL_SWARM_PASS
 # can use local Docker and the clients can reach dl3.tud.de over Tailscale.
 COSMOS_HOST=localhost
 COSMOS_USER=swarm
-COSMOS_DEPLOY_DIR=/home/swarm/deploy_test_duke_iid_2client
-SERVER_HOST_IP=100.64.4.103
+# Where the server/admin kits deploy locally on dl3. Leave unset to default to
+# $HOME/deploy_test_duke_iid_2client (works for whatever user runs the wrapper).
+# Only set this to override — and make sure the running user can write to it.
+#COSMOS_DEPLOY_DIR=/home/swarm/deploy_test_duke_iid_2client
+# The dl3 IP the CLIENTS use to reach the server on :8002. Leave unset to
+# auto-detect via `tailscale ip -4` (the Tailscale IP the dl nodes route to).
+# Only set it if auto-detection is wrong — and it MUST be an address the clients
+# can actually reach (the Tailscale IP, NOT a GoodAccess/other-subnet address).
+#SERVER_HOST_IP=100.100.101.100
 
 # dl0: node_A
 DL0_HOST=100.64.4.100

--- a/scripts/deploy/run_duke_iid_2client_validation.sh
+++ b/scripts/deploy/run_duke_iid_2client_validation.sh
@@ -174,7 +174,9 @@ PROJECT_NAME="$(grep '^name: ' "$PROJECT_FILE" \
     | sed 's/^name: //' \
     | sed "s#__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__#$VERSION#")"
 WORKSPACE_DIR="$REPO_ROOT/workspace/$PROJECT_NAME"
-DEPLOY_BASE="${COSMOS_DEPLOY_DIR:-/home/swarm/deploy_test_duke_iid_2client}"
+# Local (dl3) deploy dir for the server/admin kits. Default under $HOME so it works
+# for whichever user runs this (not just 'swarm'); override with COSMOS_DEPLOY_DIR.
+DEPLOY_BASE="${COSMOS_DEPLOY_DIR:-$HOME/deploy_test_duke_iid_2client}"
 SERVER_NAME="${SERVER_NAME:-dl3.tud.de}"
 ADMIN_USER="${ADMIN_USER:-jiefu.zhu@tu-dresden.de}"
 CLIENT_COUNT="${#CLIENT_SITES[@]}"
@@ -512,6 +514,19 @@ fix_remote_dns() {
 
 pre_pull_images() {
     step "Pull $DOCKER_IMAGE on clients"
+    # Clients pull from the registry, so the image must be there. With --skip-build
+    # (reusing a locally-built image) the push is skipped, which otherwise leaves the
+    # clients failing with "manifest unknown". If the tag isn't on the registry but
+    # exists locally, push it now so the pull below can succeed.
+    if ! docker manifest inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+        if docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+            warn "$DOCKER_IMAGE is not on the registry (e.g. --skip-push); pushing it so clients can pull"
+            docker push "$DOCKER_IMAGE" || { err "Failed to push $DOCKER_IMAGE — run 'docker login' or drop --skip-push"; return 1; }
+        else
+            err "$DOCKER_IMAGE is neither on the registry nor built locally; build it or drop --skip-build"
+            return 1
+        fi
+    fi
     local site gpu
     for site in "${CLIENT_SITES[@]}"; do
         gpu="$(site_var "$site" GPU)"


### PR DESCRIPTION
Found and fixed live while running `run_duke_iid_2client_validation.sh` on dl3 to diagnose the swarm on clean infra (the run then completed rounds successfully):

1. **SERVER_HOST_IP** — the example hardcoded `100.64.4.103` (a *different* machine), overriding the script's own `tailscale ip -4` auto-detect and leaving clients unable to reach the server on :8002. Commented out in the example so auto-detect runs.
2. **COSMOS_DEPLOY_DIR** — defaulted to `/home/swarm/...`, EACCES for any non-`swarm` operator. Now defaults to `$HOME/deploy_test_duke_iid_2client`.
3. **pre_pull_images** — with `--skip-build` the push is skipped, so clients hit `manifest unknown`. Now checks the registry manifest first and pushes (if built locally) or errors clearly.

Verified: `bash -n` clean; all three were reproduced and fixed during the 2026-07-07 clean-swarm diagnostic that proved the p2p-gather-stall is environmental, not a platform bug.