### PR TITLE
VPN: rewrite bare auth-user-pass so the systemd VPN service can auto-recover (#418)

### DIFF
--- a/scripts/client_node_setup/setup_vpntunnel.sh
+++ b/scripts/client_node_setup/setup_vpntunnel.sh
@@ -124,8 +124,30 @@ if [[ -n "$SYSTEMD_MODE" ]]; then
         fi
     }
 
+    # auth-user-pass needs special handling: GoodAccess .ovpn files ship a *bare*
+    # `auth-user-pass` (no path), which makes OpenVPN prompt interactively so the
+    # systemd mediswarm-vpn service hangs at "Enter Auth Username" and can never
+    # auto-recover (#418). A plain grep "^auth-user-pass" matches the bare directive
+    # and skips injecting the path. So: keep it if it already has a path argument,
+    # rewrite a bare/comment one, otherwise append.
+    ensure_auth_user_pass() {
+        local file="/etc/openvpn/client/mediswarm.conf"
+        local authfile="/etc/openvpn/client/mediswarm.auth"
+        if sudo grep -qE "^auth-user-pass[[:space:]]+[^[:space:]#]" "$file"; then
+            echo "  Already present: auth-user-pass <path>"
+        elif sudo grep -qE "^auth-user-pass([[:space:]]*|[[:space:]]+#.*)$" "$file"; then
+            # delete-then-append avoids an s/// whose regex contains | (sed delimiter clash)
+            sudo sed -i -E "/^auth-user-pass([[:space:]]*|[[:space:]]+#.*)$/d" "$file"
+            echo "auth-user-pass $authfile" | sudo tee -a "$file" > /dev/null
+            echo "  Rewrote bare auth-user-pass -> auth-user-pass $authfile"
+        else
+            echo "auth-user-pass $authfile" | sudo tee -a "$file" > /dev/null
+            echo "  Injected: auth-user-pass $authfile"
+        fi
+    }
+
     echo "Injecting keepalive and credential settings ..."
-    inject_if_missing "auth-user-pass"  "auth-user-pass /etc/openvpn/client/mediswarm.auth"
+    ensure_auth_user_pass
     inject_if_missing "auth-nocache"    "auth-nocache"
     inject_if_missing "persist-key"     "persist-key"
     inject_if_missing "persist-tun"     "persist-tun"


### PR DESCRIPTION
Closes #418. GoodAccess .ovpn files ship a **bare** `auth-user-pass` (no path); the old `grep -q "^auth-user-pass"` matched it and skipped injecting the credentials path, so the `mediswarm-vpn` systemd service hung at *Enter Auth Username* — no unattended start / auto-recovery. Seen live at RUMC; **likely UKA's silent-VPN-hang root cause**. `ensure_auth_user_pass` keeps a path-form directive, rewrites a bare/comment one, else appends. Logic unit-tested across all 5 cases (bare / trailing-space / inline-comment / has-path / absent); `bash -n` clean. Deploy note: sites that ran the old script can repair `mediswarm.conf` by re-running `setup_vpntunnel.sh -d <site> -s`.