### PR TITLE
CI: pin the image version per run to fix the date-rollover race (#428)

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -97,6 +97,9 @@ jobs:
           VERSION=$(./scripts/build/getVersionNumber.sh)
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # Pin the version for every later step. Without this a run that crosses
+          # local midnight builds one tag and then looks up another (#428).
+          echo "MEDISWARM_IMAGE_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Build Docker image for real project (MEVIS)
         run: |

--- a/scripts/build/getVersionNumber.sh
+++ b/scripts/build/getVersionNumber.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# A CI run can span local midnight. `date` would then yield a different YYMMDD
+# for the step that BUILDS the image and the step that CONSUMES it, so the kit
+# build looks up a tag that was never created (#428). Export
+# MEDISWARM_IMAGE_VERSION once per run and every caller reuses that value.
+if [ -n "${MEDISWARM_IMAGE_VERSION:-}" ]; then
+    echo "$MEDISWARM_IMAGE_VERSION"
+    exit 0
+fi
+
 VERSION=`tail -n 1 odelia_image.version`
 
 GIT_SHORT_HASH=`git rev-parse --short HEAD`

--- a/tests/unit_tests/test_get_version_number.py
+++ b/tests/unit_tests/test_get_version_number.py
@@ -1,0 +1,56 @@
+"""getVersionNumber.sh must be pinnable for the lifetime of a CI run (#428).
+
+The script derives YYMMDD from the wall clock, and is re-invoked independently by
+the build step and by runIntegrationTests.sh. A run that crosses local midnight
+therefore built `...260709...` and then looked up `...260710...`, which never
+existed. Exporting MEDISWARM_IMAGE_VERSION pins one value for the whole run.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "build" / "getVersionNumber.sh"
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+-dev\.\d{6}\.[0-9a-f]+$")
+
+
+def _run(env=None):
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_script_exists_and_is_executable():
+    assert SCRIPT.is_file()
+
+
+def test_pinned_version_is_echoed_verbatim():
+    import os
+    env = {**os.environ, "MEDISWARM_IMAGE_VERSION": "1.5.0-dev.260709.deadbee"}
+    assert _run(env) == "1.5.0-dev.260709.deadbee"
+
+
+def test_blank_pin_falls_back_to_computing_the_version():
+    import os
+    env = {**os.environ, "MEDISWARM_IMAGE_VERSION": ""}
+    assert VERSION_RE.match(_run(env)), "empty pin must not short-circuit"
+
+
+def test_unpinned_version_has_the_expected_shape():
+    import os
+    env = {k: v for k, v in os.environ.items() if k != "MEDISWARM_IMAGE_VERSION"}
+    out = _run(env)
+    assert VERSION_RE.match(out), f"unexpected version format: {out!r}"
+
+
+def test_pin_makes_repeated_invocations_agree():
+    """The property the CI race violated: two calls must return the same string."""
+    import os
+    env = {**os.environ, "MEDISWARM_IMAGE_VERSION": "9.9.9-dev.999999.cafe123"}
+    assert _run(env) == _run(env)


### PR DESCRIPTION
Closes #428.

**Every `validate-swarm` failure on the open PRs traces to one bug.** `getVersionNumber.sh` derives `YYMMDD` from the wall clock at call time, and each consumer invokes it independently (`runIntegrationTests.sh:9`, `buildDockerImageAndStartupKits.sh`, …). A run crossing **local midnight** builds `odelia:…260709…` and then looks up `…260710…`:

```
21:59:45  Building startup kits … version 1.5.0-dev.260709.2a270e10
22:00:46  Building startup kits … version 1.5.0-dev.260710.2a270e10   <- 00:00 CEST
          Unable to find image 'localhost:5000/odelia:1.5.0-dev.260710.2a270e10' locally
          docker: … http://localhost:5000/v2/: connection refused
```

The registry `connection refused` is a **symptom** — docker only reaches for the registry because the local tag no longer matches. That red herring has cost debugging time before.

| Run start (UTC) | Local | Result |
|---|---|---|
| 21:04 / 21:27 / 21:33 | 23:0x CEST → crosses midnight | ❌ #420, #422, #423 |
| 08:41 / 08:54 | morning | ✅ #425, #427 |

A **docs-only** PR (#404) fails this way, which is how you know it isn't the code.

**Fix:** `getVersionNumber.sh` honors `MEDISWARM_IMAGE_VERSION`; `pr-test.yaml`'s existing *Get Docker image version* step exports it to `$GITHUB_ENV` so every later step reuses one value. `stamp-deploy-test.yml` has the same latent race and inherits the fix once it exports the pin.

**Verification:** new `tests/unit_tests/test_get_version_number.py` (5 tests) — pinned value echoed verbatim, **empty** pin correctly falls through to computing, unpinned matches `X.Y.Z-dev.YYMMDD.<sha>`, and repeated invocations agree (the exact property the race violated). Full suite: 218 passed.