### PR TITLE
Fix the degenerate-input guard tests, and make CI actually run them (#416)

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -47,6 +47,10 @@ jobs:
           pip install lightning scikit-learn pytest
           # fastapi: server_tools/app.py imports it; needed by test_swarm_progress.py (#398)
           pip install fastapi
+          # torchio + pandas gate the ODELIA dataset tests (degenerate-input guard,
+          # fold validation). Without them pytest silently SKIPS those files, which is
+          # how a broken guard test reached main (#416/#423).
+          pip install torchio pandas
 
       - name: Run unit tests
         run: |

--- a/tests/unit_tests/test_odelia_degenerate_input_guard.py
+++ b/tests/unit_tests/test_odelia_degenerate_input_guard.py
@@ -38,6 +38,7 @@ def _make_dataset(transform, n=5):
     ds.config = "unilateral"
     ds._bad_input_count = 0
     ds._bad_input_logged = set()
+    ds._bad_input_reasons = {}
     ds.transform = transform
     ds.get_image_path = lambda uid, inst: f"/{uid}"
     ds._load_source_image = lambda path, inst, uid: uid
@@ -73,8 +74,35 @@ def test_getitem_aborts_when_too_many_bad():
     def transform(uid):
         raise DegenerateImageError(uid, "/p", "zero_std", 0)
     ds = _make_dataset(transform, n=40)
-    with pytest.raises(RuntimeError, match="too many degenerate/corrupt inputs"):
+    with pytest.raises(RuntimeError) as exc:
         _ = ds[0]
+
+    message = str(exc.value)
+    assert "too many unusable inputs" in message
+    assert "9x zero_std" in message, "must break the failures down by reason (#416)"
+    assert "re-export or exclude" in message, "degenerate content -> excluding is the right remedy"
+
+
+def test_abort_on_unreadable_files_says_fix_permissions_not_delete_data():
+    """The #416 regression: a site deleted valid data because the guard said 'exclude'.
+
+    When every failure is a file-access error the data is fine and the PERMISSIONS
+    are wrong, so the message must say so and must NOT advise excluding anything.
+    """
+    def loader(path):
+        raise PermissionError(13, "Permission denied", str(path))
+
+    ds = _make_dataset(transform=lambda uid: uid, n=40)
+    ds.load_img = loader
+    ds._load_source_image = lambda path_img, institution, uid: loader(path_img)
+
+    with pytest.raises(RuntimeError) as exc:
+        _ = ds[0]
+
+    message = str(exc.value)
+    assert "PERMISSION/OWNERSHIP" in message
+    assert "do NOT exclude the data" in message
+    assert "load_error:PermissionError" in message
 
 
 def test_getitem_propagates_real_transform_bugs():


### PR DESCRIPTION
**`main` is red right now** for anyone with `torchio` installed — and I broke it, in #423.

#423 added `self._bad_input_reasons` in `__init__` and writes to it from `_record_bad_input`, but the guard tests construct the dataset via `__new__` and never initialised it → 3 × `AttributeError`. A 4th test still asserted the pre-#423 abort wording.

### Why CI didn't catch it — the part that matters
`unit-tests.yaml` installs only `torch`, `lightning`, `scikit-learn`, `pytest`, `fastapi`. **No `torchio`, no `pandas`** — so `test_odelia_degenerate_input_guard.py` `importorskip`s out and is **silently skipped in every CI run**. That file covers the guard **CAM tripped over**, whose message once led a site to **delete six valid UIDs**. A green tick has meant nothing for it.

### This PR
- initialises `_bad_input_reasons` in the test fixture
- updates the abort assertion to the new reason-breakdown message
- **adds the regression that should have existed**: when every failure is a `PermissionError`, the message must say `PERMISSION/OWNERSHIP` and *"do NOT exclude the data"* — exactly the advice that was missing when CAM deleted valid data
- **installs `torchio` + `pandas` in CI**, so these tests (and #427's fold-validation tests) actually run

Suite with those deps present: **231 passed**. Worth merging promptly — `main` is broken.