### PR TITLE
STAMP: read features extracted by STAMP 2.5.0 (raise readable version ceiling)

### DIFF
--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -84,6 +84,14 @@ Coordinate with your swarm operator to ensure all sites use the **same feature
 extractor, tile size, and feature dimension** — mismatched features will cause
 training failures.
 
+**STAMP version for extraction (DECADE): 2.5.0.** Extract with standalone STAMP
+2.5.0 (it requires Python 3.13). The swarm training image itself runs STAMP
+2.4.0 — because NVFlare/PyTorch in the image are on Python 3.11 — but it is
+patched to read features extracted by STAMP up to 2.5.0. The feature H5 layout
+and the UNI extractor are identical between 2.4.0 and 2.5.0, so this is safe.
+If you extract with a STAMP newer than 2.5.0, training will refuse the features
+— tell your swarm operator first.
+
 ### Folder Structure
 
 ```

--- a/docker_config/Dockerfile_STAMP
+++ b/docker_config/Dockerfile_STAMP
@@ -48,8 +48,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # This pulls in all STAMP dependencies: h5py, lightning, timm, transformers,
 # opencv-python, openslide-bin, openslide-python, lifelines, beartype, etc.
 # Using --no-cache-dir to keep the layer small.
+#
+# NOTE: we deliberately stay on 2.4.0. STAMP 2.5.0 hard-requires Python 3.13
+# (requires-python = ">=3.13,<3.14"), while this image runs Python 3.11 and our
+# NVFlare fork declares support only through 3.12. Sites extract features with
+# STAMP 2.5.0; the patch below lets this loader read them (the H5 layout and the
+# UNI extractor are identical between 2.4.0 and 2.5.0).
 RUN python3 -m pip install --no-cache-dir \
     "stamp @ git+https://github.com/KatherLab/STAMP.git@2.4.0"
+
+# Raise STAMP's *readable* feature-extraction version ceiling to 2.5.0 so that
+# features extracted by STAMP 2.5.0 load here. Fails the build loudly if the
+# upstream guard is not found (e.g. after a STAMP pin bump).
+COPY ./MediSwarm/scripts/build/patch_stamp_feature_version_gate.py /tmp/patch_stamp_feature_version_gate.py
+RUN python3 /tmp/patch_stamp_feature_version_gate.py \
+    && rm /tmp/patch_stamp_feature_version_gate.py
 
 # ---------------------------------------------------------------------------
 # Stage 3: NVFlare from local fork (same as ODELIA)

--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -795,9 +795,13 @@ docker_cln_sh: |
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
   fi
 
-  # Forward all STAMP_* environment variables into the container
+  # Forward all STAMP_* environment variables into the container. Pass by NAME
+  # only (no =value): docker then inherits each value from this script's
+  # environment, which preserves values containing spaces (e.g. a clinical
+  # column named "Slide ID"). The "=value" form word-split on the unquoted
+  # $ENV_VARS expansion and broke the docker command for such values.
   for _var in $(env | grep '^STAMP_' | cut -d= -f1); do
-      ENV_VARS+=" --env ${_var}=${!_var}"
+      ENV_VARS+=" --env ${_var}"
   done
 
   # ── Live Sync Integration ──────────────────────────────────────────

--- a/docs/DECADE_partner_email_2026-07-13.md
+++ b/docs/DECADE_partner_email_2026-07-13.md
@@ -37,6 +37,11 @@ All sites must also agree on the **same feature extractor + feature dimension**.
 We propose **UNI (dim 1024)** — tell us if you extracted with something else
 (e.g. CTransPath = 768).
 
+**Extract with standalone STAMP 2.5.0** (it needs Python 3.13). Our training
+image runs STAMP 2.4.0 and is patched to read 2.5.0-extracted features — the
+feature H5 layout and the UNI extractor are identical between the two versions.
+Please do **not** use a STAMP newer than 2.5.0 without telling us first.
+
 ## Your site identifier
 
 | Site | Your NVFlare `SITE_NAME` |

--- a/scripts/build/patch_stamp_feature_version_gate.py
+++ b/scripts/build/patch_stamp_feature_version_gate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Raise STAMP's *readable* feature-extraction version ceiling.
+
+Why
+---
+STAMP refuses to read a feature H5 whose ``stamp_version`` attribute is newer
+than the installed STAMP::
+
+    RuntimeError: features were extracted with a newer version of stamp,
+    please update your stamp to at least version 2.5.0.
+
+DECADE sites extract features with STAMP 2.5.0, but STAMP 2.5.0 hard-requires
+Python 3.13 (``requires-python = ">=3.13,<3.14"``) while our PyTorch/NVFlare
+stack runs Python 3.11 (NVFlare declares support only through 3.12). So the
+training image stays on STAMP 2.4.0.
+
+Reading 2.5.0-extracted features on 2.4.0 is safe. Between the 2.4.0 and 2.5.0
+tags of KatherLab/STAMP:
+
+* the feature H5 layout is unchanged — datasets ``feats`` / ``coords`` and attrs
+  ``stamp_version, extractor, unit, tile_size_um, tile_size_px, code_hash,
+  feat_type`` are written identically;
+* ``preprocessing/extractor/uni.py`` is byte-identical, so UNI features are
+  numerically the same;
+* the only ``preprocessing/tiling.py`` changes are bug fixes (eager PIL decode,
+  a None-guard on MPP metadata) that do not alter tiles, coords or features.
+
+The upstream check is therefore a conservative forward-compat guard, not a
+format break. This patch raises only the *readable* ceiling to
+``MAX_READABLE_EXTRACTION_VERSION``; features newer than that still raise.
+
+Safety
+------
+Fails loudly (non-zero exit) if the expected upstream code is not found, so a
+future STAMP version bump cannot silently skip this patch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Highest extraction version we have verified this loader can read.
+MAX_READABLE_EXTRACTION_VERSION = "2.5.0"
+
+# The exact upstream comparison (stamp/modeling/data.py), which must appear once.
+TARGET = ") > Version(stamp.__version__):"
+REPLACEMENT = (
+    f') > max(Version(stamp.__version__), Version("{MAX_READABLE_EXTRACTION_VERSION}")):'
+    f"  # MediSwarm: allow reading features from STAMP <= {MAX_READABLE_EXTRACTION_VERSION}"
+)
+
+
+def _data_module_path() -> Path:
+    import stamp.modeling.data as data_mod  # noqa: PLC0415 — needs installed stamp
+
+    return Path(data_mod.__file__)
+
+
+def main() -> int:
+    path = _data_module_path()
+    source = path.read_text(encoding="utf-8")
+
+    if REPLACEMENT in source:
+        print(f"[patch_stamp] already patched: {path}")
+        return 0
+
+    count = source.count(TARGET)
+    if count != 1:
+        print(
+            f"[patch_stamp] ERROR: expected exactly 1 occurrence of\n"
+            f"  {TARGET!r}\n"
+            f"in {path}, found {count}. Upstream STAMP changed — review this patch "
+            f"before bumping the STAMP pin.",
+            file=sys.stderr,
+        )
+        return 1
+
+    path.write_text(source.replace(TARGET, REPLACEMENT), encoding="utf-8")
+
+    # Verify the patched module still imports and the ceiling behaves as intended.
+    verify = path.read_text(encoding="utf-8")
+    if REPLACEMENT not in verify:
+        print("[patch_stamp] ERROR: replacement did not persist", file=sys.stderr)
+        return 1
+
+    import importlib
+
+    importlib.invalidate_caches()
+    importlib.import_module("stamp.modeling.data")
+
+    print(
+        f"[patch_stamp] patched {path}: readable extraction version ceiling "
+        f"raised to {MAX_READABLE_EXTRACTION_VERSION}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
> **Stacks on #413** (the `--env NAME` space-forwarding fix). Once #413 merges this
> PR's diff reduces to the version-gate commit alone.

## Problem

UKB Bonn extracted DECADE features with **STAMP 2.5.0**. Our training image runs
STAMP 2.4.0, which refuses them:

```
RuntimeError: features were extracted with a newer version of stamp,
please update your stamp to at least version 2.5.0.
```

Simply bumping the pin is not possible: **STAMP 2.5.0 hard-requires Python 3.13**
(`requires-python = ">=3.13,<3.14"`), while the image runs Python 3.11 and our
NVFlare fork declares support only through 3.12. Migrating the whole stack to
3.13 days before the first consortium run is not warranted.

## Why reading 2.5.0 features on 2.4.0 is safe

The check is a conservative forward-compat guard, not a format break. Between the
`2.4.0` and `2.5.0` tags of KatherLab/STAMP:

* the feature H5 layout is **identical** — datasets `feats`/`coords`, attrs
  `stamp_version, extractor, unit, tile_size_um, tile_size_px, code_hash, feat_type`;
* `preprocessing/extractor/uni.py` is **byte-identical** → UNI features are
  numerically the same;
* the only `preprocessing/tiling.py` changes are bug fixes (eager PIL decode; a
  None-guard on MPP metadata) — they do not alter tiles, coords or features.

Empirically, the loader already parses these files (`Loaded 15 patients`) and only
then trips the guard.

## Change

`scripts/build/patch_stamp_feature_version_gate.py`, applied at image build, raises
only the **readable** extraction-version ceiling to 2.5.0:

```python
) > max(Version(stamp.__version__), Version("2.5.0")):
```

Anything newer still raises. The patch **fails the build loudly** if the upstream
guard is not found, so a future STAMP pin bump cannot silently skip it. It is
idempotent.

Docs record the DECADE policy: sites extract with STAMP 2.5.0.

## Verification (synthetic data, RTX 6000 clients)

| Case | Result |
|---|---|
| features tagged `2.5.0` | preflight **exit 0**, `Loaded 15 patients` |
| features tagged `2.6.0` | **still raises** (guard intact) |
| `2.5.0` features + `Slide ID` column (Bonn's exact case) | **exit 0** |
| partner smoke: dummy / plausibility / local on 2.5.0 features | all pass |
| 2-node deploy test (swarm + eval + compare-local) on 2.5.0 features | see below |

🤖 Generated with [Claude Code](https://claude.com/claude-code)