### PR TITLE
deploy tests: fail fast when the admin cannot submit the job (DNS + submit verification)

### DIFF
--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -84,6 +84,14 @@ Coordinate with your swarm operator to ensure all sites use the **same feature
 extractor, tile size, and feature dimension** — mismatched features will cause
 training failures.
 
+**STAMP version for extraction (DECADE): 2.5.0.** Extract with standalone STAMP
+2.5.0 (it requires Python 3.13). The swarm training image itself runs STAMP
+2.4.0 — because NVFlare/PyTorch in the image are on Python 3.11 — but it is
+patched to read features extracted by STAMP up to 2.5.0. The feature H5 layout
+and the UNI extractor are identical between 2.4.0 and 2.5.0, so this is safe.
+If you extract with a STAMP newer than 2.5.0, training will refuse the features
+— tell your swarm operator first.
+
 ### Folder Structure
 
 ```

--- a/docker_config/Dockerfile_STAMP
+++ b/docker_config/Dockerfile_STAMP
@@ -48,8 +48,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # This pulls in all STAMP dependencies: h5py, lightning, timm, transformers,
 # opencv-python, openslide-bin, openslide-python, lifelines, beartype, etc.
 # Using --no-cache-dir to keep the layer small.
+#
+# NOTE: we deliberately stay on 2.4.0. STAMP 2.5.0 hard-requires Python 3.13
+# (requires-python = ">=3.13,<3.14"), while this image runs Python 3.11 and our
+# NVFlare fork declares support only through 3.12. Sites extract features with
+# STAMP 2.5.0; the patch below lets this loader read them (the H5 layout and the
+# UNI extractor are identical between 2.4.0 and 2.5.0).
 RUN python3 -m pip install --no-cache-dir \
     "stamp @ git+https://github.com/KatherLab/STAMP.git@2.4.0"
+
+# Raise STAMP's *readable* feature-extraction version ceiling to 2.5.0 so that
+# features extracted by STAMP 2.5.0 load here. Fails the build loudly if the
+# upstream guard is not found (e.g. after a STAMP pin bump).
+COPY ./MediSwarm/scripts/build/patch_stamp_feature_version_gate.py /tmp/patch_stamp_feature_version_gate.py
+RUN python3 /tmp/patch_stamp_feature_version_gate.py \
+    && rm /tmp/patch_stamp_feature_version_gate.py
 
 # ---------------------------------------------------------------------------
 # Stage 3: NVFlare from local fork (same as ODELIA)

--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -795,9 +795,13 @@ docker_cln_sh: |
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
   fi
 
-  # Forward all STAMP_* environment variables into the container
+  # Forward all STAMP_* environment variables into the container. Pass by NAME
+  # only (no =value): docker then inherits each value from this script's
+  # environment, which preserves values containing spaces (e.g. a clinical
+  # column named "Slide ID"). The "=value" form word-split on the unquoted
+  # $ENV_VARS expansion and broke the docker command for such values.
   for _var in $(env | grep '^STAMP_' | cut -d= -f1); do
-      ENV_VARS+=" --env ${_var}=${!_var}"
+      ENV_VARS+=" --env ${_var}"
   done
 
   # ── Live Sync Integration ──────────────────────────────────────────

--- a/docs/DECADE_partner_email_2026-07-13.md
+++ b/docs/DECADE_partner_email_2026-07-13.md
@@ -37,6 +37,11 @@ All sites must also agree on the **same feature extractor + feature dimension**.
 We propose **UNI (dim 1024)** — tell us if you extracted with something else
 (e.g. CTransPath = 768).
 
+**Extract with standalone STAMP 2.5.0** (it needs Python 3.13). Our training
+image runs STAMP 2.4.0 and is patched to read 2.5.0-extracted features — the
+feature H5 layout and the UNI extractor are identical between the two versions.
+Please do **not** use a STAMP newer than 2.5.0 without telling us first.
+
 ## Your site identifier
 
 | Site | Your NVFlare `SITE_NAME` |

--- a/scripts/build/patch_stamp_feature_version_gate.py
+++ b/scripts/build/patch_stamp_feature_version_gate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Raise STAMP's *readable* feature-extraction version ceiling.
+
+Why
+---
+STAMP refuses to read a feature H5 whose ``stamp_version`` attribute is newer
+than the installed STAMP::
+
+    RuntimeError: features were extracted with a newer version of stamp,
+    please update your stamp to at least version 2.5.0.
+
+DECADE sites extract features with STAMP 2.5.0, but STAMP 2.5.0 hard-requires
+Python 3.13 (``requires-python = ">=3.13,<3.14"``) while our PyTorch/NVFlare
+stack runs Python 3.11 (NVFlare declares support only through 3.12). So the
+training image stays on STAMP 2.4.0.
+
+Reading 2.5.0-extracted features on 2.4.0 is safe. Between the 2.4.0 and 2.5.0
+tags of KatherLab/STAMP:
+
+* the feature H5 layout is unchanged — datasets ``feats`` / ``coords`` and attrs
+  ``stamp_version, extractor, unit, tile_size_um, tile_size_px, code_hash,
+  feat_type`` are written identically;
+* ``preprocessing/extractor/uni.py`` is byte-identical, so UNI features are
+  numerically the same;
+* the only ``preprocessing/tiling.py`` changes are bug fixes (eager PIL decode,
+  a None-guard on MPP metadata) that do not alter tiles, coords or features.
+
+The upstream check is therefore a conservative forward-compat guard, not a
+format break. This patch raises only the *readable* ceiling to
+``MAX_READABLE_EXTRACTION_VERSION``; features newer than that still raise.
+
+Safety
+------
+Fails loudly (non-zero exit) if the expected upstream code is not found, so a
+future STAMP version bump cannot silently skip this patch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Highest extraction version we have verified this loader can read.
+MAX_READABLE_EXTRACTION_VERSION = "2.5.0"
+
+# The exact upstream comparison (stamp/modeling/data.py), which must appear once.
+TARGET = ") > Version(stamp.__version__):"
+REPLACEMENT = (
+    f') > max(Version(stamp.__version__), Version("{MAX_READABLE_EXTRACTION_VERSION}")):'
+    f"  # MediSwarm: allow reading features from STAMP <= {MAX_READABLE_EXTRACTION_VERSION}"
+)
+
+
+def _data_module_path() -> Path:
+    import stamp.modeling.data as data_mod  # noqa: PLC0415 — needs installed stamp
+
+    return Path(data_mod.__file__)
+
+
+def main() -> int:
+    path = _data_module_path()
+    source = path.read_text(encoding="utf-8")
+
+    if REPLACEMENT in source:
+        print(f"[patch_stamp] already patched: {path}")
+        return 0
+
+    count = source.count(TARGET)
+    if count != 1:
+        print(
+            f"[patch_stamp] ERROR: expected exactly 1 occurrence of\n"
+            f"  {TARGET!r}\n"
+            f"in {path}, found {count}. Upstream STAMP changed — review this patch "
+            f"before bumping the STAMP pin.",
+            file=sys.stderr,
+        )
+        return 1
+
+    path.write_text(source.replace(TARGET, REPLACEMENT), encoding="utf-8")
+
+    # Verify the patched module still imports and the ceiling behaves as intended.
+    verify = path.read_text(encoding="utf-8")
+    if REPLACEMENT not in verify:
+        print("[patch_stamp] ERROR: replacement did not persist", file=sys.stderr)
+        return 1
+
+    import importlib
+
+    importlib.invalidate_caches()
+    importlib.import_module("stamp.modeling.data")
+
+    print(
+        f"[patch_stamp] patched {path}: readable extraction version ceiling "
+        f"raised to {MAX_READABLE_EXTRACTION_VERSION}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/deploy_common.sh
+++ b/scripts/deploy/deploy_common.sh
@@ -89,3 +89,90 @@ resolve_server_startup_dir() {
         fi
     fi
 }
+
+# ── Ensure the ADMIN/SERVER host itself resolves the server FQDN ──────────
+# The admin startup kit's docker.sh runs with --net=host, so the admin container
+# resolves $SERVER_NAME through *this* machine's /etc/hosts. The remote DNS fix
+# deliberately skips this host, so without this check the admin silently fails to
+# reach the server ("Cannot connect to host ...: Name or service not known"), the
+# job is never submitted, and the run waits out its whole timeout on a job that
+# never existed. Optional COSMOS_PASS is used for sudo when passwordless sudo is
+# unavailable.
+ensure_local_dns() {
+    local server_fqdn="${SERVER_NAME:-dl3.tud.de}"
+    local cosmos_ip
+    cosmos_ip=$(tailscale ip -4 2>/dev/null) || {
+        err "Cannot determine this host's Tailscale IP (is tailscale running?)"
+        return 1
+    }
+
+    step "Ensuring $server_fqdn resolves to $cosmos_ip on this (admin/server) host"
+
+    local current
+    current=$(getent hosts "$server_fqdn" 2>/dev/null | awk '{print $1}' | head -1 || true)
+    if [[ "$current" == "$cosmos_ip" ]]; then
+        ok "  $server_fqdn -> $cosmos_ip"
+        return 0
+    fi
+
+    warn "  $server_fqdn resolves to '${current:-nothing}' here (expected $cosmos_ip) — fixing /etc/hosts"
+
+    local -a sudo_cmd
+    if sudo -n true 2>/dev/null; then
+        sudo_cmd=(sudo)
+    elif [[ -n "${COSMOS_PASS:-}" ]]; then
+        sudo_cmd=(sudo -S -p '')
+    else
+        err "  Cannot edit /etc/hosts (no sudo, no COSMOS_PASS). Add this line and re-run:"
+        err "      $cosmos_ip $server_fqdn"
+        return 1
+    fi
+
+    if [[ -n "$current" ]]; then
+        printf '%s\n' "${COSMOS_PASS:-}" | "${sudo_cmd[@]}" \
+            sed -i "s|^.*\\b${server_fqdn}\\b.*\$|${cosmos_ip} ${server_fqdn}|" /etc/hosts
+    else
+        printf '%s\n' "${COSMOS_PASS:-}" | "${sudo_cmd[@]}" \
+            bash -c "echo '${cosmos_ip} ${server_fqdn}' >> /etc/hosts"
+    fi
+
+    current=$(getent hosts "$server_fqdn" 2>/dev/null | awk '{print $1}' | head -1 || true)
+    if [[ "$current" != "$cosmos_ip" ]]; then
+        err "  $server_fqdn still resolves to '${current:-nothing}' on this host."
+        err "  The admin container (--net=host) will not reach the server. Aborting."
+        return 1
+    fi
+    ok "  $server_fqdn -> $cosmos_ip"
+}
+
+# ── Verify an admin `submit_job` actually landed ──────────────────────────
+# `expect` exits 0 even when the admin never reached the server, so its exit
+# status must never be trusted. Prints the job id on stdout; diagnostics go to
+# stderr. Returns non-zero if the job was not submitted.
+#   usage: JOB_ID=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+assert_job_submitted() {
+    local submit_log="$1" job_name="$2"
+    local server="${SERVER_NAME:-dl3.tud.de}"
+
+    sed -i -E 's/\x1b\[[0-9;]*m//g' "$submit_log" 2>/dev/null || true
+
+    if grep -qiE "ClientConnectorDNSError|FLCommunicationError|cannot connect to server" "$submit_log"; then
+        err "Admin could not reach the server '$server' — job '$job_name' was NOT submitted."
+        grep -iE "ClientConnectorDNSError|FLCommunicationError|cannot connect" "$submit_log" \
+            | head -3 | sed 's/^/    /' >&2
+        err "  The admin runs with --net=host: '$server' must resolve on THIS host."
+        err "  Full admin session: $submit_log"
+        return 1
+    fi
+
+    local job_id
+    job_id=$(grep -oE "Submitted job: [0-9a-fA-F-]{36}" "$submit_log" | awk '{print $3}' | tail -1 || true)
+    if [[ -z "$job_id" ]]; then
+        err "Job submission failed for '$job_name' (no job id returned)"
+        tail -15 "$submit_log" | sed 's/^/    /' >&2
+        err "  Full admin session: $submit_log"
+        return 1
+    fi
+
+    printf '%s\n' "$job_id"
+}

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -549,12 +549,19 @@ expect eof
 EXPECT_EOF
     chmod +x "$expect_script"
 
+    # Capture the admin session: `expect` exits 0 even when the admin never
+    # reached the server, so its exit status must not be trusted.
+    local submit_log="$RESULTS_DIR/submit_${job_name}.log"
     cd "$admin_startup"
-    expect -f "$expect_script" || true
+    expect -f "$expect_script" > "$submit_log" 2>&1 || true
     cd "$REPO_ROOT"
 
     rm -f "$expect_script"
-    ok "Job submitted: $job_name"
+
+    # Only a real job id proves the submission landed (deploy_common.sh).
+    local job_id
+    job_id=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+    ok "Job submitted: $job_name (id: $job_id)"
 }
 
 # ── Wait for training completion ──────────────────────────────────────────
@@ -1129,6 +1136,9 @@ stop_all
 # Deploy startup kits to all sites (once — shared across all models)
 step "Deploying startup kits to all sites"
 deploy_kits
+
+# Fix DNS on this (admin/server) host first — the admin container uses --net=host
+ensure_local_dns
 
 # Fix DNS on remote machines so they can reach the NVFlare server on Cosmos
 fix_remote_dns

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -198,6 +198,9 @@ mkdir -p "$RESULTS_DIR"
 # Job to run
 JOB_NAME="${DEFAULT_JOB:-STAMP_classification}"
 
+# Set by submit_job() once the admin returns a real job id.
+SUBMITTED_JOB_ID=""
+
 # ── Evaluation configuration (#270) ────────────────────────────────────────
 # Evaluation runs on THIS (server) machine and needs the eval site's data
 # locally (mounted as /data). CLI flags override; conf may set EVAL_SITE /
@@ -600,12 +603,19 @@ expect eof
 EXPECT_EOF
     chmod +x "$expect_script"
 
+    # Capture the admin session: `expect` exits 0 even when the admin failed to
+    # reach the server, so its exit status alone must never be trusted.
+    local submit_log="$RESULTS_DIR/submit_${job_name}.log"
     cd "$admin_startup"
-    expect -f "$expect_script" || true
+    local rc=0
+    expect -f "$expect_script" > "$submit_log" 2>&1 || rc=$?
     cd "$REPO_ROOT"
-
     rm -f "$expect_script"
-    ok "Job submitted: $job_name"
+
+    # `expect` exits 0 even when the admin never reached the server (rc=$rc is
+    # not trustworthy); only a real job id proves the submission landed.
+    SUBMITTED_JOB_ID=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+    ok "Job submitted: $job_name (id: $SUBMITTED_JOB_ID)"
 }
 
 # ── Wait for training completion ──────────────────────────────────────────
@@ -1002,6 +1012,9 @@ stop_all
 # Deploy startup kits to all sites
 step "Deploying startup kits to all sites"
 deploy_kits
+
+# Fix DNS: this (admin/server) host first — the admin container uses --net=host
+ensure_local_dns
 
 # Fix DNS on remote machines
 fix_remote_dns


### PR DESCRIPTION
> **Stacks on #417 → #413.** Once those merge this PR reduces to the hardening commit.

## What happened

A DECADE rehearsal hung for the full timeout on a job that was **never submitted**.
Two defects combined, and both also exist in the **ODELIA** orchestrator used for
production runs:

1. **The admin host wasn't part of the DNS fix.** The admin startup kit's
   `docker.sh` runs with `--net=host`, so the admin container resolves
   `$SERVER_NAME` through the *admin host's* `/etc/hosts`. `fix_remote_dns()` only
   fixes the client hosts, so the admin died with:
   ```
   ClientConnectorDNSError: Cannot connect to host dl3.tud.de:8003 [Name or service not known]
   Exception FLCommunicationError: cannot connect to server for 10.0 seconds
   ```
2. **The failure was masked.** `submit_job()` ran `expect ... || true` and then
   unconditionally printed `[OK] Job submitted`. `expect` exits 0 even when the
   admin never reached the server, so the run happily proceeded to poll for a
   nonexistent job until the timeout expired.

## Change

Two shared helpers in `deploy_common.sh`, adopted by **both** `run_stamp_deploy_test.sh`
and `run_deploy_test.sh` (identical defects):

* `ensure_local_dns()` — verifies `$SERVER_NAME` resolves to this host's Tailscale
  IP; repairs `/etc/hosts` (passwordless sudo, else `COSMOS_PASS`); re-verifies;
  aborts with actionable output if it cannot.
* `assert_job_submitted()` — captures the admin session to
  `$RESULTS_DIR/submit_<job>.log`, detects connectivity failures explicitly, and
  requires a real job UUID. Prints the id; aborts otherwise.

## Verification

* The guards **trigger** on the captured failing admin session (no job id → abort).
* They still **parse the id** from real successful sessions — checked against both a
  historical ODELIA log (`0503438c-…`) and a STAMP log (`42484141-…`), so no
  false-abort risk for production.
* End-to-end: with `/etc/hosts` **deliberately deleted**, the STAMP deploy test
  self-heals (`dl3.tud.de resolves to 'nothing' … → dl3.tud.de -> 100.100.101.100`),
  submits (`id af969baf-…`) and passes: `PASSED: vit in 179s (evaluation: pass)`.
* `bash -n` + `shellcheck -S error` clean on all three scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)