### PR TITLE
CI: stop failing integration tests on any 'error' substring (#434)

### DIFF
--- a/scripts/ci/_error_filter.sh
+++ b/scripts/ci/_error_filter.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared error-detection helper for the integration tests.
+#
+# The tests used to assert success with a blanket `! grep -qi "error"`, so ANY
+# line containing "error" failed the build. NVFlare's audit logger races with
+# shutdown and intermittently emits a harmless traceback *after* training has
+# already finished:
+#
+#     root - ERROR - Traceback (most recent call last):
+#       File ".../nvflare/fuel/sec/audit.py", line 61, in add_event
+#         self.audit_file.write(line + "\n")
+#     ValueError: I/O operation on closed file.
+#
+# That made the same commit pass or fail purely on timing (#434). This narrows
+# the filter -- it does not disable it. Any other line containing "error" is
+# still fatal.
+
+_benign_error_noise() {
+    grep -viE "I/O operation on closed file|fuel/sec/audit\.py|hci/server/(reg|audit)\.py|self\.audit_file\.write|root - ERROR - Traceback"
+}
+
+# has_real_error <output>  -> exit 0 if a non-benign "error" line is present
+has_real_error() {
+    grep -i "error" <<< "$1" | _benign_error_noise | grep -q .
+}

--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -6,6 +6,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# shellcheck source=scripts/ci/_error_filter.sh
+source "$SCRIPT_DIR/_error_filter.sh"
+
 VERSION=$("$REPO_ROOT/scripts/build/getVersionNumber.sh")
 CONTAINER_VERSION_SUFFIX=$(git rev-parse --short HEAD)
 DOCKER_IMAGE=localhost:5000/odelia:$VERSION
@@ -211,7 +214,7 @@ run_dummy_training_simulation_mode(){
 
     echo "$OUTPUT"
 
-    if grep -qi "Epoch 9: 100%" <<< "$OUTPUT" && ! grep -qi "error" <<< "$OUTPUT"; then
+    if grep -qi "Epoch 9: 100%" <<< "$OUTPUT" && ! has_real_error "$OUTPUT"; then
         echo "✅ Minimal example simulation mode succeeded."
     else
         echo "❌ Minimal example simulation mode failed."
@@ -226,7 +229,7 @@ run_dummy_training_poc_mode(){
 
     echo "$OUTPUT"
 
-    if grep -qi "Epoch 9: 100%" <<< "$OUTPUT" && ! grep -qi "error" <<< "$OUTPUT"; then
+    if grep -qi "Epoch 9: 100%" <<< "$OUTPUT" && ! has_real_error "$OUTPUT"; then
         echo "✅ Minimal example proof-of-concept mode succeeded."
     else
         echo "❌ Minimal example proof-of-concept mode failed."

--- a/tests/unit_tests/test_ci_error_filter.py
+++ b/tests/unit_tests/test_ci_error_filter.py
@@ -1,0 +1,66 @@
+"""The integration-test error filter must ignore NVFlare's shutdown audit race
+but still catch every real error (#434).
+
+The old assertion was `! grep -qi "error"`, so any line containing the substring
+"error" failed the build -- including a harmless traceback NVFlare emits after
+training has already completed. The same commit then passed or failed on timing.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FILTER = REPO_ROOT / "scripts" / "ci" / "_error_filter.sh"
+
+# Verbatim from the failing run of PR #400 (validate-swarm), after training finished.
+BENIGN_SHUTDOWN_NOISE = """\
+Epoch 9: 100%|##########| 10/10 [00:01<00:00,  8.11it/s]
+2026-07-10 13:27:46,507 - root - ERROR - Traceback (most recent call last):
+  File "/opt/conda/lib/python3.10/site-packages/nvflare/fuel/hci/server/reg.py", line 105, in process_command
+    self._do_command(conn, command)
+  File "/opt/conda/lib/python3.10/site-packages/nvflare/fuel/hci/server/audit.py", line 40, in pre_command
+    event_id = self.auditor.add_event(
+  File "/opt/conda/lib/python3.10/site-packages/nvflare/fuel/sec/audit.py", line 61, in add_event
+    self.audit_file.write(line + "\\n")
+ValueError: I/O operation on closed file.
+Starting shutdown of NVFLARE
+"""
+
+
+def _has_real_error(output: str) -> bool:
+    """Exit status of has_real_error() from the shell helper."""
+    script = f'source "{FILTER}"; has_real_error "$1"'
+    result = subprocess.run(["bash", "-c", script, "_", output], capture_output=True)
+    return result.returncode == 0
+
+
+def test_filter_exists():
+    assert FILTER.is_file()
+
+
+def test_shutdown_audit_race_is_not_a_real_error():
+    """The exact output that turned PR #400 red must be treated as clean."""
+    assert not _has_real_error(BENIGN_SHUTDOWN_NOISE)
+
+
+def test_clean_output_has_no_error():
+    assert not _has_real_error("Epoch 9: 100%\nTraining completed successfully\n")
+
+
+@pytest.mark.parametrize("line", [
+    "RuntimeError: shape '[1, 3]' is invalid for input of size 4",
+    "CUDA error: out of memory",
+    "ERROR - failed to connect to the FL server",
+    "docker: Error response from daemon: manifest unknown",
+    "ValueError: too many degenerate inputs",
+])
+def test_genuine_errors_are_still_fatal(line):
+    """The filter must narrow the check, never disable it."""
+    assert _has_real_error(f"Epoch 9: 100%\n{line}\n"), f"missed a real error: {line}"
+
+
+def test_real_error_alongside_benign_noise_is_still_caught():
+    """A genuine failure must not hide behind the whitelisted shutdown traceback."""
+    assert _has_real_error(BENIGN_SHUTDOWN_NOISE + "RuntimeError: CUDA out of memory\n")


### PR DESCRIPTION
Closes #434.

The simulation- and POC-mode tests asserted success with `! grep -qi "error" <<< "$OUTPUT"`, so **any** line containing "error" failed the build. NVFlare's audit logger races with shutdown and intermittently emits a harmless traceback *after* training has already finished:

```
root - ERROR - Traceback (most recent call last):
  File ".../nvflare/fuel/sec/audit.py", line 61, in add_event
    self.audit_file.write(line + "\n")
ValueError: I/O operation on closed file.
```

so the same commit passed or failed purely on **timing**.

**This is why #400 was red.** Its failing log contains that traceback once; #404's passing log contains it zero times. #400's diff only changes `docker run --restart=` flags in the kit template, which the POC path (a plain `docker run --rm`) never even uses.

Extracts the check into `scripts/ci/_error_filter.sh` so it can be unit-tested, and **narrows** it — it does not disable it. Whitelist covers only that shutdown traceback; every other "error" line stays fatal, **including a real error appearing alongside the benign noise**.

**Verification:** `tests/unit_tests/test_ci_error_filter.py` (9 tests) using the verbatim traceback from #400's failing log. Confirmed the old assertion fails on it and the new one passes, while `RuntimeError`/`CUDA error`/`docker: Error response` all still fail.