### PR TITLE
STAMP: local baseline trained 1 epoch; prediction callback left the model in eval mode

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/main.py
+++ b/application/jobs/STAMP_classification/app/custom/main.py
@@ -46,8 +46,19 @@ elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
     SITE_NAME = os.getenv("SITE_NAME")
     if not SITE_NAME:
         raise ValueError("SITE_NAME environment variable must be set for local training")
+    # The two modes want very different epoch budgets:
+    #   preflight_check  — a smoke test: 1 epoch is the point.
+    #   local_training   — the site's *baseline*, which the swarm model is compared
+    #                      against. It must train properly, so it follows
+    #                      STAMP_MAX_EPOCHS (STAMP's own default: 32).
+    # Defaulting both to NUM_EPOCHS=1 silently produced a 1-epoch baseline, making
+    # the swarm-vs-local comparison meaningless.
+    if TRAINING_MODE == TM_LOCAL_TRAINING:
+        default_epochs = os.getenv("STAMP_MAX_EPOCHS", "32")
+    else:
+        default_epochs = "1"
     try:
-        NUM_EPOCHS = int(os.getenv("NUM_EPOCHS", "1"))
+        NUM_EPOCHS = int(os.getenv("NUM_EPOCHS", default_epochs))
     except ValueError:
         raise ValueError("NUM_EPOCHS must be an integer")
     USE_WEIGHTED_EPOCHS = False

--- a/application/jobs/STAMP_classification/app/custom/stamp_metrics_callback.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_metrics_callback.py
@@ -136,8 +136,17 @@ class STAMPPredictionCallback(Callback):
         self.csv_valid = output_dir / FILENAME_GT_PREDPROB_SITE_VALIDATION
 
     def on_train_epoch_end(self, trainer: Any, pl_module: Any) -> None:
-        """Run inference on train/val sets and write prediction CSVs."""
+        """Run inference on train/val sets and write prediction CSVs.
+
+        Restores the module's original train/eval mode afterwards: ``_write_predictions``
+        switches the model to ``eval()``, and Lightning does **not** put it back before
+        the next epoch. Leaking eval mode meant every epoch after the first (and every
+        swarm round after the first, since NVFlare calls ``fit()`` per round) trained
+        with dropout disabled — which Lightning reports as
+        "Found N module(s) in eval mode at the start of training".
+        """
         epoch = trainer.current_epoch
+        was_training = pl_module.training
 
         try:
             self._write_predictions(pl_module, self.train_dl, epoch, self.csv_train)
@@ -145,6 +154,9 @@ class STAMPPredictionCallback(Callback):
         except Exception as e:
             # Don't crash training if prediction CSV writing fails
             logger.warning(f"STAMPPredictionCallback failed at epoch {epoch}: {e}")
+        finally:
+            if was_training:
+                pl_module.train()
 
     @torch.no_grad()
     def _write_predictions(

--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -583,6 +583,13 @@ def validate_and_train(
             model, train_dl, valid_dl, current_round, output_dir,
         )
 
+    # trainer.validate() (and the prediction export above) leave the module in
+    # eval mode, and Lightning does not restore it before fit(). It warns
+    # "Found N module(s) in eval mode at the start of training" — which alarmed
+    # sites — and, more importantly, any module left in eval would train with
+    # dropout disabled. Put it back explicitly.
+    model.train()
+
     logger.info("--- Train new model ---")
     trainer.fit(model, train_dataloaders=train_dl, val_dataloaders=valid_dl)
 


### PR DESCRIPTION
Both found by **UM Mainz** from a real Step-5 run. Both are training-correctness
bugs, not cosmetics.

## 1. `--local_training` trained for a single epoch

`main.py` took the epoch budget from `NUM_EPOCHS` (default **1**) for *both*
`preflight_check` and `local_training`, and passed it to `prepare_training()` as
`max_epochs` — overriding `STAMP_MAX_EPOCHS` (STAMP's default: 32).

One epoch is correct for the preflight smoke test. But the **local baseline is what
the swarm model is compared against** (`--compare-local`, #275), so every site's
baseline was effectively untrained and the comparison meaningless.

`local_training` now defaults to `STAMP_MAX_EPOCHS`; `preflight_check` keeps 1;
`NUM_EPOCHS` still overrides both.

**Verified** (real run, synthetic site):

| mode | last epoch |
|---|---|
| `preflight_check` | `Epoch 0/0` (1 epoch) |
| `local_training` | `Epoch 31/31` (32 epochs) |

## 2. The prediction callback leaked eval mode into training

`STAMPPredictionCallback._write_predictions()` calls `model.eval()`, and nothing put
the module back. Lightning does not restore it either — so **every epoch after the
first, and every swarm round after the first** (NVFlare calls `fit()` once per
round), trained with **dropout disabled**. This is the
`Found N module(s) in eval mode at the start of training` warning sites reported.

Fixed by restoring the previous mode in a `finally` block.

**Verified** by instrumenting `on_train_batch_start` and measuring the module modes
in a real 3-epoch run:

| epoch | before | after |
|---|---|---|
| 0 | train (36/0) | train (36/0) |
| **1** | **eval (0/36)** | train (36/0) |
| **2** | **eval (0/36)** | train (36/0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)