### PR TITLE
Align the local best-checkpoint metric with the federated selector metric (#409)

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
@@ -83,7 +83,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "KEY_METRIC=val/AUC_ROC python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -36,6 +36,26 @@ FILENAME_GT_PREDPROB_SITE_MODEL_VALIDATION = 'site_model_gt_and_classprob_valida
 
 OMP_THREAD_ENV_VARS = ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS")
 
+# Default matches the `key_metric` of every job that uses this training script
+# (application/jobs/*/app/config/config_fed_client.conf). Those jobs forward their
+# selector metric as a KEY_METRIC=... prefix on the launcher command, which the
+# SubprocessLauncher strips into the environment.
+DEFAULT_KEY_METRIC = "val/AUC_ROC"
+
+
+def resolve_key_metric():
+    """Return (metric, mode) for the local best-model checkpoint.
+
+    Keeps Lightning's ModelCheckpoint in step with NVFlare's IntimeModelSelector.
+    The training script runs in a separate subprocess and cannot read the NVFlare
+    component config, so the job forwards `key_metric` through the environment (#409).
+    """
+    metric = os.environ.get("KEY_METRIC", "").strip() or DEFAULT_KEY_METRIC
+    mode = os.environ.get("KEY_METRIC_MODE", "").strip().lower()
+    if mode not in ("min", "max"):
+        mode = "min" if "loss" in metric.lower() else "max"
+    return metric, mode
+
 
 @dataclass
 class UIDwithHash:
@@ -530,8 +550,8 @@ def prepare_training(logger, max_epochs: int, site_name: str = None,
 
         logger.info(f"Using model: {env_vars['model_name']}")
 
-        to_monitor = "val/ACC"
-        min_max = "max"
+        to_monitor, min_max = resolve_key_metric()
+        logger.info(f"Local best checkpoint monitors {to_monitor} (mode={min_max})")
         log_every_n_steps = 50
 
         checkpointing = ModelCheckpoint(

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -83,7 +83,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "MODEL_NAME=1DivideAndConquer python3 custom/{app_script}  {app_config} "
+        script = "KEY_METRIC=val/AUC_ROC MODEL_NAME=1DivideAndConquer python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -83,7 +83,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "MODEL_NAME=2BCN_AIM python3 custom/{app_script}  {app_config} "
+        script = "KEY_METRIC=val/AUC_ROC MODEL_NAME=2BCN_AIM python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -83,7 +83,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "MODEL_NAME=3agaldran python3 custom/{app_script}  {app_config} "
+        script = "KEY_METRIC=val/AUC_ROC MODEL_NAME=3agaldran python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -83,7 +83,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "MODEL_NAME=4LME_ABMIL python3 custom/{app_script}  {app_config} "
+        script = "KEY_METRIC=val/AUC_ROC MODEL_NAME=4LME_ABMIL python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -83,7 +83,7 @@
       id = "launcher"
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
       args {
-        script = "MODEL_NAME=5Pimed python3 custom/{app_script}  {app_config} "
+        script = "KEY_METRIC=val/AUC_ROC MODEL_NAME=5Pimed python3 custom/{app_script}  {app_config} "
         launch_once = true
       }
     }

--- a/tests/unit_tests/test_key_metric_consistency.py
+++ b/tests/unit_tests/test_key_metric_consistency.py
@@ -1,0 +1,74 @@
+"""The launcher's KEY_METRIC prefix must equal the job's IntimeModelSelector key_metric (#409).
+
+The training script runs as a SubprocessLauncher child and cannot read the NVFlare
+component config, so `key_metric` is forwarded through the launcher command. That
+leaves two places holding the same value. This is a pure text check -- no torch,
+no NVFlare -- so it always runs in CI and fails the moment the two drift apart.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOBS_DIR = REPO_ROOT / "application" / "jobs"
+SHARED_CUSTOM = (JOBS_DIR / "_shared" / "custom").resolve()
+
+KEY_METRIC_RE = re.compile(r'key_metric\s*=\s*"([^"]+)"')
+# anchored so it cannot match `app_script = "..."`
+SCRIPT_LINE_RE = re.compile(r'^\s*script\s*=\s*"([^"]*)"', re.M)
+ENV_TOKEN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(\S+)$")
+
+
+def _shared_training_jobs():
+    """Jobs whose app/custom symlinks to _shared/custom (i.e. run threedcnn_ptl)."""
+    jobs = []
+    if not JOBS_DIR.is_dir():
+        return jobs
+    for job in sorted(JOBS_DIR.iterdir()):
+        custom = job / "app" / "custom"
+        conf = job / "app" / "config" / "config_fed_client.conf"
+        if custom.is_symlink() and conf.is_file() and custom.resolve() == SHARED_CUSTOM:
+            jobs.append((job.name, conf))
+    return jobs
+
+
+def _launcher_env(script_value):
+    """Leading KEY=VALUE tokens, mirroring SubprocessLauncher's strip loop."""
+    env = {}
+    for token in script_value.split():
+        match = ENV_TOKEN_RE.match(token)
+        if not match:
+            break
+        env[match.group(1)] = match.group(2)
+    return env
+
+
+JOBS = _shared_training_jobs()
+
+
+def test_shared_training_jobs_are_discovered():
+    assert JOBS, "no job symlinks app/custom -> _shared/custom"
+    assert len(JOBS) >= 6, f"expected >=6 shared-training jobs, found {len(JOBS)}"
+
+
+@pytest.mark.parametrize("job_name,conf_path", JOBS, ids=[name for name, _ in JOBS])
+def test_launcher_key_metric_matches_selector(job_name, conf_path):
+    text = conf_path.read_text()
+
+    selector = KEY_METRIC_RE.findall(text)
+    assert selector, f"{job_name}: no key_metric in config_fed_client.conf"
+    selector_metric = selector[0]
+
+    scripts = SCRIPT_LINE_RE.findall(text)
+    assert len(scripts) == 1, f"{job_name}: expected 1 launcher script line, got {len(scripts)}"
+    env = _launcher_env(scripts[0])
+
+    assert "KEY_METRIC" in env, (
+        f"{job_name}: launcher must forward KEY_METRIC={selector_metric} so the local "
+        f"ModelCheckpoint monitors the same metric as IntimeModelSelector (#409)"
+    )
+    assert env["KEY_METRIC"] == selector_metric, (
+        f"{job_name}: launcher KEY_METRIC={env['KEY_METRIC']} != selector key_metric={selector_metric}"
+    )

--- a/tests/unit_tests/test_threedcnn_ptl.py
+++ b/tests/unit_tests/test_threedcnn_ptl.py
@@ -173,3 +173,38 @@ def test_log_data_hash_logs_duplicate_image_data_with_uids(_importable_threedcnn
     assert "Image data with hash" in caplog.text
     assert "ID_005_left, ID_005_right" in caplog.text
     assert "client_A, client_A" not in caplog.text
+
+
+def test_resolve_key_metric_defaults_to_the_selector_metric(_importable_threedcnn_ptl, monkeypatch):
+    monkeypatch.delenv("KEY_METRIC", raising=False)
+    monkeypatch.delenv("KEY_METRIC_MODE", raising=False)
+    threedcnn_ptl = _import_threedcnn_ptl()
+    assert threedcnn_ptl.resolve_key_metric() == ("val/AUC_ROC", "max")
+
+
+def test_resolve_key_metric_reads_the_environment(_importable_threedcnn_ptl, monkeypatch):
+    monkeypatch.setenv("KEY_METRIC", "val/ACC")
+    monkeypatch.delenv("KEY_METRIC_MODE", raising=False)
+    threedcnn_ptl = _import_threedcnn_ptl()
+    assert threedcnn_ptl.resolve_key_metric() == ("val/ACC", "max")
+
+
+def test_resolve_key_metric_infers_min_mode_for_a_loss(_importable_threedcnn_ptl, monkeypatch):
+    monkeypatch.setenv("KEY_METRIC", "val/loss")
+    monkeypatch.delenv("KEY_METRIC_MODE", raising=False)
+    threedcnn_ptl = _import_threedcnn_ptl()
+    assert threedcnn_ptl.resolve_key_metric() == ("val/loss", "min")
+
+
+def test_resolve_key_metric_mode_can_be_overridden(_importable_threedcnn_ptl, monkeypatch):
+    monkeypatch.setenv("KEY_METRIC", "val/AUC_ROC")
+    monkeypatch.setenv("KEY_METRIC_MODE", "min")
+    threedcnn_ptl = _import_threedcnn_ptl()
+    assert threedcnn_ptl.resolve_key_metric() == ("val/AUC_ROC", "min")
+
+
+def test_resolve_key_metric_ignores_blank_env(_importable_threedcnn_ptl, monkeypatch):
+    monkeypatch.setenv("KEY_METRIC", "   ")
+    monkeypatch.delenv("KEY_METRIC_MODE", raising=False)
+    threedcnn_ptl = _import_threedcnn_ptl()
+    assert threedcnn_ptl.resolve_key_metric() == ("val/AUC_ROC", "max")


### PR DESCRIPTION
Closes #409.

> **Re-framed after review — @oleschwen is right, and my original description overclaimed.** Correction below.

## What this is NOT
It is **not** a federated correctness bug, and "local best and global best come from different epochs" is **expected and harmless**. The model sent to the aggregator each round is the in-memory `pl_module.state_dict()` at the end of the round (`nvflare/app_opt/lightning/api.py:160-178`) — **no checkpoint file is ever read** by the aggregation path. `IntimeModelSelector` picks the global best out of the reported metrics dict on `val/AUC_ROC` (`intime_model_selector.py:112-126`), and that chain works: `best_FL_global_model.pt` was written in our one clean completed run (`34e07bb3`). Nothing about the local checkpoint touches it.

## What it actually is
The two arms select on **different metrics**:
- local Lightning `ModelCheckpoint` → hard-coded `monitor="val/ACC"` (`threedcnn_ptl.py:533`)
- federated `IntimeModelSelector` → `key_metric = "val/AUC_ROC"` (all 6 shared-training jobs)

In a swarm run the local checkpoint is inert. **But it is exactly the checkpoint the local-baseline evaluation loads** for held-out test scoring: `scripts/evaluation/run_duke_split_local_matrix.sh:554-574` resolves `best_checkpoint.json` → `epoch=N.ckpt` and hands it to the prediction step.

So in our reports, **local baselines are selected by ACC while federated results are selected by AUROC** — and on this imbalanced task the two diverge sharply (our clean run: ACC 0.789 vs AUROC 0.588). The local-vs-federated comparison is therefore not apples-to-apples.

**This PR aligns the two arms' selection criterion. It is a consistency/reporting fix with no effect on federated aggregation.**

## How
The training script is a `SubprocessLauncher` child and cannot read the NVFlare component config, so each job forwards its selector metric as a `KEY_METRIC=…` launcher prefix (the fork's launcher already strips leading `KEY=VALUE` tokens into the env, composing with the existing `MODEL_NAME=…`). `resolve_key_metric()` reads it, defaults to `val/AUC_ROC`, infers `mode=min` for loss-like metrics, and honors a `KEY_METRIC_MODE` override.

⚠️ **Behavior change (intended):** the local best checkpoint now tracks AUROC, not ACC — so local-baseline numbers in future reports will differ from past ones. `minimal_training` / `STAMP` / `cifar10` use different training code and are untouched.

## Verification
The value now lives in two places, so `tests/unit_tests/test_key_metric_consistency.py` asserts every shared-training job's launcher `KEY_METRIC` equals its selector `key_metric` (pure text check → always runs in CI). Confirmed it **fails** both when a selector drifts and when a launcher prefix is removed. Plus 5 `resolve_key_metric` unit tests. Full local suite: 206 passed, 9 skipped.
