### PR TITLE
CI: fix STAMP Deploy Test 'Prepare local evaluation data' step (always failing)

### DIFF
--- a/.github/workflows/stamp-deploy-test.yml
+++ b/.github/workflows/stamp-deploy-test.yml
@@ -144,13 +144,23 @@ jobs:
           # Generate a synthetic STAMP dataset and remap the first generated
           # site dir to the deploy eval-site name (default: first client site).
           VERSION=$(./scripts/build/getVersionNumber.sh)
-          image="jefftud/odelia:$VERSION"
+          # Derive the image from the provision YAML's docker_image line (the build
+          # script uses the same source), so non-odelia projects (e.g. DECADE =
+          # jefftud/decade) work. Falls back to the historical default.
+          image=$(grep -m1 "docker_image:" "$DEPLOY_PROJECT_FILE" 2>/dev/null \
+            | sed 's/.*docker_image:[[:space:]]*//' \
+            | sed "s/__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__/$VERSION/")
+          image="${image:-jefftud/odelia:$VERSION}"
+          echo "Using image: $image"
 
           eval_root="$GITHUB_WORKSPACE/stamp_eval_data"
           rm -rf "$eval_root"; mkdir -p "$eval_root"
 
+          # The image's WORKDIR is /workspace, but the source lives at /MediSwarm,
+          # so the script must be addressed by absolute path (a relative path fails
+          # with "can't open file '/workspace/application/...'").
           docker run --rm -v "$eval_root":/data "$image" \
-            python3 application/jobs/STAMP_classification/app/scripts/create_synthetic_dataset/create_synthetic_stamp_dataset.py /data
+            python3 /MediSwarm/application/jobs/STAMP_classification/app/scripts/create_synthetic_dataset/create_synthetic_stamp_dataset.py /data
 
           # Resolve the eval site name from the conf (first client site).
           eval_site_name=$(bash -c \


### PR DESCRIPTION
## Problem

The **STAMP Deploy Test** workflow fails on `main` at
**"Prepare local evaluation data on Cosmos"** — and has done on every run with
`evaluate=true` (latest: `main` @ `fea266f`, run 29231124276):

```
python3: can't open file
'/workspace/application/jobs/STAMP_classification/app/scripts/create_synthetic_dataset/create_synthetic_stamp_dataset.py':
[Errno 2] No such file or directory
```

## Root causes

1. **Relative script path.** The image's `WORKDIR` is `/workspace`, but the source
   is copied to `/MediSwarm` — so the relative path resolves to a directory that
   does not exist. Confirmed:
   ```
   WORKDIR=/workspace
   /workspace has NO application/ dir
   /MediSwarm has: create_synthetic_stamp_dataset.py
   ```
2. **Hardcoded image name** (`image="jefftud/odelia:$VERSION"`), so the step can
   never work for a non-odelia project — DECADE builds `jefftud/decade`.

## Fix

Use the absolute `/MediSwarm/...` path, and derive the image from the provision
YAML's `docker_image:` line (the same source `scripts/build` and
`run_stamp_deploy_test.sh` use), falling back to the historical default.

## Verification

The fixed command generates the synthetic dataset against the real image:

```
$ docker run --rm -v /tmp/citest2:/data jefftud/decade:1.5.0-dev.260710.a295c6b \
    python3 /MediSwarm/application/.../create_synthetic_stamp_dataset.py /data
Ground truth label: Diagnosis
generated: client_A
generated: client_B
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)