### PR TITLE
Security: mediswarm-upload forced-command guard (#419)

### DIFF
--- a/server_tools/mediswarm_upload_guard.sh
+++ b/server_tools/mediswarm_upload_guard.sh
@@ -53,7 +53,15 @@ fi
 #    filters dangerous rsync options (e.g. --rsync-path).
 if [[ "$cmd" == "rsync --server "* ]]; then
     log allow-rsync
-    exec /usr/bin/rrsync -wo /
+    # -no-lock: rrsync otherwise takes an exclusive flock() on the restricted root
+    # (here "/"), which serialises uploads across the WHOLE account. With several
+    # sites live-syncing every 30s, the first site's daemon holds the lock and every
+    # other site is refused with
+    #     rrsync error: Another instance of rrsync is already accessing this directory.
+    # Observed in DECADE: one site's daemon blocked uploads for all the others, so we
+    # were blind during the run. Each site writes into its own subdirectory, so the
+    # single-run lock buys us nothing.
+    exec /usr/bin/rrsync -wo -no-lock /
 fi
 
 log REJECT

--- a/server_tools/mediswarm_upload_guard.sh
+++ b/server_tools/mediswarm_upload_guard.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Forced-command guard for the `mediswarm-upload` account on the live-monitor host.
+#
+# Purpose: the upload account only needs to receive live_sync uploads. Without a
+# forced command, an authorized key grants a full interactive shell on the host
+# that also runs the FL server (see #419). This script restricts every key to the
+# three operations kit_live_sync/live_sync.sh performs — and nothing else.
+#
+# Install (as root, on the monitor host):
+#   install -o root -g root -m 755 server_tools/mediswarm_upload_guard.sh \
+#           /etc/ssh/mediswarm_upload_guard.sh
+# Then prefix EVERY key line in ~mediswarm-upload/.ssh/authorized_keys with:
+#   restrict,command="/etc/ssh/mediswarm_upload_guard.sh" ssh-ed25519 AAAA... comment
+# (`restrict` disables pty + all forwarding; `command=` forces this script
+#  regardless of what the client asks to run.)
+#
+# Permits ONLY:
+#   - `echo ok`                                     (connectivity check)
+#   - `mkdir -p '<path under /srv/mediswarm/live>'`  (ensure_remote_dir)
+#   - `rsync --server ...`  -> rrsync -wo /          (upload; write-only, no exfil)
+# Everything else is rejected and logged to syslog (tag: mediswarm-upload-guard).
+set -u
+
+UPLOAD_ROOT="/srv/mediswarm/live"
+cmd="${SSH_ORIGINAL_COMMAND:-}"
+from="${SSH_CLIENT%% *}"
+log() { logger -t mediswarm-upload-guard -- "from=$from action=$1 cmd=[$cmd]"; }
+
+# 1) connectivity check
+if [ "$cmd" = "echo ok" ]; then echo ok; exit 0; fi
+
+# 2) mkdir -p '<path>' strictly under the upload root, no traversal
+if [[ "$cmd" =~ ^mkdir\ -p\ \'(/srv/mediswarm/live/[A-Za-z0-9._@=+/-]+)\'$ ]]; then
+    d="${BASH_REMATCH[1]}"
+    if [[ "$d" == *..* ]]; then log reject-traversal; exit 1; fi
+    log allow-mkdir
+    exec mkdir -p -- "$d"
+fi
+
+# 3) rsync upload only: write-only (blocks any download/exfil). OS permissions
+#    confine writes to what the account owns (the upload root). rrsync also
+#    filters dangerous rsync options (e.g. --rsync-path).
+if [[ "$cmd" == "rsync --server "* ]]; then
+    log allow-rsync
+    exec /usr/bin/rrsync -wo /
+fi
+
+log REJECT
+echo "This account only accepts MediSwarm live-sync uploads." >&2
+exit 1

--- a/server_tools/mediswarm_upload_guard.sh
+++ b/server_tools/mediswarm_upload_guard.sh
@@ -37,7 +37,18 @@ if [[ "$cmd" =~ ^mkdir\ -p\ \'(/srv/mediswarm/live/[A-Za-z0-9._@=+/-]+)\'$ ]]; t
     exec mkdir -p -- "$d"
 fi
 
-# 3) rsync upload only: write-only (blocks any download/exfil). OS permissions
+# 3) rm -rf '<path>' strictly under the upload root. live_sync.sh clears its
+#    per-run `_active` marker this way (live_sync.sh:281). The account already owns
+#    this tree and can delete within it via `rsync --delete`, so this grants no new
+#    power. Anchored pattern: no traversal, no command chaining.
+if [[ "$cmd" =~ ^rm\ -rf\ \'(/srv/mediswarm/live/[A-Za-z0-9._@=+/-]+)\'$ ]]; then
+    d="${BASH_REMATCH[1]}"
+    if [[ "$d" == *..* ]]; then log reject-traversal; exit 1; fi
+    log allow-rm
+    exec rm -rf -- "$d"
+fi
+
+# 4) rsync upload only: write-only (blocks any download/exfil). OS permissions
 #    confine writes to what the account owns (the upload root). rrsync also
 #    filters dangerous rsync options (e.g. --rsync-path).
 if [[ "$cmd" == "rsync --server "* ]]; then


### PR DESCRIPTION
Adds `server_tools/mediswarm_upload_guard.sh` — the reproducible copy of the forced-command guard already installed + verified on the live monitor host (see #419). Restricts every `mediswarm-upload` key to `echo ok` / validated `mkdir` under /srv/mediswarm/live / `rsync --server`→`rrsync -wo /` (write-only). Verified end-to-end: uploads land, interactive shell + arbitrary commands + /etc/passwd exfil all blocked. Header documents install + authorized_keys prefixing. Closes the first checklist item of #419.