### PR TITLE
STAMP: forward STAMP_* env vars by name so column names with spaces work

### DIFF
--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -795,9 +795,13 @@ docker_cln_sh: |
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
   fi
 
-  # Forward all STAMP_* environment variables into the container
+  # Forward all STAMP_* environment variables into the container. Pass by NAME
+  # only (no =value): docker then inherits each value from this script's
+  # environment, which preserves values containing spaces (e.g. a clinical
+  # column named "Slide ID"). The "=value" form word-split on the unquoted
+  # $ENV_VARS expansion and broke the docker command for such values.
   for _var in $(env | grep '^STAMP_' | cut -d= -f1); do
-      ENV_VARS+=" --env ${_var}=${!_var}"
+      ENV_VARS+=" --env ${_var}"
   done
 
   # ── Live Sync Integration ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

A DECADE site (UKB Bonn) uses a clinical ID column named `Slide ID` (with a
space), i.e. `STAMP_PATIENT_LABEL="Slide ID"`. The generated `docker.sh` built
`ENV_VARS` as `--env NAME=value` and used it **unquoted** in `docker run`, so the
space word-split and docker failed with:

```
docker: invalid reference format: repository name (library/ID) must be lowercase
```

This hits any site whose clinical column names contain spaces.

## Fix

Forward `STAMP_*` variables by **name only** (`--env NAME`); docker then inherits
each value from `docker.sh`'s environment, preserving spaces.

## Verification

- Reproduced the failure on a real client with `STAMP_PATIENT_LABEL="Slide ID"`.
- Isolation test: old form → docker error; new form → value arrives as
  `'Slide ID'` inside the container.
- End-to-end: rebuilt `jefftud/decade` + kits and re-ran `--preflight_check`
  with a `Slide ID` column — loads and trains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)