### PR TITLE
CI: stop validate-swarm failing healthy-but-slow swarm runs (#388)

### DIFF
--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -723,10 +723,16 @@ run_dummy_training_in_swarm () {
     cd "$CWD"
 
     # Poll for completion instead of a fixed sleep.  The server log will
-    # contain "Server runner finished." once all rounds are done.  We check
-    # every 10 seconds for up to 5 minutes (30 iterations).
+    # contain "Server runner finished." once all rounds are done.
+    #
+    # #388: 30 attempts (300s) was too tight. The self-hosted runner shares a host
+    # with image builds and deploy tests, and the observed failures show the swarm
+    # still making progress ("Round 2 started", "Contribution ... ACCEPTED") when we
+    # gave up — i.e. we were timing out on a *slow* run, not a hung one, and then
+    # failing the assertions below. Poll for up to 15 min; a genuinely hung run still
+    # fails, just later. Override with CI_SWARM_WAIT_ATTEMPTS if needed.
     local server_log="$PROJECT_DIR/prod_00/localhost/startup/nohup.out"
-    local max_attempts=30
+    local max_attempts=${CI_SWARM_WAIT_ATTEMPTS:-90}
     local attempt=0
     echo "  Waiting for swarm training to finish (checking every 10s, max ${max_attempts}0s) ..."
     while [ $attempt -lt $max_attempts ]; do

--- a/tests/integration_tests/_run_3dcnn_simulation_mode.sh
+++ b/tests/integration_tests/_run_3dcnn_simulation_mode.sh
@@ -27,10 +27,20 @@ run_3dcnn_simulation_mode () {
     sed -i 's/min_responses_required = .*/min_responses_required = 1/' ${TMPDIR}/${APP_DIR}/app/config/config_fed_client.conf
     # Production ODELIA jobs use long timeouts to ride out VPN stalls. This
     # synthetic CI simulation should fail promptly and print the simulator log.
+    #
+    # EXCEPT max_status_report_interval (#388): that is a *liveness* check, not a
+    # duration budget. The self-hosted runner shares a host with image builds and
+    # deploy tests, so a healthy-but-slow simulated client can miss a 300s status
+    # report and be declared dead:
+    #   FATAL_SYSTEM_ERROR: client simulated_node_1 didn't report status for 300 seconds
+    # That aborts the whole simulation and fails PRs that cannot affect swarm
+    # training at all (it has failed docs-only PRs). Keep the *task* timeouts short
+    # so genuine hangs still fail fast; give the liveness check slack for CI load.
     sed -i \
         -e 's/start_task_timeout = .*/start_task_timeout = 300/' \
         -e 's/progress_timeout = .*/progress_timeout = 600/' \
         -e 's/configure_task_timeout = .*/configure_task_timeout = 300/' \
+        -e 's/max_status_report_interval = .*/max_status_report_interval = 1800/' \
         ${TMPDIR}/${APP_DIR}/app/config/config_fed_server.conf
     sed -i \
         -e 's/last_result_transfer_timeout = .*/last_result_transfer_timeout = 300/' \


### PR DESCRIPTION
Closes #388.

`validate-swarm` has been failing PRs that **cannot affect swarm training** — most
tellingly a **docs-only PR** (#444, one markdown file) — which forced admin-merges of
otherwise-green work (#442, #443, #444). Both failure signatures turn out to be the
same story: **a slow run, not a broken one.**

## 1. Simulation mode

```
FATAL_SYSTEM_ERROR: client simulated_node_1 didn't report status for 300 seconds
```

That message comes from `ccwf/server_ctl.py:488` and is governed by
**`max_status_report_interval`**, which `config_fed_server.conf` pins to **300**.
`_run_3dcnn_simulation_mode.sh` rewrites **eleven** timeouts — but not that one — so it
stayed at 300 s.

`max_status_report_interval` is a **liveness check, not a duration budget**. The
self-hosted runner shares a host with image builds and deploy tests, so a *healthy*
simulated client can miss a 300 s status report under contention and be declared dead,
aborting the whole simulation.

→ raise it to **1800 s**. The *task* timeouts (`start_task_timeout`,
`learn_task_timeout`, …) stay short, so a genuine hang still fails fast.

## 2. Proof-of-concept mode

```
⚠️  Timed out after 300s waiting for swarm completion — proceeding to assertions
```

Our own poll: `max_attempts=30` × 10 s. The captured logs show the swarm **still
progressing** when we gave up (`Round 2 started`, `Contribution … ACCEPTED`) — so we
timed out on a slow run and then failed the assertions below.

→ poll for up to **15 min**, overridable via `CI_SWARM_WAIT_ATTEMPTS`. A hung run still
fails, just later.

## Verification

Applying the simulation `sed` to the real `config_fed_server.conf`:

```
before:  progress_timeout = 28800   max_status_report_interval = 300
after :  progress_timeout = 600     max_status_report_interval = 1800
```

…and the file stays well-formed.

## Note on the underlying cause

The deeper problem is that the self-hosted runner **shares a host with the DECADE image
builds and deploy tests**. This PR makes CI tolerant of that; it does not remove the
contention. Worth considering a dedicated runner, or a concurrency group that keeps
`validate-swarm` and the deploy tests off the box at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)