### PR TITLE
351 ODELIA CI should use unproblematic datasets

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/scripts/create_synthetic_dataset/create_synthetic_dataset.py
+++ b/application/jobs/ODELIA_ternary_classification/app/scripts/create_synthetic_dataset/create_synthetic_dataset.py
@@ -12,9 +12,12 @@ from tqdm import tqdm
 
 np.random.seed(1)
 
+unproblematic_sites = ('client_A', 'client_B')
+problematic_sites = ('client_P',)
+sites = unproblematic_sites + problematic_sites  # this must match the swarm project definition
+
 size = (32, 256, 256)
 num_images_per_site = 15
-sites = ('client_A', 'client_B')  # this must match the swarm project definition
 metadata_folder = 'metadata_unilateral'
 data_folder = 'data_unilateral'
 other_unused_folders = ('data_raw', 'data')
@@ -116,13 +119,13 @@ if __name__ == '__main__':
                 os.mkdir(side_folder)
                 image = get_image(i, j, lesion_class)
                 sitk.WriteImage(image, side_folder / 'Sub_1.nii.gz')
-                if (site == 'client_A') or (j < num_images_per_site - 1):  # one image per side without table entry for client_B
+                if ((site not in problematic_sites) or (j < num_images_per_site - 1)):  # one image per side without table entry for problematic sites
                     for f in range(num_folds):
                         table_data.append(
                             {'UID': uid, 'PatientID': patientid, 'Lesion': lesion_class, 'Age': some_age + i + j, 'Fold': f,
                              'Split': get_split(j, f)})
 
-        if site == 'client_B':
+        if site in problematic_sites:
             for patientid in ('SomeUID_both', 'ID_016_right', 'ID_016_left', 'ID_998_right', 'ID_999_left'):
                 folder = output_folder/site/data_folder/patientid
                 os.mkdir(folder)

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -552,7 +552,7 @@ run_data_access_preflight_check_without_data () {
     # also check that it finishes the single round within one minute
     timeout --signal=kill 15s ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_P --GPU "$GPU_FOR_TESTING" --preflight_check --log_dataset_details --no_pull 2>&1 | tee $CONSOLE_OUTPUT_FILE
 
-    if grep -Eq "No such file or directory: '/data/client_A/metadata_unilateral/(annotation|split)\.csv'" "$CONSOLE_OUTPUT_FILE" ; then
+    if grep -Eq "No such file or directory: '/data/client_P/metadata_unilateral/(annotation|split)\.csv'" "$CONSOLE_OUTPUT_FILE" ; then
         echo "✅ Expected error output of data access preflight check found if no data is present"
     else
         echo "❌ Missing expected output of data access preflight check found if no data is present"

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -457,10 +457,10 @@ run_data_access_preflight_check_with_problems () {
     # requires having built a startup kit and synthetic dataset
     echo "[Run] Data access preflight check with problematic dataset ..."
     cd "$PROJECT_DIR"/prod_00
-    cd client_B/startup
+    cd client_P/startup
     CONSOLE_OUTPUT_FILE=data_access_preflight_check_console_output.txt
     # timeout may kill epoch before it is finished, this test is only about logging before the epoch is started
-    timeout --signal=kill 1m ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_B --GPU "$GPU_FOR_TESTING" --job ODELIA_ternary_classification --model_name ResNet18 --preflight_check --no_pull 2>&1 | tee $CONSOLE_OUTPUT_FILE
+    timeout --signal=kill 1m ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_P --GPU "$GPU_FOR_TESTING" --job ODELIA_ternary_classification --model_name ResNet18 --preflight_check --no_pull 2>&1 | tee $CONSOLE_OUTPUT_FILE
 
     for EXPECTED_OUTPUT in "WARNING:threedcnn_ptl:No Samples of class 2 in test set, please make sure this was intended."                                \
                            "ERROR:threedcnn_ptl:Duplicate image UIDs detected. This should not happen."                                                  \
@@ -505,10 +505,10 @@ run_data_access_preflight_check_with_problems_log_details () {
     echo "[Run] Data access preflight check with logging dataset details..."
     cd "$PROJECT_DIR"/prod_00
 
-    cd client_B/startup
+    cd client_P/startup
     CONSOLE_OUTPUT_FILE=data_access_preflight_check_console_output.txt
     # timeout may kill epoch before it is finished, this test is only about logging before the epoch is started
-    timeout --signal=kill 1m ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --job ODELIA_ternary_classification --model_name ResNet18 --preflight_check --log_dataset_details --no_pull 2>&1 | tee $CONSOLE_OUTPUT_FILE
+    timeout --signal=kill 1m ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_P --GPU "$GPU_FOR_TESTING" --job ODELIA_ternary_classification --model_name ResNet18 --preflight_check --log_dataset_details --no_pull 2>&1 | tee $CONSOLE_OUTPUT_FILE
 
     for EXPECTED_OUTPUT in "INFO:threedcnn_ptl:All training data image UIDs, UIDs with hashes:"                                                       \
                            "INFO:threedcnn_ptl:All validation data image UIDs, UIDs with hashes:"                                                     \
@@ -547,10 +547,10 @@ run_data_access_preflight_check_without_data () {
     # requires having built a startup kit and _not_ having a synthetic dataset
     echo "[Run] Data access preflight check with logging dataset details..."
     cd "$PROJECT_DIR"/prod_00
-    cd client_A/startup
+    cd client_P/startup
     CONSOLE_OUTPUT_FILE=data_access_preflight_check_console_output.txt
     # also check that it finishes the single round within one minute
-    timeout --signal=kill 15s ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_A --GPU "$GPU_FOR_TESTING" --preflight_check --log_dataset_details --no_pull 2>&1 | tee $CONSOLE_OUTPUT_FILE
+    timeout --signal=kill 15s ./docker.sh --data_dir "$SYNTHETIC_DATA_DIR" --scratch_dir "$SCRATCH_DIR"/client_P --GPU "$GPU_FOR_TESTING" --preflight_check --log_dataset_details --no_pull 2>&1 | tee $CONSOLE_OUTPUT_FILE
 
     if grep -Eq "No such file or directory: '/data/client_A/metadata_unilateral/(annotation|split)\.csv'" "$CONSOLE_OUTPUT_FILE" ; then
         echo "✅ Expected error output of data access preflight check found if no data is present"

--- a/tests/provision/dummy_project_for_testing.yml
+++ b/tests/provision/dummy_project_for_testing.yml
@@ -15,6 +15,9 @@ participants:
   - name: client_B
     type: client
     org: Test_Org
+  - name: client_P
+    type: client
+    org: Test_Org
   - name: admin@test.odelia
     type: admin
     org: Test_Org


### PR DESCRIPTION
This PR adds a separate test client node with a problematic dataset, used only in the tests whether problematic datasets are handled correctly.
Other tests now use unproblematic datasets, avoiding unnecessary and confusing warnings.