### PR TITLE
STAMP docker.sh: require a value for --data_dir/--scratch_dir/--GPU (empty var swallows the next flag)

### DIFF
--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -714,12 +714,33 @@ docker_cln_sh: |
       TTY_OPT=""
   fi
 
+  # Require a real value for options that take one. An unset shell variable —
+  # e.g. `--scratch_dir $SCRATCHDIR` when SCRATCHDIR was never exported — expands
+  # to nothing, so the option silently swallows the *next* flag and the argument
+  # after that is reported as unknown. A site hit exactly this:
+  #     ./docker.sh --scratch_dir $SCRATCHDIR --GPU device=0 --dummy_training
+  #     Unknown parameter passed: device=0
+  # ...which blames --GPU, when the real problem is an empty $SCRATCHDIR.
+  _need_value() {
+      # $1 = option name, $2 = the value we are about to consume
+      if [ -z "${2:-}" ] || case "${2:-}" in --*) true ;; *) false ;; esac; then
+          echo "❗ Option $1 requires a value, but got '${2:-<nothing>}'."
+          echo ""
+          echo "   This usually means a shell variable is empty or was never exported."
+          echo "   Check them first:"
+          echo "       echo \"DATADIR=[\$DATADIR] SCRATCHDIR=[\$SCRATCHDIR]\""
+          echo "   Then set the missing one, e.g.:"
+          echo "       export SCRATCHDIR=/path/to/scratch && mkdir -p \$SCRATCHDIR"
+          exit 1
+      fi
+  }
+
   # Parse command-line arguments
   while [[ "$#" -gt 0 ]]; do
       case $1 in
-          --data_dir)            MY_DATA_DIR="$2"; shift ;;
-          --scratch_dir)         MY_SCRATCH_DIR="$2"; shift ;;
-          --GPU)                 GPU2USE="$2"; shift ;;
+          --data_dir)            _need_value "$1" "${2:-}"; MY_DATA_DIR="$2"; shift ;;
+          --scratch_dir)         _need_value "$1" "${2:-}"; MY_SCRATCH_DIR="$2"; shift ;;
+          --GPU)                 _need_value "$1" "${2:-}"; GPU2USE="$2"; shift ;;
           --no_pull)             NOPULL="1" ;;
           --dummy_training)      DUMMY_TRAINING="1" ;;
           --preflight_check)     PREFLIGHT_CHECK="1" ;;


### PR DESCRIPTION
## Problem

A DECADE site ran the documented command with `SCRATCHDIR` never exported:

```console
$ ./docker.sh --scratch_dir $SCRATCHDIR --GPU device=0 --dummy_training
[INFO] No interactive terminal detected, disabling TTY.
Unknown parameter passed: device=0
```

The empty variable expands to nothing, so `--scratch_dir` silently consumes the
**next flag** (`--GPU`) as its value, leaving `device=0` orphaned. The error then
blames `--GPU` — which is perfectly valid usage — and the site went looking for a
problem with the GPU flag that does not exist.

## Fix

Validate that options which take a value actually receive one, and that the value
is not another flag. The message now names the real cause.

## Verification

| case | result |
|---|---|
| `SCRATCHDIR` unset (the site's case) | `❗ Option --scratch_dir requires a value, but got '--GPU'.` |
| `SCRATCHDIR` set | parses correctly |
| `--GPU` with no value at all | caught |
| genuinely unknown option | still rejected as before |

🤖 Generated with [Claude Code](https://claude.com/claude-code)