### PR TITLE
docs: DECADE partner correspondence (first-run prep)

### DIFF
--- a/docs/DECADE_consortium_email_2026-07-10.md
+++ b/docs/DECADE_consortium_email_2026-07-10.md
@@ -1,0 +1,191 @@
+# DECADE consortium email — new startup kits + open questions (2026-07-10)
+
+> Send to all four sites. Attach each site its own kit zip from
+> `workspace/decade_1.5.0-dev.260710.a295c6b_allsites/prod_00/`.
+> Fill `<YOUR NAME>` / `<OPERATOR_CONTACT>` before sending.
+
+---
+
+**Subject:** DECADE — new startup kits (please re-download), answers to your questions, and the one decision we still need
+
+Dear all,
+
+Thank you — especially **Islem (Bonn)** and **Christina (Mainz)** for the very
+precise reports this week. Both of you found **real bugs**, and both are now fixed
+for everyone. Attached is a **new startup kit for each site**; please switch to it.
+
+A quick reminder on wording: we call this **swarm learning** (each site trains
+locally and only model weights are shared — no data ever leaves your institution).
+
+---
+
+## 1. New startup kits — please use these
+
+| Site | `SITE_NAME` | Your kit |
+|------|-------------|----------|
+| Universitätsklinikum Bonn | `UKB_1` | `UKB_1_1.5.0-dev.260710.a295c6b.zip` |
+| Universitätsmedizin Mainz | `Mainz_1` | `Mainz_1_1.5.0-dev.260710.a295c6b.zip` |
+| Universitätsklinikum Düsseldorf | `UKD_1` | `UKD_1_1.5.0-dev.260710.a295c6b.zip` |
+| Universitätsklinikum Heidelberg | `UKHD_1` | `UKHD_1_1.5.0-dev.260710.a295c6b.zip` |
+
+Unpack it and `cd <SITE_NAME>/startup`. `./docker.sh` pulls the matching container
+image for you. **Please discard any earlier kit** — older kits are missing the
+fixes below.
+
+**What is fixed in this kit**
+
+1. **`sudo` is now detected.** If the `STAMP_*` variables are not visible, the
+   script tells you exactly what to do instead of failing with a Python traceback
+   (thanks, Christina — see §2).
+2. **Features extracted with STAMP 2.5.0 are now readable.** Previously training
+   refused them with *"features were extracted with a newer version of stamp"*
+   (thanks, Islem — see §3).
+3. **Clinical column names containing spaces** (e.g. `Slide ID`) now work.
+4. **Step 1 (dummy training)** and **Steps 2/5 (preflight, local training)** run
+   correctly — two packaging bugs are fixed.
+
+---
+
+## 2. Christina's question — "I exported the variable, why can't the script see it?"
+
+Because of **`sudo`**. It resets the environment, so although
+`echo $STAMP_CLINI_TABLE` prints the right value in *your* shell, `sudo ./docker.sh`
+starts the script with a clean environment and forwards nothing into the container.
+We measured this on one of our machines:
+
+| command | `STAMP_*` variables the script can see |
+|---|---|
+| `sudo ./docker.sh …` | **none** |
+| `sudo -E ./docker.sh …` | all of them |
+| `./docker.sh …` (no sudo) | all of them |
+
+**Fix — preferred** (run Docker without `sudo`; one-time, then re-login):
+
+```bash
+sudo usermod -aG docker $USER
+newgrp docker
+./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check
+```
+
+**Fallback:** `sudo -E ./docker.sh …` (preserves your environment).
+
+Sanity check at any time: `env | grep '^STAMP_'`.
+
+### Patients with several slides — use a slide table
+
+If a patient has more than one slide, your `clini_table.csv` has one row per
+**patient** while `features/` has one `.h5` per **slide**. A slide table maps them,
+so all of a patient's slides are pooled into one bag:
+
+```bash
+export STAMP_SLIDE_TABLE="/data/<SITE_NAME>/slide_table.csv"
+export STAMP_PATIENT_LABEL="PATIENT"     # patient-ID column (both tables)
+export STAMP_FILENAME_LABEL="FILENAME"   # slide-filename column (slide table)
+```
+
+`slide_table.csv`, one row per slide:
+
+| PATIENT | FILENAME |
+|---------|----------|
+| P_001 | slide_001.h5 |
+| P_001 | slide_002.h5 |
+| P_002 | slide_003.h5 |
+
+`FILENAME` must match the files in your `features/` folder. Use your real column
+names and set `STAMP_PATIENT_LABEL` / `STAMP_FILENAME_LABEL` accordingly.
+
+---
+
+## 3. Islem's question — STAMP version for feature extraction
+
+Please **extract features with standalone STAMP 2.5.0** (Bonn already has). The
+training container itself runs STAMP 2.4.0, because STAMP 2.5.0 requires Python
+3.13 and the swarm stack inside the image does not support that yet. We verified
+that the feature files and the UNI extractor are **identical** between 2.4.0 and
+2.5.0, and the new kit reads 2.5.0-extracted features. **No re-extraction is
+needed.**
+
+Please do **not** use a STAMP newer than 2.5.0 without telling us first.
+
+---
+
+## 4. Agreed technical settings
+
+- **Feature extractor: UNI, `STAMP_DIM_INPUT=1024`** — identical at all sites.
+- **Model: `vit`** (default). Also available: `mlp`, `trans_mil`, `linear`.
+  `barspoon` is **not** available in this release.
+- **Tailscale:** accept the invitation, then add to `/etc/hosts`:
+  `100.100.101.100  dl3.tud.de  dl3` and check `ping dl3.tud.de`.
+- **Never send us** the output of `--log_dataset_details` — it can contain patient
+  IDs. Just tell us pass/fail and any error message.
+
+---
+
+## 5. The one open decision: our shared prediction target
+
+Swarm learning requires **every site to train the identical model** — the same
+label, the same number of classes, in the same order. Right now the two proposals
+we have are different *kinds* of label:
+
+- **Bonn:** germline syndrome — *Lynch / familial (FAP) / sporadic* (3 classes), or
+  *Lynch vs. sporadic* (2 classes).
+- **Mainz:** tumour phenotype — *MSI-High* (yes/no, 678 slides), or a *dMMR* column
+  with six mixed values (103 slides).
+
+These cannot simply be merged. Two remarks:
+
+1. **`MSI-High` (binary)** looks like the most harmonizable candidate: it is the
+   standard, best-populated label.
+2. Mainz's `dMMR` column mixes MMR **status** (`pMMR`, `dMMR`) with the **specific
+   protein loss** (`MLH1`, `MSH6`, `MLH1, PMS2`, …). As six classes over 103 slides
+   it would be very sparse; we would collapse it to **binary dMMR vs pMMR**.
+
+**Please answer, all four sites:**
+
+- Do you have **MSI status** (MSI-High vs. MSS/MSI-Low)? How many slides per class?
+- Do you have a clean **binary dMMR vs pMMR** column? How many slides per class?
+- If neither, what is the closest label you can provide?
+
+As soon as we have all four answers we will confirm the final
+`STAMP_GROUND_TRUTH_LABEL` and `STAMP_NUM_CLASSES` to everyone. **Please hold your
+Step 5 (local training) until then** — the class count determines the model's output
+layer, so a baseline trained on the wrong target is not comparable.
+
+---
+
+## 6. Where each site stands
+
+| Site | Tailscale | Steps 1–5 | SSH key | Target values |
+|------|-----------|-----------|---------|---------------|
+| **UKB_1** (Bonn) | ✅ | ✅ (please re-run with the new kit) | ✅ authorized | proposed, pending consortium |
+| **Mainz_1** (Mainz) | ✅ | Step 1 ✅, Steps 2/3/5 blocked by `sudo` → now unblocked | ✅ authorized | proposed, pending consortium |
+| **UKD_1** (Düsseldorf) | appears connected | **awaiting** | **awaiting** | **awaiting** |
+| **UKHD_1** (Heidelberg) | **awaiting** | **awaiting** | **awaiting** | **awaiting** |
+
+**Düsseldorf and Heidelberg** — could you please send us:
+
+1. Your **two values** (`STAMP_GROUND_TRUTH_LABEL`, `STAMP_NUM_CLASSES`) — see §5.
+2. Your **SSH public key** (Step 4) for run-log collection:
+   `ssh-keygen -t ed25519 -C "$(hostname)@mediswarm"` → send `~/.ssh/id_ed25519.pub`
+   to <OPERATOR_CONTACT>. Never the private key.
+3. Confirmation that **Tailscale** is connected and `ping dl3.tud.de` works.
+4. Pass/fail for **Steps 1–3** with the new kit.
+
+---
+
+## 7. Monday 13 July
+
+Given the open target question, we propose to use Monday for an **infrastructure
+dry run**: all four sites start their client, we confirm every node registers with
+the server and completes a couple of short swarm rounds. We then start the **real
+training run** as soon as the target is agreed and each site has re-run Steps 2–3.
+If we do have all four answers before Monday, we will go straight to the real run.
+
+We will send the exact start time on Monday morning.
+
+Thank you all again — the two reports this week genuinely improved the software for
+every site.
+
+Best regards,
+<YOUR NAME>
+DECADE Swarm Operator, TU Dresden

--- a/docs/DECADE_postpone_email_2026-07-13.md
+++ b/docs/DECADE_postpone_email_2026-07-13.md
@@ -1,0 +1,139 @@
+# DECADE consortium — postpone the first swarm run (2026-07-13)
+
+> Send to all four sites. Fill `<YOUR NAME>` / `<OPERATOR_CONTACT>`.
+> Attach each site its new kit (see §4) once the final build is ready.
+
+---
+
+**Subject:** DECADE — first swarm run postponed; new startup kits + the one decision we still need
+
+Dear all,
+
+We are **postponing today's first swarm training run.** Two of the four sites are
+not yet ready, and — more importantly — we have not yet agreed on the **single
+prediction target** that all four sites must share. I would rather delay than burn
+a run on a setup we know is incomplete.
+
+Thank you to **Bonn** and **Mainz**: your reports this week found **five real bugs**,
+all now fixed. Below is where we stand and exactly what we need.
+
+---
+
+## 1. Why we are postponing
+
+Swarm learning trains **one model together**: every site must train the *same*
+architecture on the *same* label with the *same* number of classes. Today:
+
+- **Bonn** is fully ready and configured for **germline syndrome**
+  (Lynch / familial FAP / sporadic — 3 classes).
+- **Mainz** is now running, and proposes **MSI-High** (binary), a **tumour
+  phenotype**.
+- **Düsseldorf** and **Heidelberg** have not yet reported their data or settings.
+
+Bonn's and Mainz's labels answer **different biological questions** and cannot be
+merged or aggregated. Starting a run with mismatched targets would produce a model
+that is meaningless — and because a consortium run has no partial credit (every
+site must complete), a single mismatched site invalidates the whole run.
+
+---
+
+## 2. The decision we need — please reply
+
+Mainz has clarified (thank you, Christina, and Sebastian) that a binary
+**dMMR vs. pMMR** column and **MSI-High** carry essentially the **same biological
+information** — they are two lab routes to the same conclusion. Mainz can supply
+**719 slides / 569 patients** on that basis.
+
+**Our proposal: use MSI status (MSI-High vs. not) as the shared target — binary,
+`STAMP_NUM_CLASSES=2`.** It is the standard, best-populated, most harmonizable
+label in colorectal cancer, and sites can fill it from either MSI or MMR testing.
+
+**Every site, please answer:**
+
+1. Can you provide **MSI status** (MSI-High vs. MSS/MSI-Low), directly or derived
+   from dMMR/pMMR? **How many slides and patients per class?**
+2. What is the **exact column name** in your `clini_table.csv`, and its possible
+   values?
+3. If you cannot provide it, tell us now and say what you *can* provide.
+
+Bonn's germline-syndrome labels remain scientifically interesting, but they are a
+**different study**. We suggest running MSI first, as it is the target all sites
+can realistically share, and revisiting the germline question afterwards.
+
+---
+
+## 3. What Bonn and Mainz found (fixed for everyone)
+
+Both sites hit genuine bugs; every one is fixed in the new kits:
+
+1. **Features extracted with STAMP 2.5.0 were rejected** by the training image
+   (Bonn). Now readable — **no re-extraction needed**.
+2. **Clinical column names containing spaces** (e.g. `Slide ID`) broke the run
+   (Bonn). Fixed.
+3. **`sudo` silently discarded your configuration** (Mainz) — the script now
+   detects it and tells you what to do. *Do not run `docker.sh` with `sudo`.*
+4. **Multi-slide patients loaded 0 patients** (Mainz) — sites using a slide table
+   were silently training on nothing. Fixed and verified. **This one is important:
+   if any of your patients have more than one slide, you need the new kit.**
+5. **Local training (Step 5) ran for only 1 epoch** (Mainz) — so your "baseline"
+   was effectively untrained and not comparable to the swarm model. It now trains
+   properly (32 epochs by default, `STAMP_MAX_EPOCHS`).
+
+Also fixed: a warning several of you saw — *"Found N module(s) in eval mode at the
+start of training"*. This was real: after the first epoch the model kept training
+with dropout disabled. Corrected.
+
+**Please re-run Step 5 with the new kit** so your baseline is a fair comparison.
+
+---
+
+## 4. New startup kits — required
+
+| Site | `SITE_NAME` | Kit |
+|------|-------------|-----|
+| Universitätsklinikum Bonn | `UKB_1` | `UKB_1_1.5.0-dev.260713.6bc06c4.zip` |
+| Universitätsmedizin Mainz | `Mainz_1` | `Mainz_1_1.5.0-dev.260713.6bc06c4.zip` |
+| Universitätsklinikum Düsseldorf | `UKD_1` | `UKD_1_1.5.0-dev.260713.6bc06c4.zip` |
+| Universitätsklinikum Heidelberg | `UKHD_1` | `UKHD_1_1.5.0-dev.260713.6bc06c4.zip` |
+
+**Everyone must switch to the new kit, including Bonn** — the new kits carry fresh
+certificates, so an older kit can no longer connect to the server. If you have a
+client running, please **stop it** and redeploy:
+
+```bash
+cd <SITE_NAME>/startup
+./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --start_client   # only when we say go
+```
+
+Apologies for the extra round-trip, Bonn — this is the cost of the multi-slide and
+epoch fixes landing after your kit was issued.
+
+---
+
+## 5. Düsseldorf and Heidelberg — we need to hear from you
+
+Please send:
+
+1. **MSI status** availability + counts per class (see §2).
+2. Your **SSH public key** (`ssh-keygen -t ed25519 -C "$(hostname)@mediswarm"`,
+   send `~/.ssh/id_ed25519.pub`) to <OPERATOR_CONTACT>.
+3. Confirmation that **Tailscale** is connected and `ping dl3.tud.de` works.
+4. Pass/fail for **Steps 1–3** with the new kit.
+
+If your data or hardware is not ready, please just say so — that is far more useful
+to us than silence.
+
+---
+
+## 6. New date
+
+We will propose a new run date **as soon as we have the target confirmed by all
+four sites** (§2). Realistically that means the run happens once §2 is answered and
+each site has re-run Steps 2, 3 and 5 on the new kit.
+
+Thank you all — and particularly Islem and Christina, whose careful reports made
+the software materially better for every site.
+
+Best regards,
+<YOUR NAME>
+DECADE Swarm Operator, TU Dresden

--- a/docs/DECADE_replies_2026-07-11.md
+++ b/docs/DECADE_replies_2026-07-11.md
@@ -1,0 +1,104 @@
+# DECADE replies — 2026-07-11 (Mainz + Heidelberg)
+
+---
+
+## A) Reply to Christina Glasner (UM Mainz / `Mainz_1`)
+
+**Subject:** Re: DECADE — slide table bug found and fixed
+
+Dear Christina,
+
+Your instinct was exactly right: **the slide table was not being used at all.** This
+was a bug on our side, not a mistake in your setup.
+
+### What was wrong
+
+Our code read `STAMP_SLIDE_TABLE` and passed it to the training step — but the
+patient list was built *earlier*, by a STAMP function that takes **no slide table**
+and instead assumes each patient has exactly one feature file named
+`<patient_id>.h5`. Your H5 files are named per *slide*, so every patient looked
+"missing", the patient list came back empty, and training then failed with the
+confusing `n_samples=0` error.
+
+So any site with multi-slide patients simply could not train. We reproduced your log
+exactly, then fixed it: when `STAMP_SLIDE_TABLE` is set we now use STAMP's real
+slide-table path (slide → patient mapping, then pooling each patient's slides into
+one bag).
+
+Verified on data shaped like yours: **48 slides → 24 patients**, training proceeds.
+We also made the failure mode honest — if no patients can be matched you now get a
+message naming the tables, the columns and the fix, instead of `n_samples=0`.
+
+### What you need to do
+
+Use the **new `Mainz_1` startup kit** (attached), keep your `STAMP_SLIDE_TABLE`
+export exactly as you had it, and re-run Steps 2 and 3:
+
+```bash
+export STAMP_SLIDE_TABLE="/data/Mainz_1/slide_table.csv"
+export STAMP_PATIENT_LABEL="PATIENT"      # your patient column, in BOTH tables
+export STAMP_FILENAME_LABEL="FILENAME"    # your slide-filename column
+```
+
+(Use your real column names if they differ — and remember `/data/...` are paths
+*inside* the container.)
+
+Thank you for the precise report — you have now found two genuine bugs for the
+consortium.
+
+Best regards,
+Jeff
+
+---
+
+## B) Reply to Christian Zöllner (UK Heidelberg / `UKHD_1`)
+
+**Subject:** Re: DECADE — Tailscale invite + the shared target
+
+Dear Christian,
+
+Thanks — SSH key **received and authorized**, nothing further needed there.
+
+### Tailscale
+
+I checked our tailnet: there is currently **no Heidelberg machine registered at all**
+(the only DECADE nodes are Bonn, Mainz and Düsseldorf). So nothing was lost — the
+node simply was never added, which is why none of your addresses are recognised.
+
+I am sending you a **fresh invitation to `ckobrow@mailbox.org`** (the address you
+wrote from). Accept it, connect the Heidelberg machine, then:
+
+```bash
+tailscale status          # your node should appear
+ping dl3.tud.de           # should answer from 100.100.101.100
+```
+
+Make sure `/etc/hosts` contains `100.100.101.100  dl3.tud.de  dl3`. If you'd rather
+we invite a different address, just say which.
+
+### "But don't we all need the same training target?"
+
+**Yes — exactly right, and that's the crux.** Swarm learning trains *one* shared
+model, so every site must use the identical label with the identical classes in the
+identical order. That is why we have been holding this decision.
+
+Good news: your **`Sporadic vs. Familial`** is the same label family Bonn proposed,
+so **Heidelberg and Bonn already agree**. Mainz has a different kind of label
+(tumour MSI/MMR phenotype). We are resolving this now and will send the final
+`STAMP_GROUND_TRUTH_LABEL` + `STAMP_NUM_CLASSES` to everybody.
+
+Two questions for you so we can line the sites up:
+
+1. **`not provided`** — we read this as *missing data*, not a real biological class.
+   We would **exclude** those patients rather than train a third class on them. How
+   many of your cases are `not provided`, and do you agree?
+2. So your usable labels are **`Lynch syndrome` vs `Sporadic`** — how many cases in
+   each? (Bonn additionally has a *familial CRC / FAP* group; if you have no such
+   cases, the common denominator across sites is the binary **Lynch vs. Sporadic**.)
+3. Do you *also* have **MSI status** or **dMMR/pMMR**? That would tell us whether a
+   tumour-phenotype target is feasible for everyone (Mainz's proposal).
+
+Once you and Mainz answer, we can fix the target for all four sites.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_Heidelberg_2026-07-14.md
+++ b/docs/DECADE_reply_Heidelberg_2026-07-14.md
@@ -1,0 +1,76 @@
+# Reply to Christian Zoellner (Heidelberg / UKHD_1) — 2026-07-14
+
+**Subject:** Re: DECADE — `--GPU` is fine; your `$SCRATCHDIR` is empty
+
+Dear Christian,
+
+You're not missing anything — `--GPU device=0` **is** valid. The error message is
+lying to you, and that's our bug.
+
+## What actually happened
+
+Your `$SCRATCHDIR` was never exported (or is empty). The shell expands it to
+nothing, so this:
+
+```bash
+./docker.sh --scratch_dir $SCRATCHDIR --GPU device=0 --dummy_training
+```
+
+is what *you* typed, but what `docker.sh` actually receives is:
+
+```bash
+./docker.sh --scratch_dir --GPU device=0 --dummy_training
+```
+
+`--scratch_dir` then swallows `--GPU` as its value, and `device=0` is left over as
+an unrecognised argument — hence `Unknown parameter passed: device=0`, blaming the
+one flag that was correct.
+
+## Fix on your side (30 seconds)
+
+```bash
+export SCRATCHDIR=/path/to/a/writable/scratch/folder
+mkdir -p $SCRATCHDIR
+echo "SCRATCHDIR=[$SCRATCHDIR]"          # must NOT be empty
+
+./docker.sh --scratch_dir $SCRATCHDIR --GPU device=0 --dummy_training 2>&1 | tee dummy_training_console_output.txt
+```
+
+Quick check before any step — if either prints `[]`, that's your problem:
+
+```bash
+echo "DATADIR=[$DATADIR] SCRATCHDIR=[$SCRATCHDIR]"
+```
+
+Also: please **don't** run `docker.sh` with `sudo` — it discards these variables
+entirely (a different site lost an afternoon to that one).
+
+## Fix on our side
+
+The script now refuses an empty value and says so plainly:
+
+```
+❗ Option --scratch_dir requires a value, but got '--GPU'.
+   This usually means a shell variable is empty or was never exported.
+```
+
+That will be in the next kit — your current one is fine, just export the variable.
+
+## While you're here
+
+Whenever you get a chance, we still need from Heidelberg:
+
+1. **MSI status** — can you provide MSI-High vs. MSS/MSI-Low (directly, or derived
+   from dMMR/pMMR)? How many slides and patients per class? What's the exact column
+   name and its values?
+2. Your **SSH public key** (`ssh-keygen -t ed25519 -C "$(hostname)@mediswarm"` →
+   send `~/.ssh/id_ed25519.pub`).
+3. Confirmation that **Tailscale** is connected and `ping dl3.tud.de` works.
+
+No rush on the run itself — it's postponed until the target is settled.
+
+Thanks for reporting this; the error message was genuinely misleading and is now
+fixed for everyone.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_Mainz_2026-07-10.md
+++ b/docs/DECADE_reply_Mainz_2026-07-10.md
@@ -1,0 +1,115 @@
+# Reply to Christina Glasner (UM Mainz / Mainz_1) — 2026-07-10
+
+**Subject:** Re: DECADE — checks + 2 values before Monday 13 July
+
+Dear Christina,
+
+Great report — you found a real trap, and the answer to the bolded paragraph is
+short: **it's `sudo`.**
+
+## Why `echo` works but the training doesn't
+
+`sudo` resets the environment. So although `STAMP_CLINI_TABLE` is exported in
+*your* shell (which is why `echo` prints it), `sudo ./docker.sh …` starts
+`docker.sh` with a **clean environment**, it sees no `STAMP_*` variables, forwards
+none into the container, and training dies with `KeyError: 'STAMP_CLINI_TABLE'`.
+
+We measured it on one of our clients:
+
+| command | `STAMP_*` variables visible to `docker.sh` |
+|---|---|
+| `sudo ./docker.sh …` | **0** |
+| `sudo -E ./docker.sh …` | all of them |
+| `./docker.sh …` (no sudo) | all of them |
+
+### Fix — pick either
+
+**Preferred** (run Docker without `sudo`; one-time setup, then log out/in):
+
+```bash
+sudo usermod -aG docker $USER
+newgrp docker                      # or just re-login
+./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check
+```
+
+**Fallback** (keep `sudo`, preserve the environment):
+
+```bash
+sudo -E ./docker.sh --data_dir $DATADIR --scratch_dir $SCRATCHDIR --GPU device=0 --preflight_check
+```
+
+Quick check of what `docker.sh` will actually forward: `env | grep '^STAMP_'`.
+
+Thanks to your report, the **new kit now detects this** and prints exactly what to
+do instead of a Python traceback.
+
+## Multi-slide patients — yes, use a slide table
+
+Exactly right, you need one. Your `clini_table.csv` has one row per **patient**,
+while `features/` has one `.h5` per **slide**. A slide table maps between them so
+STAMP pools all of a patient's slides into a single bag:
+
+```bash
+export STAMP_SLIDE_TABLE="/data/Mainz_1/slide_table.csv"
+export STAMP_PATIENT_LABEL="PATIENT"     # patient-ID column (both tables)
+export STAMP_FILENAME_LABEL="FILENAME"   # slide-filename column (slide table)
+```
+
+`slide_table.csv` — one row per slide:
+
+| PATIENT | FILENAME |
+|---------|----------|
+| P_001   | slide_001.h5 |
+| P_001   | slide_002.h5 |
+| P_002   | slide_003.h5 |
+
+`FILENAME` must match the files in your `features/` directory. (Use whatever your
+real column names are and set `STAMP_PATIENT_LABEL` / `STAMP_FILENAME_LABEL`
+accordingly — column names with spaces are fine in the new kit.)
+
+## New startup kit
+
+Please use the new **`Mainz_1`** kit attached
+(`Mainz_1_1.5.0-dev.260710.a295c6b.zip`) — you are currently on an older one
+(`…260706.9b0148b`). Besides the `sudo` diagnostic, it also fixes reading features
+extracted with STAMP 2.5.0 and column names containing spaces.
+
+## SSH key
+
+Received and **authorized** — nothing further needed.
+
+## Prediction target — not settled yet
+
+Thank you for the concrete options; this is the piece we still have to align
+across all four centres, because swarm training requires **every site to train
+the identical model** (same classes, in the same order).
+
+Two observations we'd like your view on:
+
+1. **`MSI-High` (binary, yes/no, 678 slides)** looks like the most harmonizable
+   target — it is the standard, widely available CRC label. Bonn has proposed
+   germline-syndrome labels (Lynch / familial / sporadic), which are a *different*
+   kind of label from a tumour MSI/MMR phenotype, so we cannot simply merge them.
+2. Your **`dMMR` column mixes two things**: MMR *status* (`pMMR`, `dMMR`) and the
+   *specific protein loss* (`MLH1`, `MSH6`, `MLH1, PMS2`, `MSH2, MSH6`). As six
+   classes over 103 slides it would be very sparse. If we go this route we would
+   almost certainly collapse it to **binary dMMR vs pMMR**.
+
+So: **do you also have MSI status and/or a clean binary dMMR/pMMR column?** That
+would let us line the centres up on one target. We will confirm
+`STAMP_GROUND_TRUTH_LABEL` + `STAMP_NUM_CLASSES` to everyone once Düsseldorf and
+Heidelberg reply.
+
+## Next steps for you
+
+1. Unpack the new `Mainz_1` kit.
+2. Re-run Step 2 **without `sudo`** (or with `sudo -E`).
+3. Steps 3 and 5 should then work; hold the final Step 5 until we confirm the
+   target.
+
+A call is not necessary unless you'd still like one — the `sudo` change should
+unblock you immediately. Sorry for the lost afternoon, and thank you for the
+precise output; it let us fix this for every centre.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_Mainz_2026-07-13.md
+++ b/docs/DECADE_reply_Mainz_2026-07-13.md
@@ -1,0 +1,49 @@
+# Reply to Christina Glasner (UM Mainz / Mainz_1) — 2026-07-13 (short)
+
+**Subject:** Re: DECADE — you found two real bugs; new kit attached
+
+Dear Christina,
+
+You were right to be suspicious. Two of the three were **genuine bugs**, and you
+found them.
+
+**1. `max_epochs = 1` — a real bug.** Not intentional. Local training was using the
+preflight's 1-epoch default instead of `STAMP_MAX_EPOCHS` (32), so every site's
+"baseline" was effectively untrained — and that baseline is exactly what we compare
+the swarm model against. Fixed; local training now runs 32 epochs.
+
+**2. The "modules in eval mode" warning — a worse bug.** Our prediction callback
+switched the model to `eval()` and never switched it back, so from the **second
+epoch onward** (and in the swarm, from the second round onward) the model trained
+with **dropout disabled**. We measured it directly:
+
+| epoch | before | after |
+|---|---|---|
+| 0 | train | train |
+| **1** | **eval** ❌ | train ✅ |
+| **2** | **eval** ❌ | train ✅ |
+
+Fixed. This would have quietly degraded every model we trained — thank you.
+
+**3. The rsync warnings — expected.** The live-sync helper pushes only **logs and
+metrics** (never data or features) to our monitoring host, so we can see what
+happened at your site when comparing baselines. It's non-fatal by design. You saw
+warnings because your SSH key wasn't authorized yet — it is now, so you should see
+`SSH OK — live sync enabled`. Say the word if you'd rather we disable it.
+
+**4. Target — agreed.** Your discussion with Sebastian is exactly what we needed.
+Since binary dMMR/pMMR and MSI-High carry the same information, and you have
+**719 slides / 569 patients**, we're proposing **MSI-High (binary)** to the whole
+consortium as the shared target, and dropping the mixed six-value `dMMR` column.
+The open question is Bonn, whose labels are germline syndrome.
+
+**Please take the new kit** (attached, `Mainz_1_1.5.0-dev.260713.6bc06c4.zip`) and
+re-run **Steps 2, 3 and 5**. Besides the two fixes above, it contains one that
+matters specifically to you: **multi-slide patients previously loaded 0 patients** —
+if you were using a slide table, you were silently training on nothing (verified:
+0 → 15 in our test). Keep `sudo` out of it (or use `sudo -E`).
+
+The run is postponed (see the consortium mail), so there's no time pressure.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_Mainz_2026-07-13b.md
+++ b/docs/DECADE_reply_Mainz_2026-07-13b.md
@@ -1,0 +1,81 @@
+# Reply to Christina Glasner (UM Mainz / Mainz_1) — 2026-07-13 (follow-up)
+
+**Subject:** Re: DECADE — you were right again: the rsync failures were real
+
+Dear Christina,
+
+You were right to push back on both. One of them I mis-reported, and the other
+turned out to be a serious bug that you have now found for us. Thank you — and
+sorry for telling you it was fixed when it wasn't.
+
+## 1. The rsync warnings — a real bug, and a bad one
+
+Not expected after all. Uploads were failing for **every site**, and the cause was
+on **our** server, not yours.
+
+Our upload account is protected by a restricted-rsync wrapper. It turns out that
+wrapper takes an **exclusive lock on the whole upload area**, so only **one site in
+the entire consortium can upload at a time**. Bonn's live-sync daemon was holding
+that lock, and every upload from Mainz was refused:
+
+```
+rrsync error: Another instance of rrsync is already accessing this directory.
+```
+
+That is exactly the contradiction you spotted: `SSH OK — live sync enabled` (the
+connection works) followed by a stream of rsync errors (every transfer refused).
+
+Had we started the swarm run, we would have been **blind** — no logs, no
+heartbeats, no checkpoints from any site but the first. Fixed on our monitoring
+host; uploads now succeed, including from several sites at once. **Nothing for you
+to do**, and no new kit is needed for this — it was purely server-side.
+
+## 2. The "eval mode" warning — my previous answer was imprecise
+
+There were **two** separate things, and I conflated them:
+
+- **The real bug** — from the second epoch onward the model was training with
+  **dropout disabled**. That *is* fixed in your kit; I verified it by measuring the
+  module state at every training batch.
+- **The warning you still see** — a *different* cause that I had not found: we
+  validate the model before training it, which leaves it in eval mode, and Lightning
+  then prints the warning at the start of `fit`. Lightning immediately puts the
+  model back into training mode, so **your training is correct** — but the warning is
+  noise and I should not have claimed it was gone.
+
+Now fixed properly at the source (we restore training mode explicitly). It will
+disappear in the next kit. In the meantime: **your current run is fine** — please
+let it finish.
+
+## 3. Everything else
+
+Confirmed on your side: **32 epochs** — that fix landed. Together with the
+multi-slide fix, your Step 5 is now a genuine baseline.
+
+## 4. Your MSI numbers — thank you, this is exactly what we needed
+
+Recorded:
+
+| | |
+|---|---|
+| Column | `MSI-High` |
+| Values | `yes` / `no` |
+| Cohort | 719 slides, 569 patients |
+| Split | **61 positive / 508 negative** patients |
+
+So `STAMP_NUM_CLASSES=2`, `STAMP_GROUND_TRUTH_LABEL=MSI-High`.
+
+One thing worth flagging now rather than after a run: at roughly **11 % positives**,
+the classes are quite imbalanced. That is normal and workable for MSI, but it means
+we should judge the model on **AUROC** rather than accuracy (a model that predicts
+"no" for everyone would already be ~89 % "accurate"). We will keep an eye on it.
+
+We are still waiting on Bonn (whose labels are germline syndrome, a different
+question) and on Düsseldorf and Heidelberg before we can fix the target for
+everyone.
+
+Thanks again — that is now three real bugs from your reports, including one that
+would have left us blind during the run.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_UKB_Bonn_2026-07-08.md
+++ b/docs/DECADE_reply_UKB_Bonn_2026-07-08.md
@@ -1,0 +1,51 @@
+# Reply to Islem Gammoudi (UKB Bonn / UKB_1) — 2026-07-08
+
+**Subject:** Re: DECADE — please complete these checks + send us 2 values before Monday 13 July
+
+Dear Islem,
+
+Thank you — this is exactly the detail we needed, and great to see everything
+passing on your side (RTX A6000, 1197 slides, val_loss 0.031 all look excellent).
+
+A few answers and next steps:
+
+**SSH key** — received and **authorized** on our monitoring host. Nothing further
+needed; your live-sync will connect automatically during the run once you're on
+Tailscale with the `/etc/hosts` entry.
+
+**Startup kit** — please use the **`UKB_1` startup kit we provide** (with the
+`docker.sh` wrapper), not the `mediswarm-stamp-1.4.5` source package — the source
+is superseded and won't match the swarm. Importantly, we just fixed an issue where
+the kit mishandled clinical column names containing a **space**, so I'm sending you
+an **updated `UKB_1` kit** that handles your `Slide ID` column directly. Please
+unpack it, `cd UKB_1/startup`, and run everything via `./docker.sh`.
+
+**Patient/ID column (`STAMP_PATIENT_LABEL`)** — no need to rename anything: with the
+updated kit you can set `STAMP_PATIENT_LABEL="Slide ID"` (keep the quotes). The
+values in that column must match your H5 filenames (without `.h5`). If any patient
+has multiple slides and you provide a slide table, also set `STAMP_SLIDE_TABLE` and
+`STAMP_FILENAME_LABEL`, and let us know.
+
+**Prediction target** — we're finalizing the **single shared target** to be used by
+all four sites, because federated training requires everyone to train the *same*
+model (same class definitions and count). Both of your options are viable; please
+**hold on the target for now** — we'll confirm the agreed one (and its
+`STAMP_NUM_CLASSES`) with the whole consortium this week, then you'd point
+`STAMP_GROUND_TRUTH_LABEL` at whichever of your columns encodes it.
+
+**Feature extractor** — we're standardizing on **one** extractor across all sites so
+the feature dimensions match. **UNI (1024-dim)** is our working assumption, so your
+UNI extraction (ready ~July 9) is perfect — please continue it and set
+`STAMP_DIM_INPUT=1024`. If the consortium ends up choosing UNI2 (1536) instead
+(you already have it), we'll let you know and you'd set `STAMP_DIM_INPUT=1536`.
+Your updated stats by Friday are exactly what we need.
+
+So the two things pending on your side: (1) finish the UNI features and re-run
+Steps 2–5 with the **new kit's** `docker.sh`, and (2) wait for our confirmation of
+the shared target + extractor (this week). Everything else is done.
+
+Thanks again for the careful work — please reach out if anything in the new kit
+behaves differently from your source runs.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_UKB_Bonn_2026-07-09.md
+++ b/docs/DECADE_reply_UKB_Bonn_2026-07-09.md
@@ -1,0 +1,79 @@
+# Reply to Islem Gammoudi (UKB Bonn / UKB_1) — 2026-07-09
+
+**Subject:** Re: DECADE — checks + 2 values before Monday 13 July
+
+Dear Islem,
+
+Thank you — both issues are clear, and the STATISTICS screenshots are very helpful.
+Good news: **you do not need to re-extract anything.**
+
+## Issue 1 — STAMP version mismatch: fixed on our side
+
+You diagnosed this correctly. Your features were extracted with STAMP **2.5.0**,
+and the training image shipped STAMP 2.4.0, which refuses to read newer features.
+
+We cannot simply upgrade the image to STAMP 2.5.0: STAMP 2.5.0 requires **Python
+3.13**, while the swarm-learning stack inside the image (NVFlare + PyTorch)
+runs on Python 3.11. Instead we verified that reading 2.5.0-extracted features on
+2.4.0 is safe — between the two versions the feature H5 layout is identical and
+the **UNI extractor source is byte-identical**, so your features are numerically
+exactly what 2.4.0 would have produced. The version check is a conservative guard,
+not a format change.
+
+We have therefore updated the image so it accepts features extracted by STAMP up
+to 2.5.0 (anything newer still raises, deliberately). We tested precisely your
+situation — 2.5.0-extracted features **with a `Slide ID` column** — end to end.
+
+**What you need to do:** use the **new `UKB_1` startup kit** attached
+(`UKB_1_1.5.0-dev.260709.8afff27.zip`). It pins the updated image
+(`jefftud/decade:1.5.0-dev.260709.8afff27`), which `docker.sh` will pull for you.
+Keep your existing UNI (1024-dim) features from STAMP 2.5.0 — no re-extraction.
+
+For the consortium we are standardizing on **extraction with STAMP 2.5.0**, which
+is what you already have.
+
+This kit also contains the fix for column names with spaces, so you can set:
+
+```bash
+export STAMP_PATIENT_LABEL="Slide ID"
+export STAMP_DIM_INPUT=1024
+```
+
+## Issue 2 — Tailscale
+
+Nothing is wrong on your machine: your `/etc/hosts` entry (`100.100.101.100
+dl3.tud.de`) is correct. The problem is that your node is currently joined to your
+**personal** tailnet rather than the DECADE tailnet, so the address is
+unreachable.
+
+Jeff is resending the DECADE Tailscale invitation to **islemislem65@gmail.com**.
+After you accept it and reconnect, please check:
+
+```bash
+tailscale status        # should list the DECADE tailnet / dl3
+ping dl3.tud.de         # should reply from 100.100.101.100
+```
+
+## Prediction target — still pending
+
+Thank you for both options and the statistics. Because swarm training requires
+**all four sites to train the identical model** (same classes, same order), we are
+waiting for Mainz, Düsseldorf and Heidelberg to confirm they can label the same
+target. We will send the final decision (`STAMP_GROUND_TRUTH_LABEL` +
+`STAMP_NUM_CLASSES`) as soon as we have it — most likely early next week. Please
+hold on that until then.
+
+## Summary of what to do next
+
+1. Unpack the **new** `UKB_1` startup kit and use its `docker.sh` (not the
+   `mediswarm-stamp` source package).
+2. Accept the new Tailscale invitation, reconnect, confirm `ping dl3.tud.de`.
+3. Re-run Steps 1–5 with the new kit and your existing UNI features
+   (`STAMP_DIM_INPUT=1024`, `STAMP_PATIENT_LABEL="Slide ID"`).
+4. Await our target confirmation before Monday's run.
+
+Thanks again for the precise reports — the STAMP-version issue would have hit the
+other sites too, and you caught it early.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_UKB_Bonn_2026-07-13.md
+++ b/docs/DECADE_reply_UKB_Bonn_2026-07-13.md
@@ -1,0 +1,42 @@
+# Reply to Islem Gammoudi (UKB Bonn / UKB_1) — 2026-07-13 (short)
+
+**Subject:** Re: DECADE — please stop your client; new kit attached
+
+Dear Islem,
+
+Thank you — UKB_1 was the first site fully ready, and your reports fixed real bugs
+for everyone. Two things, and I'm sorry about the first one.
+
+**1. Please stop your client.** The run is postponed (see the consortium mail), so
+the server is deliberately not up and your client is retrying into nothing:
+
+```bash
+docker ps                      # find the stamp_swarm_client_UKB_1_* container
+docker stop <that container>
+```
+
+**2. You need the new kit** (attached, `UKB_1_1.5.0-dev.260713.6bc06c4.zip`).
+Please discard `…a295c6b`. Two fixes since then affect you — local training only
+ran **1 epoch** (so your baseline was effectively untrained), and the model was
+training with **dropout disabled** after the first epoch. Also, the new kits carry
+fresh certificates, so the old one can no longer connect.
+
+When you have a moment (no rush): unpack it and re-run **Step 5** — it now trains
+32 epochs and gives us a real baseline. Please don't start the client again until
+we send the go-ahead.
+
+**One question.** Your target is **germline syndrome** (Lynch / FAP / sporadic,
+3 classes). Mainz can only provide **MSI status** (binary) — a different biological
+question, and swarm learning needs all four sites on the *same* label. We're
+therefore proposing MSI as the shared target:
+
+> **Do you have MSI status (MSI-High vs. MSS/MSI-Low), or dMMR/pMMR — and how many
+> slides/patients per class?**
+
+Your germline question is a good one and we'd like to return to it as a follow-up
+study once the first run has proven the setup.
+
+Apologies for the extra round-trip after you had everything working.
+
+Best regards,
+Jeff

--- a/docs/DECADE_reply_UKB_Bonn_2026-07-14.md
+++ b/docs/DECADE_reply_UKB_Bonn_2026-07-14.md
@@ -1,0 +1,56 @@
+# Reply to Islem Gammoudi (UKB Bonn / UKB_1) — 2026-07-14
+
+**Subject:** Re: DECADE — thanks; your MSI answer changes the target question
+
+Dear Islem,
+
+Thank you — and a very clean baseline: 32 epochs, val loss 0.350 → 0.031 on 1174
+patients. That's exactly what we needed.
+
+## Your MSI answer is the important part
+
+To be explicit, because it changes the plan: **Bonn cannot currently supply MSI
+status.** The `MSI-High` and `dMMR` columns exist but every slide reads
+*not provided*. So the MSI target we proposed to the consortium is **not achievable
+across all four sites** as things stand.
+
+**One thing we should not do**, even though it's tempting: derive MSI from Lynch
+status. You're right that Lynch patients are biologically dMMR/MSI-High — but the
+converse doesn't hold. **Sporadic MSI-High tumours** (typically MLH1
+hypermethylated) are common, and they would be labelled "MSI-negative" simply
+because the patient has no germline variant. That would systematically mislabel a
+large part of the negative class and quietly corrupt the model. Lynch-vs-sporadic
+is a *germline* question; MSI is a *tumour* phenotype. They are genuinely different
+labels, not two names for the same thing.
+
+So: **please do check with Dr. Robert and Dr. Jacob** whether any real MSI or MMR
+testing exists for your cohort (even for a subset — a partial cohort with a *true*
+MSI label is far more useful than a full cohort with a derived one). That answer
+now determines the consortium's target.
+
+## Where this leaves us
+
+| target | Bonn | Mainz | verdict |
+|---|---|---|---|
+| **MSI-High** (binary) | ❌ not provided | ✅ 569 patients (61 pos / 508 neg) | blocked on your answer |
+| **Lynch vs. Sporadic** (binary) | ✅ 1174 | ❓ needs a germline label | possible alternative |
+
+If Bonn genuinely has no MSI data, the honest options are (a) Mainz/Düsseldorf/
+Heidelberg supply a germline label so we run Lynch-vs-sporadic, or (b) we run MSI
+without Bonn — which we'd rather avoid. We'll decide once Düsseldorf (by Wed) and
+Heidelberg have reported.
+
+## Server
+
+Not up yet, and won't be until the target is agreed — so **please leave your client
+stopped**. I'll write to everyone with a date and a go-ahead; you won't have to
+guess.
+
+Your `Affected Gene in the Germline` (MLH1, MSH2, MSH6, PMS2, EPCAM, APC) and
+adenoma dysplasia grades are noted — we may come back to those for the follow-up
+study.
+
+Thanks again for the speed and the care.
+
+Best regards,
+Jeff


### PR DESCRIPTION
Records what was sent to the four DECADE sites during first-run prep — the new kits, each bug we fixed for them (sudo/env, slide table, STAMP 2.5.0 features, column names with spaces), and the still-open shared-target question.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)