### PR TITLE
Evaluation: broaden metrics beyond Accuracy+AUROC (#410)

### DIFF
--- a/application/jobs/_shared/custom/models/base_model.py
+++ b/application/jobs/_shared/custom/models/base_model.py
@@ -1,10 +1,42 @@
 from pathlib import Path
 import json
+import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import pytorch_lightning as pl
-from torchmetrics import AUROC, Accuracy
+from torchmetrics import (
+    AUROC,
+    Accuracy,
+    AveragePrecision,
+    CalibrationError,
+    F1Score,
+    Recall,
+    Specificity,
+)
+
+# Extended evaluation metrics (#410) are attached to these states only, so the
+# per-training-step cost of a run is unchanged.
+EXTENDED_METRIC_STATES = ("val_", "test_")
+# Bootstrap CIs re-compute each metric N times over the buffered predictions, so
+# they stay on the test split even when enabled.
+BOOTSTRAP_METRIC_STATES = ("test_",)
+
+
+def _eval_tier():
+    """'default' = macro scalars; 'full' also adds per-class values + calibration."""
+    return os.environ.get("ODELIA_EVAL_METRICS", "default").strip().lower()
+
+
+def _bootstrap_enabled():
+    return os.environ.get("ODELIA_EVAL_BOOTSTRAP", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _bootstrap_samples():
+    try:
+        return max(2, int(os.environ.get("ODELIA_EVAL_BOOTSTRAP_N", "200")))
+    except ValueError:
+        return 200
 
 
 class VeryBasicModel(pl.LightningModule):
@@ -153,6 +185,68 @@ class BasicClassifier(BasicModel):
         self.auc_roc = nn.ModuleDict({state: AUROC(**aucroc_kwargs) for state in ["train_", "val_", "test_"]})
         self.acc = nn.ModuleDict({state: Accuracy(**acc_kwargs) for state in ["train_", "val_", "test_"]})
 
+        self.eval_tier = _eval_tier()
+        self.eval_bootstrap = _bootstrap_enabled()
+        self.eval_bootstrap_samples = _bootstrap_samples()
+        self.extra_metrics = nn.ModuleDict({
+            state: nn.ModuleDict(self._build_extended_metrics(out_ch, state))
+            for state in EXTENDED_METRIC_STATES
+        })
+
+    def _build_extended_metrics(self, num_classes, state):
+        """Metrics beyond ACC/AUROC. All accept raw logits (torchmetrics softmaxes)."""
+        kwargs = {"task": "multiclass", "num_classes": num_classes}
+        metrics = {
+            "F1": F1Score(average="macro", **kwargs),
+            "Recall": Recall(average="macro", **kwargs),  # sensitivity
+            "Specificity": Specificity(average="macro", **kwargs),
+            "PR_AUC": AveragePrecision(average="macro", **kwargs),
+        }
+        if self.eval_tier == "full":
+            metrics.update({
+                "ECE": CalibrationError(**kwargs),
+                "AUC_ROC_per_class": AUROC(average=None, **kwargs),
+                "F1_per_class": F1Score(average=None, **kwargs),
+                "Recall_per_class": Recall(average=None, **kwargs),
+                "Specificity_per_class": Specificity(average=None, **kwargs),
+                "PR_AUC_per_class": AveragePrecision(average=None, **kwargs),
+            })
+        if self.eval_bootstrap and state in BOOTSTRAP_METRIC_STATES:
+            from torchmetrics.wrappers import BootStrapper
+            quantile = torch.tensor([0.025, 0.975])
+            for name, base in (("ACC_boot", Accuracy(**kwargs)), ("AUC_ROC_boot", AUROC(**kwargs))):
+                metrics[name] = BootStrapper(base, num_bootstraps=self.eval_bootstrap_samples, quantile=quantile)
+        return metrics
+
+    def compute_epoch_metrics(self, state):
+        """Compute every metric for `state` as {log_key: scalar tensor}.
+
+        Pure -- performs no logging, so it is unit-testable without a Trainer.
+        The `{state}/ACC` and `{state}/AUC_ROC` keys are preserved verbatim
+        because IntimeModelSelector selects the global model on `val/AUC_ROC`.
+        """
+        key = state + "_"
+        values = {
+            f"{state}/ACC": self.acc[key].compute(),
+            f"{state}/AUC_ROC": self.auc_roc[key].compute(),
+        }
+        if key not in self.extra_metrics:
+            return values
+        for name, metric in self.extra_metrics[key].items():
+            computed = metric.compute()
+            if name.endswith("_boot"):
+                base = name[: -len("_boot")]
+                low, high = computed["quantile"]
+                values[f"{state}/{base}_ci_low"] = low
+                values[f"{state}/{base}_ci_high"] = high
+            elif name.endswith("_per_class"):
+                base = name[: -len("_per_class")]
+                for index, value in enumerate(computed):
+                    values[f"{state}/{base}_class{index}"] = value
+            else:
+                values[f"{state}/{name}"] = computed
+        return values
+
     def _step(self, batch: dict, batch_idx: int, state: str, step: int):
         source = batch['source']
         target = batch['target']
@@ -164,15 +258,19 @@ class BasicClassifier(BasicModel):
         target_squeezed = torch.squeeze(target, 1)  # TODO Why is this necessary and is it the right thing to do?
         self.acc[state + "_"].update(pred, target_squeezed)
         self.auc_roc[state + "_"].update(pred, target_squeezed)
+        if state + "_" in self.extra_metrics:
+            for metric in self.extra_metrics[state + "_"].values():
+                metric.update(pred, target_squeezed)
 
         self.log(f"{state}/loss", loss_val, batch_size=batch_size, on_step=True, on_epoch=True)
         return loss_val
 
     def _epoch_end(self, state):
-        acc_value = self.acc[state + "_"].compute()
-        auc_roc_value = self.auc_roc[state + "_"].compute()
-        self.log(f"{state}/ACC", acc_value, batch_size=self.batch_size, on_step=False, on_epoch=True)
-        self.log(f"{state}/AUC_ROC", auc_roc_value, batch_size=self.batch_size, on_step=False, on_epoch=True)
+        metric_values = self.compute_epoch_metrics(state)
+        acc_value = metric_values[f"{state}/ACC"]
+        auc_roc_value = metric_values[f"{state}/AUC_ROC"]
+        for name, value in metric_values.items():
+            self.log(name, value, batch_size=self.batch_size, on_step=False, on_epoch=True)
         # For ModelCheckpoint, also log as "val/AUC_ROC" if state == "val"
         if state == "val":
             self.log("val/AUC_ROC", auc_roc_value, batch_size=self.batch_size, on_step=False, on_epoch=True)
@@ -180,6 +278,9 @@ class BasicClassifier(BasicModel):
         print(f"Epoch {self.current_epoch} - {state} ACC: {acc_value:.4f}, AUC_ROC: {auc_roc_value:.4f}")
         self.acc[state + "_"].reset()
         self.auc_roc[state + "_"].reset()
+        if state + "_" in self.extra_metrics:
+            for metric in self.extra_metrics[state + "_"].values():
+                metric.reset()
 
     def compute_loss(self, pred, target):
         target_squeezed = torch.squeeze(target, 1)  # TODO Why is this necessary and is it the right thing to do?

--- a/application/jobs/_shared/custom/models/base_model.py
+++ b/application/jobs/_shared/custom/models/base_model.py
@@ -161,8 +161,13 @@ class BasicClassifier(BasicModel):
         self.out_ch = out_ch
         self.spatial_dims = spatial_dims
 
-        if loss_kwargs is None:
-            loss_kwargs = {}
+        # Defensive copies. These are mutable default arguments and the code below
+        # pops/updates them: without copying, `loss_kwargs.pop('weight')` empties the
+        # caller's dict (a second model built from the same config would silently train
+        # unweighted) and the shared defaults stay polluted for the process (#430).
+        loss_kwargs = dict(loss_kwargs) if loss_kwargs else {}
+        aucroc_kwargs = dict(aucroc_kwargs) if aucroc_kwargs else {}
+        acc_kwargs = dict(acc_kwargs) if acc_kwargs else {}
 
         # Store class weights as a buffer so they move to the correct device
         # with the model (e.g. GPU).  nn.CrossEntropyLoss.weight is NOT an

--- a/tests/unit_tests/test_base_model_kwargs_isolation.py
+++ b/tests/unit_tests/test_base_model_kwargs_isolation.py
@@ -1,0 +1,69 @@
+"""BasicClassifier must not mutate its kwargs dicts (#430).
+
+`__init__` takes mutable default arguments and then pops/updates them. Without
+defensive copies, `loss_kwargs.pop('weight')` empties the *caller's* dict, so a
+second model built from the same config trains silently unweighted -- no
+exception, no warning, just a wrong loss on an imbalanced task.
+"""
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torchmetrics")
+pytest.importorskip("pytorch_lightning")
+
+import torch  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import MODELS_DIR, import_module_from_path  # noqa: E402
+
+BASE_MODEL_PATH = MODELS_DIR / "base_model.py"
+
+
+@pytest.fixture(scope="module")
+def base_model():
+    return import_module_from_path("_test_base_model_kwargs", BASE_MODEL_PATH)
+
+
+def _weights():
+    return torch.tensor([1.0, 2.0, 3.0])
+
+
+def test_caller_loss_kwargs_is_not_mutated(base_model):
+    cfg = {"weight": _weights()}
+    base_model.BasicClassifier(in_ch=1, out_ch=3, spatial_dims=3, loss_kwargs=cfg)
+    assert "weight" in cfg, "construction popped 'weight' out of the caller's dict"
+
+
+def test_second_model_from_the_same_config_keeps_class_weights(base_model):
+    """The silent-failure case: reusing one config dict for two models."""
+    cfg = {"weight": _weights()}
+    first = base_model.BasicClassifier(in_ch=1, out_ch=3, spatial_dims=3, loss_kwargs=cfg)
+    second = base_model.BasicClassifier(in_ch=1, out_ch=3, spatial_dims=3, loss_kwargs=cfg)
+    assert first._class_weight is not None
+    assert second._class_weight is not None, "second model silently lost its class weights"
+    assert torch.equal(second._class_weight, _weights())
+
+
+def test_metric_kwargs_defaults_stay_empty(base_model):
+    base_model.BasicClassifier(in_ch=1, out_ch=3, spatial_dims=3)
+    params = inspect.signature(base_model.BasicClassifier.__init__).parameters
+    assert params["aucroc_kwargs"].default == {}, "shared default dict was polluted"
+    assert params["acc_kwargs"].default == {}, "shared default dict was polluted"
+
+
+def test_caller_metric_kwargs_are_not_mutated(base_model):
+    aucroc, acc = {}, {}
+    base_model.BasicClassifier(in_ch=1, out_ch=3, spatial_dims=3, aucroc_kwargs=aucroc, acc_kwargs=acc)
+    assert aucroc == {} and acc == {}
+
+
+def test_models_with_different_class_counts_get_their_own_metrics(base_model):
+    three = base_model.BasicClassifier(in_ch=1, out_ch=3, spatial_dims=3)
+    two = base_model.BasicClassifier(in_ch=1, out_ch=2, spatial_dims=3)
+    assert three.acc["val_"].num_classes == 3
+    assert two.acc["val_"].num_classes == 2

--- a/tests/unit_tests/test_base_model_metrics.py
+++ b/tests/unit_tests/test_base_model_metrics.py
@@ -1,0 +1,122 @@
+"""Unit tests for the extended evaluation metrics in models/base_model.py (#410).
+
+These exercise the pure `compute_epoch_metrics()` helper, so no Trainer, GPU, or
+dataset is required. The tiers are env-gated, so each test constructs a fresh
+classifier after setting the environment.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torchmetrics")
+pytest.importorskip("pytorch_lightning")
+
+import torch  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import MODELS_DIR, import_module_from_path  # noqa: E402
+
+BASE_MODEL_PATH = MODELS_DIR / "base_model.py"
+NUM_CLASSES = 3
+
+# Perfectly separable logits -> ACC/AUROC/F1/Recall/Specificity/PR_AUC all == 1.0
+LOGITS = torch.tensor([
+    [3.0, 0.0, 0.0],
+    [0.0, 3.0, 0.0],
+    [0.0, 0.0, 3.0],
+    [2.5, 0.2, 0.1],
+    [0.1, 2.5, 0.2],
+    [0.1, 0.2, 2.5],
+])
+TARGETS = torch.tensor([0, 1, 2, 0, 1, 2])
+
+ENV_KEYS = ("ODELIA_EVAL_METRICS", "ODELIA_EVAL_BOOTSTRAP", "ODELIA_EVAL_BOOTSTRAP_N")
+COMPAT_KEYS = ("val/ACC", "val/AUC_ROC")
+DEFAULT_KEYS = ("val/F1", "val/Recall", "val/Specificity", "val/PR_AUC")
+
+
+@pytest.fixture(scope="module")
+def base_model():
+    return import_module_from_path("_test_base_model", BASE_MODEL_PATH)
+
+
+def _make(base_model, monkeypatch, **env):
+    """Build a classifier with a clean, explicitly-set environment."""
+    for key in ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return base_model.BasicClassifier(in_ch=1, out_ch=NUM_CLASSES, spatial_dims=3)
+
+
+def _feed(model, state):
+    key = state + "_"
+    model.acc[key].update(LOGITS, TARGETS)
+    model.auc_roc[key].update(LOGITS, TARGETS)
+    if key in model.extra_metrics:
+        for metric in model.extra_metrics[key].values():
+            metric.update(LOGITS, TARGETS)
+    return model.compute_epoch_metrics(state)
+
+
+def test_default_tier_keeps_compat_keys_and_adds_macro_scalars(base_model, monkeypatch):
+    values = _feed(_make(base_model, monkeypatch), "val")
+    for key in COMPAT_KEYS + DEFAULT_KEYS:
+        assert key in values, f"missing {key}"
+    # perfectly separable inputs
+    assert values["val/ACC"].item() == pytest.approx(1.0)
+    assert values["val/AUC_ROC"].item() == pytest.approx(1.0)
+    assert values["val/F1"].item() == pytest.approx(1.0)
+    assert values["val/Specificity"].item() == pytest.approx(1.0)
+    # every value is a scalar so Lightning can log it
+    assert all(v.ndim == 0 for v in values.values())
+
+
+def test_default_tier_excludes_per_class_calibration_and_ci(base_model, monkeypatch):
+    values = _feed(_make(base_model, monkeypatch), "val")
+    assert not any("_class" in k for k in values)
+    assert "val/ECE" not in values
+    assert not any(k.endswith(("_ci_low", "_ci_high")) for k in values)
+
+
+def test_train_state_has_no_extended_metrics(base_model, monkeypatch):
+    """Training steps must keep their original cost -- compat keys only."""
+    model = _make(base_model, monkeypatch)
+    assert "train_" not in model.extra_metrics
+    values = _feed(model, "train")
+    assert set(values) == {"train/ACC", "train/AUC_ROC"}
+
+
+def test_full_tier_adds_per_class_and_calibration(base_model, monkeypatch):
+    values = _feed(_make(base_model, monkeypatch, ODELIA_EVAL_METRICS="full"), "val")
+    assert "val/ECE" in values
+    for base in ("AUC_ROC", "F1", "Recall", "Specificity", "PR_AUC"):
+        for index in range(NUM_CLASSES):
+            assert f"val/{base}_class{index}" in values
+    # compat keys survive the full tier
+    for key in COMPAT_KEYS:
+        assert key in values
+    assert all(v.ndim == 0 for v in values.values())
+
+
+def test_bootstrap_adds_confidence_intervals_on_test_only(base_model, monkeypatch):
+    model = _make(base_model, monkeypatch, ODELIA_EVAL_BOOTSTRAP="1", ODELIA_EVAL_BOOTSTRAP_N="20")
+
+    test_values = _feed(model, "test")
+    for base in ("ACC", "AUC_ROC"):
+        assert f"test/{base}_ci_low" in test_values
+        assert f"test/{base}_ci_high" in test_values
+        assert test_values[f"test/{base}_ci_low"] <= test_values[f"test/{base}_ci_high"]
+
+    # val must stay cheap: bootstrap is restricted to the test split
+    val_values = _feed(model, "val")
+    assert not any(k.endswith(("_ci_low", "_ci_high")) for k in val_values)
+
+
+def test_bootstrap_off_by_default(base_model, monkeypatch):
+    model = _make(base_model, monkeypatch)
+    assert model.eval_bootstrap is False
+    assert not any("boot" in name for name in model.extra_metrics["test_"])


### PR DESCRIPTION
Closes #410.

Adds a **tiered** metric set to `models/base_model.py`, attached to **val/test states only** so the per-training-step cost is unchanged:

| Tier | Metrics |
|---|---|
| always on | `F1`, `Recall` (sensitivity), `Specificity`, `PR_AUC` — macro |
| `ODELIA_EVAL_METRICS=full` | + per-class values + `ECE` (calibration) |
| `ODELIA_EVAL_BOOTSTRAP=1` | + `_ci_low`/`_ci_high`, **test split only** (the one expensive path) |

**Back-compat:** `{state}/ACC`, `{state}/AUC_ROC` and the explicit `val/AUC_ROC` log keys are preserved verbatim → `IntimeModelSelector` (`key_metric = val/AUC_ROC`) is unaffected.

Metric computation is factored into a **pure** `compute_epoch_metrics(state)` (no logging) so it is testable without a Trainer/GPU/dataset.

**Verification:** new `tests/unit_tests/test_base_model_metrics.py` (6 tests) — compat keys survive, macro scalars correct on separable inputs, train state keeps only the compat keys, `full` adds per-class+ECE, bootstrap adds CIs on test but **not** val. Ran the full unit suite locally on a CPU torch venv: **200 passed, 9 skipped, 0 failures**. Torchmetrics API assumptions verified empirically (logits accepted; `average=None` → per-class; `BootStrapper.compute()` → `{mean,std,quantile}`).

*Note:* CI resolves torchmetrics transitively via `lightning` (1.9.0 here) while the image pins `1.7.1` — all classes used exist in both; see the version-skew follow-up in #410.