### PR TITLE
STAMP docker.sh: actionable error when STAMP_* config is missing (the sudo trap)

### DIFF
--- a/application/jobs/STAMP_classification/README.md
+++ b/application/jobs/STAMP_classification/README.md
@@ -72,7 +72,7 @@ All STAMP-specific variables use the `STAMP_` prefix to avoid collision with ODE
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `STAMP_MODEL_NAME` | `vit` | Model architecture: `vit`, `mlp`, `trans_mil`, `linear`, `barspoon` |
+| `STAMP_MODEL_NAME` | `vit` | Model architecture: `vit`, `mlp`, `trans_mil`, `linear` (`barspoon` needs STAMP ≥ 2.5.0) |
 | `STAMP_FEATURE_TYPE` | *(auto-detect)* | Feature level: `tile`, `slide`, or `patient` |
 | `STAMP_DIM_INPUT` | `1024` | Input feature dimension (UNI/UNI2=1024, CTransPath=768) |
 | `STAMP_NUM_CLASSES` | `3` | Number of output classes |
@@ -118,7 +118,7 @@ Each site needs:
 | MLP | `mlp` | Multi-layer perceptron |
 | TransMIL | `trans_mil` | Transformer-based MIL |
 | Linear | `linear` | Linear classifier |
-| Barspoon | `barspoon` | Encoder-decoder transformer |
+| Barspoon | `barspoon` | Encoder-decoder transformer — **unavailable**: added in STAMP 2.5.0; image ships 2.4.0 |
 
 ## Quick Start
 

--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -84,6 +84,14 @@ Coordinate with your swarm operator to ensure all sites use the **same feature
 extractor, tile size, and feature dimension** — mismatched features will cause
 training failures.
 
+**STAMP version for extraction (DECADE): 2.5.0.** Extract with standalone STAMP
+2.5.0 (it requires Python 3.13). The swarm training image itself runs STAMP
+2.4.0 — because NVFlare/PyTorch in the image are on Python 3.11 — but it is
+patched to read features extracted by STAMP up to 2.5.0. The feature H5 layout
+and the UNI extractor are identical between 2.4.0 and 2.5.0, so this is safe.
+If you extract with a STAMP newer than 2.5.0, training will refuse the features
+— tell your swarm operator first.
+
 ### Folder Structure
 
 ```

--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -13,7 +13,7 @@ trains on raw 3D NIfTI volumes, STAMP expects HDF5 (`.h5`) feature files that
 have already been extracted from WSIs using a foundation model (e.g. UNI,
 CTransPath, RetCCL).
 
-Only the **training** step is federated. Feature extraction (preprocessing) and
+Only the **training** step is done as swarm learning. Feature extraction (preprocessing) and
 inference (deployment) remain standalone steps that each site runs locally.
 
 ## Prerequisites

--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -140,10 +140,32 @@ The patient ID column name is configured via `STAMP_PATIENT_LABEL` (default:
 identifiers in the clinical table, or a separate slide table must be provided
 to map between them.
 
-#### Optional: Slide Table
+#### Optional: Slide Table (patients with multiple slides)
 
-If patients have multiple slides, provide a slide table (`STAMP_SLIDE_TABLE`)
-that maps patient IDs to slide filenames.
+If any patient has **more than one slide**, your `clini_table.csv` has one row per
+*patient*, while `features/` has one `.h5` per *slide*. A **slide table** maps the
+two together, so STAMP can pool all of a patient's slides into one bag.
+
+Provide a second CSV with one row per slide — a patient-ID column and a slide
+filename column — and point STAMP at it:
+
+```bash
+export STAMP_SLIDE_TABLE="/data/<SITE_NAME>/slide_table.csv"
+export STAMP_PATIENT_LABEL="PATIENT"     # patient-ID column (both tables)
+export STAMP_FILENAME_LABEL="FILENAME"   # slide-filename column (slide table)
+```
+
+`slide_table.csv`:
+
+| PATIENT | FILENAME |
+|---------|----------|
+| P_001   | slide_001.h5 |
+| P_001   | slide_002.h5 |
+| P_002   | slide_003.h5 |
+
+The `FILENAME` values must match the files in `STAMP_FEATURE_DIR`. Without a slide
+table, STAMP expects each H5 filename (minus `.h5`) to equal a patient identifier,
+which only works when every patient has exactly one slide.
 
 ### Synthetic Test Data
 
@@ -168,6 +190,20 @@ patients across 3 classes.
 STAMP uses environment variables (all prefixed with `STAMP_`) to configure the
 training. These must be exported **before** calling `docker.sh` — the script
 automatically forwards all `STAMP_*` variables into the Docker container.
+
+> **Do not run `docker.sh` with `sudo`.** `sudo` resets the environment, so the
+> `STAMP_*` variables you exported are *not* visible to `docker.sh` and training
+> fails with `KeyError: 'STAMP_CLINI_TABLE'` — even though `echo $STAMP_CLINI_TABLE`
+> prints the right value in your own shell.
+>
+> If you need root to talk to Docker, add your user to the `docker` group once and
+> then run without `sudo`:
+> ```bash
+> sudo usermod -aG docker $USER && newgrp docker
+> ./docker.sh ...
+> ```
+> As a fallback, preserve the environment explicitly: `sudo -E ./docker.sh ...`.
+> To see what `docker.sh` will forward: `env | grep '^STAMP_'`.
 
 ```bash
 # ── Required ──

--- a/assets/readme/README.participant.STAMP.md
+++ b/assets/readme/README.participant.STAMP.md
@@ -178,7 +178,7 @@ export STAMP_PATIENT_LABEL="PATIENT"               # patient ID column name
 
 # ── Task & Model ──
 export STAMP_TASK="classification"                 # classification, regression, or survival
-export STAMP_MODEL_NAME="vit"                      # vit, mlp, trans_mil, linear, barspoon
+export STAMP_MODEL_NAME="vit"                      # vit, mlp, trans_mil, linear
 export STAMP_DIM_INPUT="1024"                      # must match your feature extractor
 export STAMP_NUM_CLASSES="3"                        # number of output classes
 
@@ -209,7 +209,7 @@ Your swarm operator will tell you the correct values for `STAMP_MODEL_NAME`,
 | MLP | `mlp` | Multi-layer perceptron |
 | TransMIL | `trans_mil` | Transformer-based multiple instance learning |
 | Linear | `linear` | Linear classifier |
-| Barspoon | `barspoon` | Encoder-decoder transformer |
+| Barspoon | `barspoon` | Encoder-decoder transformer — **not available**: requires STAMP ≥ 2.5.0, the swarm image ships 2.4.0 |
 
 ### Local Testing on Your Data
 

--- a/docker_config/Dockerfile_STAMP
+++ b/docker_config/Dockerfile_STAMP
@@ -48,8 +48,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # This pulls in all STAMP dependencies: h5py, lightning, timm, transformers,
 # opencv-python, openslide-bin, openslide-python, lifelines, beartype, etc.
 # Using --no-cache-dir to keep the layer small.
+#
+# NOTE: we deliberately stay on 2.4.0. STAMP 2.5.0 hard-requires Python 3.13
+# (requires-python = ">=3.13,<3.14"), while this image runs Python 3.11 and our
+# NVFlare fork declares support only through 3.12. Sites extract features with
+# STAMP 2.5.0; the patch below lets this loader read them (the H5 layout and the
+# UNI extractor are identical between 2.4.0 and 2.5.0).
 RUN python3 -m pip install --no-cache-dir \
     "stamp @ git+https://github.com/KatherLab/STAMP.git@2.4.0"
+
+# Raise STAMP's *readable* feature-extraction version ceiling to 2.5.0 so that
+# features extracted by STAMP 2.5.0 load here. Fails the build loudly if the
+# upstream guard is not found (e.g. after a STAMP pin bump).
+COPY ./MediSwarm/scripts/build/patch_stamp_feature_version_gate.py /tmp/patch_stamp_feature_version_gate.py
+RUN python3 /tmp/patch_stamp_feature_version_gate.py \
+    && rm /tmp/patch_stamp_feature_version_gate.py
 
 # ---------------------------------------------------------------------------
 # Stage 3: NVFlare from local fork (same as ODELIA)

--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -795,6 +795,42 @@ docker_cln_sh: |
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
   fi
 
+  # Fail early (with an actionable message) when the STAMP_* configuration this
+  # mode needs is not visible to *this script*. The classic cause is running
+  # `sudo ./docker.sh ...`: sudo resets the environment, so the STAMP_* variables
+  # the user exported in their own shell never reach us, and training would die
+  # deep inside Python with `KeyError: 'STAMP_CLINI_TABLE'`.
+  if [ -n "${PREFLIGHT_CHECK:-}${LOCAL_TRAINING:-}${START_CLIENT:-}" ]; then
+      _missing=""
+      for _req in STAMP_CLINI_TABLE STAMP_FEATURE_DIR; do
+          eval "_val=\${${_req}:-}"
+          [ -z "$_val" ] && _missing="$_missing $_req"
+      done
+      if [ -n "$_missing" ]; then
+          echo "❗ Missing required STAMP environment variable(s):$_missing"
+          echo ""
+          if [ -n "${SUDO_USER:-}" ]; then
+              echo "   You ran this through 'sudo', which resets the environment, so the"
+              echo "   STAMP_* variables you exported are not visible to docker.sh."
+              echo ""
+              echo "   Preferred — run Docker without sudo (one-time setup, then re-login):"
+              echo "       sudo usermod -aG docker \$USER && newgrp docker"
+              echo "       ./docker.sh ..."
+              echo ""
+              echo "   Or preserve your environment through sudo:"
+              echo "       sudo -E ./docker.sh ..."
+          else
+              echo "   Export them before calling docker.sh, for example:"
+              echo "       export STAMP_CLINI_TABLE=\"/data/<SITE_NAME>/clini_table.csv\""
+              echo "       export STAMP_FEATURE_DIR=\"/data/<SITE_NAME>/features\""
+              echo "   (these are paths *inside* the container: --data_dir is mounted at /data)"
+          fi
+          echo ""
+          echo "   Check what this script can see with:  env | grep '^STAMP_'"
+          exit 1
+      fi
+  fi
+
   # Forward all STAMP_* environment variables into the container. Pass by NAME
   # only (no =value): docker then inherits each value from this script's
   # environment, which preserves values containing spaces (e.g. a clinical

--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -795,9 +795,13 @@ docker_cln_sh: |
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
   fi
 
-  # Forward all STAMP_* environment variables into the container
+  # Forward all STAMP_* environment variables into the container. Pass by NAME
+  # only (no =value): docker then inherits each value from this script's
+  # environment, which preserves values containing spaces (e.g. a clinical
+  # column named "Slide ID"). The "=value" form word-split on the unquoted
+  # $ENV_VARS expansion and broke the docker command for such values.
   for _var in $(env | grep '^STAMP_' | cut -d= -f1); do
-      ENV_VARS+=" --env ${_var}=${!_var}"
+      ENV_VARS+=" --env ${_var}"
   done
 
   # ── Live Sync Integration ──────────────────────────────────────────

--- a/docs/DECADE_partner_email_2026-07-13.md
+++ b/docs/DECADE_partner_email_2026-07-13.md
@@ -12,7 +12,7 @@
 
 Dear DECADE partners,
 
-Next **Monday 13 July** we will do our first federated (swarm) training run for
+Next **Monday 13 July** we will do our first swarm training run for
 DECADE. Unlike the ODELIA breast-MRI runs, DECADE uses **STAMP**, which trains on
 **pre-extracted pathology features (H5 files)** rather than raw images. This week,
 please (a) send us the two values in the box below, and (b) work through Steps 1–5
@@ -148,7 +148,7 @@ authorize it on the monitoring host and confirm.
 ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --local_training 2>&1 | tee local_training_console_output.txt
 ```
 
-Trains a model on only your data, so on Monday we can compare the federated model
+Trains a model on only your data, so on Monday we can compare the swarm model
 against your local baseline. Checkpoints/metrics land in `$SCRATCHDIR` under a
 timestamped folder.
 

--- a/docs/DECADE_partner_email_2026-07-13.md
+++ b/docs/DECADE_partner_email_2026-07-13.md
@@ -37,6 +37,11 @@ All sites must also agree on the **same feature extractor + feature dimension**.
 We propose **UNI (dim 1024)** — tell us if you extracted with something else
 (e.g. CTransPath = 768).
 
+**Extract with standalone STAMP 2.5.0** (it needs Python 3.13). Our training
+image runs STAMP 2.4.0 and is patched to read 2.5.0-extracted features — the
+feature H5 layout and the UNI extractor are identical between the two versions.
+Please do **not** use a STAMP newer than 2.5.0 without telling us first.
+
 ## Your site identifier
 
 | Site | Your NVFlare `SITE_NAME` |

--- a/scripts/build/patch_stamp_feature_version_gate.py
+++ b/scripts/build/patch_stamp_feature_version_gate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Raise STAMP's *readable* feature-extraction version ceiling.
+
+Why
+---
+STAMP refuses to read a feature H5 whose ``stamp_version`` attribute is newer
+than the installed STAMP::
+
+    RuntimeError: features were extracted with a newer version of stamp,
+    please update your stamp to at least version 2.5.0.
+
+DECADE sites extract features with STAMP 2.5.0, but STAMP 2.5.0 hard-requires
+Python 3.13 (``requires-python = ">=3.13,<3.14"``) while our PyTorch/NVFlare
+stack runs Python 3.11 (NVFlare declares support only through 3.12). So the
+training image stays on STAMP 2.4.0.
+
+Reading 2.5.0-extracted features on 2.4.0 is safe. Between the 2.4.0 and 2.5.0
+tags of KatherLab/STAMP:
+
+* the feature H5 layout is unchanged — datasets ``feats`` / ``coords`` and attrs
+  ``stamp_version, extractor, unit, tile_size_um, tile_size_px, code_hash,
+  feat_type`` are written identically;
+* ``preprocessing/extractor/uni.py`` is byte-identical, so UNI features are
+  numerically the same;
+* the only ``preprocessing/tiling.py`` changes are bug fixes (eager PIL decode,
+  a None-guard on MPP metadata) that do not alter tiles, coords or features.
+
+The upstream check is therefore a conservative forward-compat guard, not a
+format break. This patch raises only the *readable* ceiling to
+``MAX_READABLE_EXTRACTION_VERSION``; features newer than that still raise.
+
+Safety
+------
+Fails loudly (non-zero exit) if the expected upstream code is not found, so a
+future STAMP version bump cannot silently skip this patch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Highest extraction version we have verified this loader can read.
+MAX_READABLE_EXTRACTION_VERSION = "2.5.0"
+
+# The exact upstream comparison (stamp/modeling/data.py), which must appear once.
+TARGET = ") > Version(stamp.__version__):"
+REPLACEMENT = (
+    f') > max(Version(stamp.__version__), Version("{MAX_READABLE_EXTRACTION_VERSION}")):'
+    f"  # MediSwarm: allow reading features from STAMP <= {MAX_READABLE_EXTRACTION_VERSION}"
+)
+
+
+def _data_module_path() -> Path:
+    import stamp.modeling.data as data_mod  # noqa: PLC0415 — needs installed stamp
+
+    return Path(data_mod.__file__)
+
+
+def main() -> int:
+    path = _data_module_path()
+    source = path.read_text(encoding="utf-8")
+
+    if REPLACEMENT in source:
+        print(f"[patch_stamp] already patched: {path}")
+        return 0
+
+    count = source.count(TARGET)
+    if count != 1:
+        print(
+            f"[patch_stamp] ERROR: expected exactly 1 occurrence of\n"
+            f"  {TARGET!r}\n"
+            f"in {path}, found {count}. Upstream STAMP changed — review this patch "
+            f"before bumping the STAMP pin.",
+            file=sys.stderr,
+        )
+        return 1
+
+    path.write_text(source.replace(TARGET, REPLACEMENT), encoding="utf-8")
+
+    # Verify the patched module still imports and the ceiling behaves as intended.
+    verify = path.read_text(encoding="utf-8")
+    if REPLACEMENT not in verify:
+        print("[patch_stamp] ERROR: replacement did not persist", file=sys.stderr)
+        return 1
+
+    import importlib
+
+    importlib.invalidate_caches()
+    importlib.import_module("stamp.modeling.data")
+
+    print(
+        f"[patch_stamp] patched {path}: readable extraction version ceiling "
+        f"raised to {MAX_READABLE_EXTRACTION_VERSION}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/deploy_common.sh
+++ b/scripts/deploy/deploy_common.sh
@@ -89,3 +89,90 @@ resolve_server_startup_dir() {
         fi
     fi
 }
+
+# ── Ensure the ADMIN/SERVER host itself resolves the server FQDN ──────────
+# The admin startup kit's docker.sh runs with --net=host, so the admin container
+# resolves $SERVER_NAME through *this* machine's /etc/hosts. The remote DNS fix
+# deliberately skips this host, so without this check the admin silently fails to
+# reach the server ("Cannot connect to host ...: Name or service not known"), the
+# job is never submitted, and the run waits out its whole timeout on a job that
+# never existed. Optional COSMOS_PASS is used for sudo when passwordless sudo is
+# unavailable.
+ensure_local_dns() {
+    local server_fqdn="${SERVER_NAME:-dl3.tud.de}"
+    local cosmos_ip
+    cosmos_ip=$(tailscale ip -4 2>/dev/null) || {
+        err "Cannot determine this host's Tailscale IP (is tailscale running?)"
+        return 1
+    }
+
+    step "Ensuring $server_fqdn resolves to $cosmos_ip on this (admin/server) host"
+
+    local current
+    current=$(getent hosts "$server_fqdn" 2>/dev/null | awk '{print $1}' | head -1 || true)
+    if [[ "$current" == "$cosmos_ip" ]]; then
+        ok "  $server_fqdn -> $cosmos_ip"
+        return 0
+    fi
+
+    warn "  $server_fqdn resolves to '${current:-nothing}' here (expected $cosmos_ip) — fixing /etc/hosts"
+
+    local -a sudo_cmd
+    if sudo -n true 2>/dev/null; then
+        sudo_cmd=(sudo)
+    elif [[ -n "${COSMOS_PASS:-}" ]]; then
+        sudo_cmd=(sudo -S -p '')
+    else
+        err "  Cannot edit /etc/hosts (no sudo, no COSMOS_PASS). Add this line and re-run:"
+        err "      $cosmos_ip $server_fqdn"
+        return 1
+    fi
+
+    if [[ -n "$current" ]]; then
+        printf '%s\n' "${COSMOS_PASS:-}" | "${sudo_cmd[@]}" \
+            sed -i "s|^.*\\b${server_fqdn}\\b.*\$|${cosmos_ip} ${server_fqdn}|" /etc/hosts
+    else
+        printf '%s\n' "${COSMOS_PASS:-}" | "${sudo_cmd[@]}" \
+            bash -c "echo '${cosmos_ip} ${server_fqdn}' >> /etc/hosts"
+    fi
+
+    current=$(getent hosts "$server_fqdn" 2>/dev/null | awk '{print $1}' | head -1 || true)
+    if [[ "$current" != "$cosmos_ip" ]]; then
+        err "  $server_fqdn still resolves to '${current:-nothing}' on this host."
+        err "  The admin container (--net=host) will not reach the server. Aborting."
+        return 1
+    fi
+    ok "  $server_fqdn -> $cosmos_ip"
+}
+
+# ── Verify an admin `submit_job` actually landed ──────────────────────────
+# `expect` exits 0 even when the admin never reached the server, so its exit
+# status must never be trusted. Prints the job id on stdout; diagnostics go to
+# stderr. Returns non-zero if the job was not submitted.
+#   usage: JOB_ID=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+assert_job_submitted() {
+    local submit_log="$1" job_name="$2"
+    local server="${SERVER_NAME:-dl3.tud.de}"
+
+    sed -i -E 's/\x1b\[[0-9;]*m//g' "$submit_log" 2>/dev/null || true
+
+    if grep -qiE "ClientConnectorDNSError|FLCommunicationError|cannot connect to server" "$submit_log"; then
+        err "Admin could not reach the server '$server' — job '$job_name' was NOT submitted."
+        grep -iE "ClientConnectorDNSError|FLCommunicationError|cannot connect" "$submit_log" \
+            | head -3 | sed 's/^/    /' >&2
+        err "  The admin runs with --net=host: '$server' must resolve on THIS host."
+        err "  Full admin session: $submit_log"
+        return 1
+    fi
+
+    local job_id
+    job_id=$(grep -oE "Submitted job: [0-9a-fA-F-]{36}" "$submit_log" | awk '{print $3}' | tail -1 || true)
+    if [[ -z "$job_id" ]]; then
+        err "Job submission failed for '$job_name' (no job id returned)"
+        tail -15 "$submit_log" | sed 's/^/    /' >&2
+        err "  Full admin session: $submit_log"
+        return 1
+    fi
+
+    printf '%s\n' "$job_id"
+}

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -549,12 +549,19 @@ expect eof
 EXPECT_EOF
     chmod +x "$expect_script"
 
+    # Capture the admin session: `expect` exits 0 even when the admin never
+    # reached the server, so its exit status must not be trusted.
+    local submit_log="$RESULTS_DIR/submit_${job_name}.log"
     cd "$admin_startup"
-    expect -f "$expect_script" || true
+    expect -f "$expect_script" > "$submit_log" 2>&1 || true
     cd "$REPO_ROOT"
 
     rm -f "$expect_script"
-    ok "Job submitted: $job_name"
+
+    # Only a real job id proves the submission landed (deploy_common.sh).
+    local job_id
+    job_id=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+    ok "Job submitted: $job_name (id: $job_id)"
 }
 
 # ── Wait for training completion ──────────────────────────────────────────
@@ -1129,6 +1136,9 @@ stop_all
 # Deploy startup kits to all sites (once — shared across all models)
 step "Deploying startup kits to all sites"
 deploy_kits
+
+# Fix DNS on this (admin/server) host first — the admin container uses --net=host
+ensure_local_dns
 
 # Fix DNS on remote machines so they can reach the NVFlare server on Cosmos
 fix_remote_dns

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -198,6 +198,9 @@ mkdir -p "$RESULTS_DIR"
 # Job to run
 JOB_NAME="${DEFAULT_JOB:-STAMP_classification}"
 
+# Set by submit_job() once the admin returns a real job id.
+SUBMITTED_JOB_ID=""
+
 # ── Evaluation configuration (#270) ────────────────────────────────────────
 # Evaluation runs on THIS (server) machine and needs the eval site's data
 # locally (mounted as /data). CLI flags override; conf may set EVAL_SITE /
@@ -600,12 +603,19 @@ expect eof
 EXPECT_EOF
     chmod +x "$expect_script"
 
+    # Capture the admin session: `expect` exits 0 even when the admin failed to
+    # reach the server, so its exit status alone must never be trusted.
+    local submit_log="$RESULTS_DIR/submit_${job_name}.log"
     cd "$admin_startup"
-    expect -f "$expect_script" || true
+    local rc=0
+    expect -f "$expect_script" > "$submit_log" 2>&1 || rc=$?
     cd "$REPO_ROOT"
-
     rm -f "$expect_script"
-    ok "Job submitted: $job_name"
+
+    # `expect` exits 0 even when the admin never reached the server (rc=$rc is
+    # not trustworthy); only a real job id proves the submission landed.
+    SUBMITTED_JOB_ID=$(assert_job_submitted "$submit_log" "$job_name") || exit 1
+    ok "Job submitted: $job_name (id: $SUBMITTED_JOB_ID)"
 }
 
 # ── Wait for training completion ──────────────────────────────────────────
@@ -1002,6 +1012,9 @@ stop_all
 # Deploy startup kits to all sites
 step "Deploying startup kits to all sites"
 deploy_kits
+
+# Fix DNS: this (admin/server) host first — the admin container uses --net=host
+ensure_local_dns
 
 # Fix DNS on remote machines
 fix_remote_dns

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -56,8 +56,17 @@ source "$SCRIPT_DIR/deploy_common.sh"
 CONF_FILE=""
 TIMEOUT_MINUTES=120   # 2 hours for a quick 2-round test
 MODELS_ARG=""
-ALL_STAMP_MODELS=(vit mlp trans_mil linear barspoon)
+# Models supported by the STAMP version shipped in the image (2.4.0), i.e.
+# stamp.modeling.registry.ModelName == {vit, mlp, trans_mil, linear}.
+# `barspoon` was only added in STAMP 2.5.0 (models/barspoon.py) and raises
+# "'barspoon' is not a valid ModelName" here — see BARSPOON_MIN_STAMP below.
+ALL_STAMP_MODELS=(vit mlp trans_mil linear)
+BARSPOON_MIN_STAMP="2.5.0"
 TEST_MODELS=()
+
+# Populated by run_single_model(); drive the script's exit status.
+PASSED_MODELS=()
+FAILED_MODELS=()
 EVALUATE=false          # run the post-training evaluation step (#270)
 EVAL_SITE_ARG=""        # site whose data to evaluate on (default: first client site)
 EVAL_DATA_DIR_ARG=""    # host path to eval data on this (server) machine
@@ -82,7 +91,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --conf           Path to site configuration file (required)"
             echo "  --timeout        Per-model training timeout in minutes (default: 120)"
             echo "  --models         Comma-separated STAMP models to test"
-            echo "                   (default: vit,mlp,trans_mil,linear,barspoon)"
+            echo "                   (default: vit,mlp,trans_mil,linear; barspoon needs STAMP >= 2.5.0)"
             echo "  --task           STAMP task type (default: classification). The site"
             echo "                   data must be generated for this task, e.g."
             echo "                   create_synthetic_stamp_dataset.py <dir> --task survival (#271)."
@@ -144,6 +153,14 @@ resolve_test_models() {
     for model in "${raw_models[@]}"; do
         model="${model//[[:space:]]/}"
         [[ -z "$model" ]] && continue
+
+        if [[ "$model" == "barspoon" ]]; then
+            err "STAMP model 'barspoon' requires STAMP >= $BARSPOON_MIN_STAMP."
+            err "  The image ships STAMP 2.4.0, whose ModelName enum has no 'barspoon';"
+            err "  training would abort with \"'barspoon' is not a valid ModelName\"."
+            err "  Supported models: ${ALL_STAMP_MODELS[*]}"
+            exit 1
+        fi
 
         if ! is_supported_stamp_model "$model"; then
             err "Unsupported STAMP model: $model"
@@ -981,10 +998,14 @@ run_single_model() {
     echo ""
     if [[ "$train_status" == "pass" ]]; then
         ok "PASSED: $model_name in ${duration}s (evaluation: $eval_status)"
+        PASSED_MODELS+=("$model_name")
     else
         err "FAILED: $model_name in ${duration}s"
+        FAILED_MODELS+=("$model_name")
     fi
 
+    # Always return 0 so the caller keeps testing the remaining models; the
+    # script's exit status is decided from FAILED_MODELS at the end.
     return 0
 }
 
@@ -1027,3 +1048,17 @@ step "Selected STAMP models: ${TEST_MODELS[*]}"
 for model_name in "${TEST_MODELS[@]}"; do
     run_single_model "$JOB_NAME" "$model_name"
 done
+
+# ── Summary + exit status ────────────────────────────────────────────────
+# Previously the script always exited 0, so a failing model (e.g. barspoon,
+# which the shipped STAMP cannot instantiate) still reported success to CI.
+step "STAMP deploy test summary"
+for m in "${PASSED_MODELS[@]:-}"; do [[ -n "$m" ]] && ok "  PASS  $m"; done
+for m in "${FAILED_MODELS[@]:-}"; do [[ -n "$m" ]] && err "  FAIL  $m"; done
+info "  ${#PASSED_MODELS[@]} passed, ${#FAILED_MODELS[@]} failed (results: $RESULTS_DIR)"
+
+if [[ ${#FAILED_MODELS[@]} -gt 0 ]]; then
+    err "Deploy test FAILED for: ${FAILED_MODELS[*]}"
+    exit 1
+fi
+ok "All ${#PASSED_MODELS[@]} model(s) passed"


### PR DESCRIPTION
> **Stacks on #424 → #421 → #417 → #413.**

## Problem

A DECADE site (Mainz) ran the documented command with `sudo` and got an opaque
failure:

```console
$ sudo ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check
[Mainz_1] ERROR __main__: STAMP training failed: 'STAMP_CLINI_TABLE'
KeyError: 'STAMP_CLINI_TABLE'

$ echo $STAMP_CLINI_TABLE
/data/Mainz_1/clini_table.csv        # ...but it *is* set!
```

`sudo` resets the environment, so the `STAMP_*` variables the user exported are
invisible to `docker.sh`, which forwards none of them. Measured on a client:

| invocation | `STAMP_*` visible to `docker.sh` | forwarded |
|---|---|---|
| `sudo ./docker.sh` | **0** | `<empty>` |
| `sudo -E ./docker.sh` | 2 | `--env STAMP_CLINI_TABLE --env STAMP_FEATURE_DIR` |
| `./docker.sh` | 2 | forwarded |

The `echo` succeeding in the user's own shell makes this maximally confusing, and
the failure surfaces as a Python `KeyError` several layers down.

## Change

Before dispatching `--preflight_check` / `--local_training` / `--start_client`,
verify `STAMP_CLINI_TABLE` and `STAMP_FEATURE_DIR` are visible; if not, print how
to fix it. The `sudo` case is detected via `$SUDO_USER` and recommends the docker
group (or `sudo -E`). `--dummy_training` needs no STAMP config and is unaffected.

Docs: a "do not run `docker.sh` with sudo" warning, plus a concrete **slide table**
section (Mainz has multi-slide patients) — `STAMP_SLIDE_TABLE` /
`STAMP_FILENAME_LABEL` are already supported by `load_stamp_environment()`.

## Verification

Guard matrix (isolated):

| case | result |
|---|---|
| preflight, no vars | aborts, rc=1 |
| preflight, no vars, `SUDO_USER` set | aborts, rc=1, sudo-specific hint |
| preflight, vars set | proceeds |
| local_training / start_client, no vars | aborts, rc=1 |
| **dummy_training**, no vars | **proceeds** (needs no STAMP config) |
| no mode flags | proceeds |

End-to-end on a real client with the rebuilt kit, reproducing the site's exact command:

* `sudo ./docker.sh … --preflight_check` → actionable message, **exit 1** (no more `KeyError`)
* `sudo -E ./docker.sh …` → exit 0, `Loaded 15 patients`
* `./docker.sh …` → exit 0, `Loaded 15 patients`

🤖 Generated with [Claude Code](https://claude.com/claude-code)