### PR TITLE
Data guard: surface failure-reason breakdown (unreadable vs degenerate) so sites don't delete valid data (#416)

### DIFF
--- a/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
+++ b/application/jobs/_shared/custom/data/datasets/dataset_3d_odelia.py
@@ -295,6 +295,7 @@ class ODELIA_Dataset3D(data.Dataset):
         self.item_pointers = self.df.index.tolist()
         self._bad_input_count = 0
         self._bad_input_logged: set = set()
+        self._bad_input_reasons: dict = {}
 
     def __len__(self):
         return len(self.item_pointers)
@@ -321,6 +322,7 @@ class ODELIA_Dataset3D(data.Dataset):
         return Path(scratch) / "odelia_bad_inputs.jsonl"
 
     def _record_bad_input(self, uid, institution, reason):
+        self._bad_input_reasons[reason] = self._bad_input_reasons.get(reason, 0) + 1
         # Loud, non-identifying warning to the console; the UID goes only to a local jsonl.
         key = (uid, reason)
         if key not in self._bad_input_logged:
@@ -335,6 +337,30 @@ class ODELIA_Dataset3D(data.Dataset):
                 f.write("\n")
         except Exception:
             pass
+
+    @staticmethod
+    def _format_bad_input_error(count, budget, frac, n, reasons, log_path):
+        """Build the abort message with a per-reason breakdown + the right remedy.
+
+        Unreadable inputs (PermissionError/OSError/...) are a file-permission problem
+        and must NOT be excluded; genuinely degenerate images should be re-exported or
+        excluded. Conflating them once led a site to delete valid data (#416)."""
+        breakdown = ", ".join(f"{c}x {r}" for r, c in
+                              sorted(reasons.items(), key=lambda kv: (-kv[1], kv[0])))
+        access_errs = ("PermissionError", "OSError", "FileNotFoundError", "IsADirectoryError")
+        unreadable = sum(c for r, c in reasons.items()
+                         if r.startswith("load_error:") and any(t in r for t in access_errs))
+        if unreadable and unreadable == count:
+            hint = ("ALL failures are file-access errors -- this is a PERMISSION/OWNERSHIP problem "
+                    "(the container cannot READ the files), NOT corrupt images. Fix the file "
+                    "permissions/ownership; do NOT exclude the data.")
+        elif unreadable:
+            hint = (f"{unreadable} unreadable (fix file permissions) + {count - unreadable} degenerate "
+                    "(re-export or exclude those UIDs).")
+        else:
+            hint = "Degenerate/corrupt image content -- re-export or exclude the listed UIDs."
+        return (f"ODELIA: too many unusable inputs ({count} > {budget} = {frac:.0%} of {n}). "
+                f"Reasons: {breakdown or 'unknown'}. {hint} Per-UID details: {log_path}")
 
     @classmethod
     def _normalize_institutions(cls, institutions) -> List[str]:
@@ -413,11 +439,9 @@ class ODELIA_Dataset3D(data.Dataset):
                     self._record_bad_input(uid, institution, e.reason)
             self._bad_input_count += 1
             if self._bad_input_count > budget:
-                raise RuntimeError(
-                    f"ODELIA: too many degenerate/corrupt inputs "
-                    f"({self._bad_input_count} > {budget} = {self.MAX_BAD_INPUT_FRACTION:.0%} of {n}); "
-                    f"run the preflight scan (find_degenerate_inputs) and fix/exclude the data."
-                )
+                raise RuntimeError(self._format_bad_input_error(
+                    self._bad_input_count, budget, self.MAX_BAD_INPUT_FRACTION, n,
+                    self._bad_input_reasons, self._bad_input_log_path()))
         raise RuntimeError(f"ODELIA: no usable input found while resampling around index {index} ({n} items)")
 
     def find_degenerate_inputs(self, limit: int | None = None):


### PR DESCRIPTION
Closes #416. The degenerate-input abort previously said *fix/exclude the data* for every failure type; when the real reason was `load_error:PermissionError` (unreadable files) it led a site to **delete valid data** instead of fixing permissions (CAM, 2026-07). Now the message carries a per-reason breakdown and the correct remedy: all-file-access -> *PERMISSION/OWNERSHIP problem, do NOT exclude*; degenerate -> *re-export/exclude*; mixed -> both counts; plus the per-UID jsonl path. Message builder is a pure staticmethod, validated standalone (all-perm / all-degenerate / mixed). Compiles clean.