### PR TITLE
STAMP deploy test: barspoon unsupported on 2.4.0 + fail the run when a model fails

### DIFF
--- a/application/jobs/STAMP_classification/README.md
+++ b/application/jobs/STAMP_classification/README.md
@@ -72,7 +72,7 @@ All STAMP-specific variables use the `STAMP_` prefix to avoid collision with ODE
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `STAMP_MODEL_NAME` | `vit` | Model architecture: `vit`, `mlp`, `trans_mil`, `linear`, `barspoon` |
+| `STAMP_MODEL_NAME` | `vit` | Model architecture: `vit`, `mlp`, `trans_mil`, `linear` (`barspoon` needs STAMP ≥ 2.5.0) |
 | `STAMP_FEATURE_TYPE` | *(auto-detect)* | Feature level: `tile`, `slide`, or `patient` |
 | `STAMP_DIM_INPUT` | `1024` | Input feature dimension (UNI/UNI2=1024, CTransPath=768) |
 | `STAMP_NUM_CLASSES` | `3` | Number of output classes |
@@ -118,7 +118,7 @@ Each site needs:
 | MLP | `mlp` | Multi-layer perceptron |
 | TransMIL | `trans_mil` | Transformer-based MIL |
 | Linear | `linear` | Linear classifier |
-| Barspoon | `barspoon` | Encoder-decoder transformer |
+| Barspoon | `barspoon` | Encoder-decoder transformer — **unavailable**: added in STAMP 2.5.0; image ships 2.4.0 |
 
 ## Quick Start
 

--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -84,6 +84,14 @@ Coordinate with your swarm operator to ensure all sites use the **same feature
 extractor, tile size, and feature dimension** — mismatched features will cause
 training failures.
 
+**STAMP version for extraction (DECADE): 2.5.0.** Extract with standalone STAMP
+2.5.0 (it requires Python 3.13). The swarm training image itself runs STAMP
+2.4.0 — because NVFlare/PyTorch in the image are on Python 3.11 — but it is
+patched to read features extracted by STAMP up to 2.5.0. The feature H5 layout
+and the UNI extractor are identical between 2.4.0 and 2.5.0, so this is safe.
+If you extract with a STAMP newer than 2.5.0, training will refuse the features
+— tell your swarm operator first.
+
 ### Folder Structure
 
 ```

--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -178,7 +178,7 @@ export STAMP_PATIENT_LABEL="PATIENT"               # patient ID column name
 
 # ── Task & Model ──
 export STAMP_TASK="classification"                 # classification, regression, or survival
-export STAMP_MODEL_NAME="vit"                      # vit, mlp, trans_mil, linear, barspoon
+export STAMP_MODEL_NAME="vit"                      # vit, mlp, trans_mil, linear
 export STAMP_DIM_INPUT="1024"                      # must match your feature extractor
 export STAMP_NUM_CLASSES="3"                        # number of output classes
 
@@ -209,7 +209,7 @@ Your swarm operator will tell you the correct values for `STAMP_MODEL_NAME`,
 | MLP | `mlp` | Multi-layer perceptron |
 | TransMIL | `trans_mil` | Transformer-based multiple instance learning |
 | Linear | `linear` | Linear classifier |
-| Barspoon | `barspoon` | Encoder-decoder transformer |
+| Barspoon | `barspoon` | Encoder-decoder transformer — **not available**: requires STAMP ≥ 2.5.0, the swarm image ships 2.4.0 |
 
 ### Local Testing on Your Data
 

--- a/docker_config/Dockerfile_STAMP
+++ b/docker_config/Dockerfile_STAMP
@@ -48,8 +48,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # This pulls in all STAMP dependencies: h5py, lightning, timm, transformers,
 # opencv-python, openslide-bin, openslide-python, lifelines, beartype, etc.
 # Using --no-cache-dir to keep the layer small.
+#
+# NOTE: we deliberately stay on 2.4.0. STAMP 2.5.0 hard-requires Python 3.13
+# (requires-python = ">=3.13,<3.14"), while this image runs Python 3.11 and our
+# NVFlare fork declares support only through 3.12. Sites extract features with
+# STAMP 2.5.0; the patch below lets this loader read them (the H5 layout and the
+# UNI extractor are identical between 2.4.0 and 2.5.0).
 RUN python3 -m pip install --no-cache-dir \
     "stamp @ git+https://github.com/KatherLab/STAMP.git@2.4.0"
+
+# Raise STAMP's *readable* feature-extraction version ceiling to 2.5.0 so that
+# features extracted by STAMP 2.5.0 load here. Fails the build loudly if the
+# upstream guard is not found (e.g. after a STAMP pin bump).
+COPY ./MediSwarm/scripts/build/patch_stamp_feature_version_gate.py /tmp/patch_stamp_feature_version_gate.py
+RUN python3 /tmp/patch_stamp_feature_version_gate.py \
+    && rm /tmp/patch_stamp_feature_version_gate.py
 
 # ---------------------------------------------------------------------------
 # Stage 3: NVFlare from local fork (same as ODELIA)

--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -795,9 +795,13 @@ docker_cln_sh: |
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
   fi
 
-  # Forward all STAMP_* environment variables into the container
+  # Forward all STAMP_* environment variables into the container. Pass by NAME
+  # only (no =value): docker then inherits each value from this script's
+  # environment, which preserves values containing spaces (e.g. a clinical
+  # column named "Slide ID"). The "=value" form word-split on the unquoted
+  # $ENV_VARS expansion and broke the docker command for such values.
   for _var in $(env | grep '^STAMP_' | cut -d= -f1); do
-      ENV_VARS+=" --env ${_var}=${!_var}"
+      ENV_VARS+=" --env ${_var}"
   done
 
   # ── Live Sync Integration ──────────────────────────────────────────

--- a/docs/DECADE_partner_email_2026-07-13.md
+++ b/docs/DECADE_partner_email_2026-07-13.md
@@ -37,6 +37,11 @@ All sites must also agree on the **same feature extractor + feature dimension**.
 We propose **UNI (dim 1024)** — tell us if you extracted with something else
 (e.g. CTransPath = 768).
 
+**Extract with standalone STAMP 2.5.0** (it needs Python 3.13). Our training
+image runs STAMP 2.4.0 and is patched to read 2.5.0-extracted features — the
+feature H5 layout and the UNI extractor are identical between the two versions.
+Please do **not** use a STAMP newer than 2.5.0 without telling us first.
+
 ## Your site identifier
 
 | Site | Your NVFlare `SITE_NAME` |

--- a/scripts/build/patch_stamp_feature_version_gate.py
+++ b/scripts/build/patch_stamp_feature_version_gate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Raise STAMP's *readable* feature-extraction version ceiling.
+
+Why
+---
+STAMP refuses to read a feature H5 whose ``stamp_version`` attribute is newer
+than the installed STAMP::
+
+    RuntimeError: features were extracted with a newer version of stamp,
+    please update your stamp to at least version 2.5.0.
+
+DECADE sites extract features with STAMP 2.5.0, but STAMP 2.5.0 hard-requires
+Python 3.13 (``requires-python = ">=3.13,<3.14"``) while our PyTorch/NVFlare
+stack runs Python 3.11 (NVFlare declares support only through 3.12). So the
+training image stays on STAMP 2.4.0.
+
+Reading 2.5.0-extracted features on 2.4.0 is safe. Between the 2.4.0 and 2.5.0
+tags of KatherLab/STAMP:
+
+* the feature H5 layout is unchanged — datasets ``feats`` / ``coords`` and attrs
+  ``stamp_version, extractor, unit, tile_size_um, tile_size_px, code_hash,
+  feat_type`` are written identically;
+* ``preprocessing/extractor/uni.py`` is byte-identical, so UNI features are
+  numerically the same;
+* the only ``preprocessing/tiling.py`` changes are bug fixes (eager PIL decode,
+  a None-guard on MPP metadata) that do not alter tiles, coords or features.
+
+The upstream check is therefore a conservative forward-compat guard, not a
+format break. This patch raises only the *readable* ceiling to
+``MAX_READABLE_EXTRACTION_VERSION``; features newer than that still raise.
+
+Safety
+------
+Fails loudly (non-zero exit) if the expected upstream code is not found, so a
+future STAMP version bump cannot silently skip this patch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Highest extraction version we have verified this loader can read.
+MAX_READABLE_EXTRACTION_VERSION = "2.5.0"
+
+# The exact upstream comparison (stamp/modeling/data.py), which must appear once.
+TARGET = ") > Version(stamp.__version__):"
+REPLACEMENT = (
+    f') > max(Version(stamp.__version__), Version("{MAX_READABLE_EXTRACTION_VERSION}")):'
+    f"  # MediSwarm: allow reading features from STAMP <= {MAX_READABLE_EXTRACTION_VERSION}"
+)
+
+
+def _data_module_path() -> Path:
+    import stamp.modeling.data as data_mod  # noqa: PLC0415 — needs installed stamp
+
+    return Path(data_mod.__file__)
+
+
+def main() -> int:
+    path = _data_module_path()
+    source = path.read_text(encoding="utf-8")
+
+    if REPLACEMENT in source:
+        print(f"[patch_stamp] already patched: {path}")
+        return 0
+
+    count = source.count(TARGET)
+    if count != 1:
+        print(
+            f"[patch_stamp] ERROR: expected exactly 1 occurrence of\n"
+            f"  {TARGET!r}\n"
+            f"in {path}, found {count}. Upstream STAMP changed — review this patch "
+            f"before bumping the STAMP pin.",
+            file=sys.stderr,
+        )
+        return 1
+
+    path.write_text(source.replace(TARGET, REPLACEMENT), encoding="utf-8")
+
+    # Verify the patched module still imports and the ceiling behaves as intended.
+    verify = path.read_text(encoding="utf-8")
+    if REPLACEMENT not in verify:
+        print("[patch_stamp] ERROR: replacement did not persist", file=sys.stderr)
+        return 1
+
+    import importlib
+
+    importlib.invalidate_caches()
+    importlib.import_module("stamp.modeling.data")
+
+    print(
+        f"[patch_stamp] patched {path}: readable extraction version ceiling "
+        f"raised to {MAX_READABLE_EXTRACTION_VERSION}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/deploy_common.sh
+++ b/scripts/deploy/deploy_common.sh
@@ -89,3 +89,90 @@ resolve_server_startup_dir() {
         fi
     fi
 }
+
+# ── Ensure the ADMIN/SERVER host itself resolves the server FQDN ──────────
+# The admin startup kit's docker.sh runs with --net=host, so the admin container
+# resolves $SERVER_NAME through *this* machine's /etc/hosts. The remote DNS fix
+# deliberately skips this host, so without this check the admin silently fails to
+# reach the server ("Cannot connect to host ...: Name or service not known"), the
+# job is never submitted, and the run waits out its whole timeout on a job that
+# never existed. Optional COSMOS_PASS is used for sudo when passwordless sudo is
+# unavailable.
+ensure_local_dns() {
+    local server_fqdn="${SERVER_NAME:-dl3.tud.de}"
+    local cosmos_ip
+    cosmos_ip=$(tailscale ip -4 2>/dev/null) || {
+        err "Cannot determine this host's Tailscale IP (is tailscale running?)"
+        return 1
+    }
+
+    step "Ensuring $server_fqdn resolves to $cosmos_ip on this (admin/server) host"
+
+    local current
+    current=$(getent hosts "$server_fqdn" 2>/dev/null | awk '{print $1}' | head -1 || true)
+    if [[ "$current" == "$cosmos_ip" ]]; then
+        ok "  $server_fqdn -> $cosmos_ip"
+        return 0
+    fi
+
+    warn "  $server_fqdn resolves to '${current:-nothing}' here (expected $cosmos_ip) — fixing /etc/hosts"
+
+    local -a sudo_cmd
+    if sudo -n true 2>/dev/null; then
+        sudo_cmd=(sudo)
+    elif [[ -n "${COSMOS_PASS:-}" ]]; then
+        sudo_cmd=(sudo -S -p '')
+    else
+        err "  Cannot edit /etc/hosts (no sudo, no COSMOS_PASS). Add this line and re-run:"
+        err "      $cosmos_ip $server_fqdn"
+        return 1
+    fi
+
+    if [[ -n "$current" ]]; then
+        printf '%s\n' "${COSMOS_PASS:-}" | "${sudo_cmd[@]}" \
+            sed -i "s|^.*\\b${server_fqdn}\\b.*\$|${cosmos_ip} ${server_fqdn}|" /etc/hosts
+    else
+        printf '%s\n' "${COSMOS_PASS:-}" | "${sudo_cmd[@]}" \
+            bash -c "echo '${cosmos_ip} ${server_fqdn}' >> /etc/hosts"
+    fi
+
+    current=$(getent hosts "$server_fqdn" 2>/dev/null | awk '{print $1}' | head -1 || true)
+    if [[ "$current" != "$cosmos_ip" ]]; then
+        err "  $server_fqdn still resolves to '${current:-nothing}' on this host."
+        err "  The admin container (--net=host) will not reach the server. Aborting."
+        return 1
+    fi
+    ok "  $server_fqdn -> $cosmos_ip"
+}
+
+# ── Verify an admin `submit_job` actually landed ──────────────────────────
+# `expect` exits 0 even when the admin never reached the server, so its exit
+# status must never be trusted. Prints the job id on stdout; diagnostics go to
+# stderr. Returns non-zero if the job was not submitted.
+#   usage: JOB_ID=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+assert_job_submitted() {
+    local submit_log="$1" job_name="$2"
+    local server="${SERVER_NAME:-dl3.tud.de}"
+
+    sed -i -E 's/\x1b\[[0-9;]*m//g' "$submit_log" 2>/dev/null || true
+
+    if grep -qiE "ClientConnectorDNSError|FLCommunicationError|cannot connect to server" "$submit_log"; then
+        err "Admin could not reach the server '$server' — job '$job_name' was NOT submitted."
+        grep -iE "ClientConnectorDNSError|FLCommunicationError|cannot connect" "$submit_log" \
+            | head -3 | sed 's/^/    /' >&2
+        err "  The admin runs with --net=host: '$server' must resolve on THIS host."
+        err "  Full admin session: $submit_log"
+        return 1
+    fi
+
+    local job_id
+    job_id=$(grep -oE "Submitted job: [0-9a-fA-F-]{36}" "$submit_log" | awk '{print $3}' | tail -1 || true)
+    if [[ -z "$job_id" ]]; then
+        err "Job submission failed for '$job_name' (no job id returned)"
+        tail -15 "$submit_log" | sed 's/^/    /' >&2
+        err "  Full admin session: $submit_log"
+        return 1
+    fi
+
+    printf '%s\n' "$job_id"
+}

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -549,12 +549,19 @@ expect eof
 EXPECT_EOF
     chmod +x "$expect_script"
 
+    # Capture the admin session: `expect` exits 0 even when the admin never
+    # reached the server, so its exit status must not be trusted.
+    local submit_log="$RESULTS_DIR/submit_${job_name}.log"
     cd "$admin_startup"
-    expect -f "$expect_script" || true
+    expect -f "$expect_script" > "$submit_log" 2>&1 || true
     cd "$REPO_ROOT"
 
     rm -f "$expect_script"
-    ok "Job submitted: $job_name"
+
+    # Only a real job id proves the submission landed (deploy_common.sh).
+    local job_id
+    job_id=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+    ok "Job submitted: $job_name (id: $job_id)"
 }
 
 # ── Wait for training completion ──────────────────────────────────────────
@@ -1129,6 +1136,9 @@ stop_all
 # Deploy startup kits to all sites (once — shared across all models)
 step "Deploying startup kits to all sites"
 deploy_kits
+
+# Fix DNS on this (admin/server) host first — the admin container uses --net=host
+ensure_local_dns
 
 # Fix DNS on remote machines so they can reach the NVFlare server on Cosmos
 fix_remote_dns

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -198,6 +198,9 @@ mkdir -p "$RESULTS_DIR"
 # Job to run
 JOB_NAME="${DEFAULT_JOB:-STAMP_classification}"
 
+# Set by submit_job() once the admin returns a real job id.
+SUBMITTED_JOB_ID=""
+
 # ── Evaluation configuration (#270) ────────────────────────────────────────
 # Evaluation runs on THIS (server) machine and needs the eval site's data
 # locally (mounted as /data). CLI flags override; conf may set EVAL_SITE /
@@ -600,12 +603,19 @@ expect eof
 EXPECT_EOF
     chmod +x "$expect_script"
 
+    # Capture the admin session: `expect` exits 0 even when the admin failed to
+    # reach the server, so its exit status alone must never be trusted.
+    local submit_log="$RESULTS_DIR/submit_${job_name}.log"
     cd "$admin_startup"
-    expect -f "$expect_script" || true
+    local rc=0
+    expect -f "$expect_script" > "$submit_log" 2>&1 || rc=$?
     cd "$REPO_ROOT"
-
     rm -f "$expect_script"
-    ok "Job submitted: $job_name"
+
+    # `expect` exits 0 even when the admin never reached the server (rc=$rc is
+    # not trustworthy); only a real job id proves the submission landed.
+    SUBMITTED_JOB_ID=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+    ok "Job submitted: $job_name (id: $SUBMITTED_JOB_ID)"
 }
 
 # ── Wait for training completion ──────────────────────────────────────────
@@ -1002,6 +1012,9 @@ stop_all
 # Deploy startup kits to all sites
 step "Deploying startup kits to all sites"
 deploy_kits
+
+# Fix DNS: this (admin/server) host first — the admin container uses --net=host
+ensure_local_dns
 
 # Fix DNS on remote machines
 fix_remote_dns

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -56,8 +56,17 @@ source "$SCRIPT_DIR/deploy_common.sh"
 CONF_FILE=""
 TIMEOUT_MINUTES=120   # 2 hours for a quick 2-round test
 MODELS_ARG=""
-ALL_STAMP_MODELS=(vit mlp trans_mil linear barspoon)
+# Models supported by the STAMP version shipped in the image (2.4.0), i.e.
+# stamp.modeling.registry.ModelName == {vit, mlp, trans_mil, linear}.
+# `barspoon` was only added in STAMP 2.5.0 (models/barspoon.py) and raises
+# "'barspoon' is not a valid ModelName" here — see BARSPOON_MIN_STAMP below.
+ALL_STAMP_MODELS=(vit mlp trans_mil linear)
+BARSPOON_MIN_STAMP="2.5.0"
 TEST_MODELS=()
+
+# Populated by run_single_model(); drive the script's exit status.
+PASSED_MODELS=()
+FAILED_MODELS=()
 EVALUATE=false          # run the post-training evaluation step (#270)
 EVAL_SITE_ARG=""        # site whose data to evaluate on (default: first client site)
 EVAL_DATA_DIR_ARG=""    # host path to eval data on this (server) machine
@@ -82,7 +91,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --conf           Path to site configuration file (required)"
             echo "  --timeout        Per-model training timeout in minutes (default: 120)"
             echo "  --models         Comma-separated STAMP models to test"
-            echo "                   (default: vit,mlp,trans_mil,linear,barspoon)"
+            echo "                   (default: vit,mlp,trans_mil,linear; barspoon needs STAMP >= 2.5.0)"
             echo "  --task           STAMP task type (default: classification). The site"
             echo "                   data must be generated for this task, e.g."
             echo "                   create_synthetic_stamp_dataset.py <dir> --task survival (#271)."
@@ -144,6 +153,14 @@ resolve_test_models() {
     for model in "${raw_models[@]}"; do
         model="${model//[[:space:]]/}"
         [[ -z "$model" ]] && continue
+
+        if [[ "$model" == "barspoon" ]]; then
+            err "STAMP model 'barspoon' requires STAMP >= $BARSPOON_MIN_STAMP."
+            err "  The image ships STAMP 2.4.0, whose ModelName enum has no 'barspoon';"
+            err "  training would abort with \"'barspoon' is not a valid ModelName\"."
+            err "  Supported models: ${ALL_STAMP_MODELS[*]}"
+            exit 1
+        fi
 
         if ! is_supported_stamp_model "$model"; then
             err "Unsupported STAMP model: $model"
@@ -981,10 +998,14 @@ run_single_model() {
     echo ""
     if [[ "$train_status" == "pass" ]]; then
         ok "PASSED: $model_name in ${duration}s (evaluation: $eval_status)"
+        PASSED_MODELS+=("$model_name")
     else
         err "FAILED: $model_name in ${duration}s"
+        FAILED_MODELS+=("$model_name")
     fi
 
+    # Always return 0 so the caller keeps testing the remaining models; the
+    # script's exit status is decided from FAILED_MODELS at the end.
     return 0
 }
 
@@ -1027,3 +1048,17 @@ step "Selected STAMP models: ${TEST_MODELS[*]}"
 for model_name in "${TEST_MODELS[@]}"; do
     run_single_model "$JOB_NAME" "$model_name"
 done
+
+# ── Summary + exit status ────────────────────────────────────────────────
+# Previously the script always exited 0, so a failing model (e.g. barspoon,
+# which the shipped STAMP cannot instantiate) still reported success to CI.
+step "STAMP deploy test summary"
+for m in "${PASSED_MODELS[@]:-}"; do [[ -n "$m" ]] && ok "  PASS  $m"; done
+for m in "${FAILED_MODELS[@]:-}"; do [[ -n "$m" ]] && err "  FAIL  $m"; done
+info "  ${#PASSED_MODELS[@]} passed, ${#FAILED_MODELS[@]} failed (results: $RESULTS_DIR)"
+
+if [[ ${#FAILED_MODELS[@]} -gt 0 ]]; then
+    err "Deploy test FAILED for: ${FAILED_MODELS[*]}"
+    exit 1
+fi
+ok "All ${#PASSED_MODELS[@]} model(s) passed"


### PR DESCRIPTION
> **Stacks on #421 → #417 → #413.**

Found by actually running the deploy test across all five advertised STAMP models
(#274 covered exactly this and is *closed*).

## Bug 1 — `barspoon` cannot work on the shipped STAMP

`stamp.modeling.registry.ModelName` in STAMP **2.4.0** is `{vit, mlp, trans_mil, linear}`;
`models/barspoon.py` was **added in 2.5.0**. The client aborted with:

```
ValueError: failed to instantiate class: ValueError: 'barspoon' is not a valid ModelName
ServerRunner - ERROR - Aborting current RUN due to FATAL_SYSTEM_ERROR received:
  failed to configure clients ['UKB_1', 'Mainz_1']: only 0/2 configured
```

Yet `barspoon` was in the **default** model list, and both
`README.participant.STAMP.md` and the job README advertised it **to sites** — a
DECADE site selecting it would hard-fail. (Adopting STAMP 2.5.0 isn't an option
today: it requires Python 3.13; the image runs 3.11 and our NVFlare fork declares
support only through 3.12 — see #417.)

## Bug 2 — a failing model still exited 0

The run loop called `run_single_model` (which always `return 0`) and then ended.
No aggregate status, no exit code. That is how CI stayed green while barspoon was
broken:

```
[ERROR] FAILED: barspoon in 426s
DEPLOY_EXIT_CODE=0        # <-- reported success
```

## Changes

* Drop `barspoon` from `ALL_STAMP_MODELS`; reject it **early** with a message naming
  the required STAMP version, instead of aborting a swarm run 7 minutes in.
* Track `PASSED_MODELS` / `FAILED_MODELS`, print a summary, and **exit non-zero**
  when any model failed.
* Fix the model tables in the participant guide and job README.

## Evidence (2-node deploy test, features tagged `stamp_version=2.5.0`)

| model | training | evaluation | federated ≥ local |
|---|---|---|---|
| vit | pass | pass | ✅ |
| mlp | pass | pass | ✅ |
| trans_mil | pass | pass | ✅ |
| linear | pass | pass | ✅ |
| barspoon | **fail** | skipped | — |

`barspoon` now exits 1 in <1s with a clear message; unknown models still rejected;
summary/exit logic verified under `set -euo pipefail` with empty and populated arrays.

This also confirms the eval-path rewrite in #417 holds for **all** supported models
(#270/#274/#275 stay closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)