### PR TITLE
STAMP: survival training crashed under fp16 (Cox loss logcumsumexp) — closes #431

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -378,6 +378,40 @@ def compute_weighted_epochs(num_train_samples: int, site_name: str = "") -> int:
     return epochs
 
 
+def _select_precision(task: str, use_gpu: bool) -> str:
+    """Pick a Lightning precision that the task's loss can actually backprop.
+
+    ``STAMP_PRECISION`` overrides this if set.
+
+    Mixed fp16 is a big speed win and is fine for classification/regression. It is
+    **not** usable for ``survival``: STAMP's Cox loss calls ``torch.logcumsumexp``
+    (``stamp/modeling/models/cox.py``), whose backward has no half kernel, so
+    training dies with::
+
+        RuntimeError: "logcumsumexp_backward" not implemented for 'Half'
+
+    Measured on a client GPU: fp16 backward FAILS, bf16 OK, fp32 OK. So for
+    survival prefer bf16 where the GPU supports it and fall back to full precision.
+    On CPU always use full precision (fp16/bf16 backward is unsupported on some
+    CPU platforms, e.g. DNNL with avx2_vnni_2).
+    """
+    override = os.environ.get("STAMP_PRECISION", "").strip()
+    if override:
+        return override
+
+    if not use_gpu:
+        return "32-true"
+
+    if task == "survival":
+        try:
+            bf16_ok = torch.cuda.is_bf16_supported()
+        except Exception:  # noqa: BLE001 — older torch / odd driver
+            bf16_ok = False
+        return "bf16-mixed" if bf16_ok else "32-true"
+
+    return "16-mixed"
+
+
 def prepare_training(
     env: dict,
     max_epochs: int,
@@ -476,9 +510,11 @@ def prepare_training(
     # CPU because bf16/fp16 backward is not supported on all CPU platforms
     # (e.g. DNNL with avx2_vnni_2 raises RuntimeError).
     use_gpu = torch.cuda.is_available()
+    precision = _select_precision(env["task"], use_gpu)
+    logger.info(f"Trainer precision: {precision} (task={env['task']}, gpu={use_gpu})")
     trainer = Trainer(
         accelerator="gpu" if use_gpu else "cpu",
-        precision="16-mixed" if use_gpu else "32-true",
+        precision=precision,
         default_root_dir=str(output_dir),
         callbacks=callbacks,
         enable_checkpointing=True,


### PR DESCRIPTION
Validating the survival + regression tasks through the deploy test (**#431**) surfaced
a hard crash in survival training.

## Bug

Every survival run died on the client as soon as it tried to step:

```
RuntimeError: "logcumsumexp_backward" not implemented for 'Half'
```

`prepare_training()` set `precision="16-mixed"` on **any** GPU. STAMP's Cox partial-
likelihood loss calls `torch.logcumsumexp` (`stamp/modeling/models/cox.py`), whose
backward has **no half kernel**. Measured on a client GPU (Quadro RTX 6000):

| dtype | `logcumsumexp` backward |
|---|---|
| float16 | **FAILS** |
| bfloat16 | OK |
| float32 | OK |

So the survival task was completely unusable on GPU — it never got past the first
optimizer step.

## Fix

Choose precision per task (`_select_precision`):

* `classification` / `regression` → `16-mixed` (keep the speed win)
* `survival` → `bf16-mixed` where the GPU supports it, else `32-true`
* CPU → `32-true` (unchanged)
* `STAMP_PRECISION` overrides, if a site ever needs to force it

## Verification — 2-node deploy test, `--evaluate --compare-local`

**Survival** (was: hard crash):

```
training_status: pass   evaluation_status: pass
  global Mainz_1  c_index=1.0   global UKB_1  c_index=1.0   baseline c_index=1.0
  federated_vs_local: {"comparable": true, "metric": "c_index", "federated_at_least_as_good": true}
client log: Trainer precision: bf16-mixed (task=survival, gpu=True)
```

**Regression** (also previously unvalidated through the rewritten eval path):

```
training_status: pass   evaluation_status: pass
  global  mse=0.0519  mae=0.189  r2=0.981
  baseline mse=2.023   r2=0.254
  federated_vs_local: {"comparable": true, "metric": "mse", "higher_is_better": false,
                       "federated": 0.0519, "local": 2.023, "federated_at_least_as_good": true}
```

Both tasks now train, evaluate, and produce sane task-appropriate metrics through the
`stamp_predict.py` path rewritten in #417 — which is exactly what #431 asked for.
Classification is unaffected (still `16-mixed`).

Closes #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)