### PR TITLE
docs: DECADE registry — Heidelberg reported (MSI available)

### DIFF
--- a/docs/DECADE_SITE_REGISTRY.md
+++ b/docs/DECADE_SITE_REGISTRY.md
@@ -1,7 +1,7 @@
 # DECADE — site registry (data, targets, contacts, status)
 
 **Single source of truth for what each centre can actually provide.**
-Update this whenever a site reports new numbers. Last updated: **2026-07-14**.
+Update this whenever a site reports new numbers. Last updated: **2026-07-15**.
 
 Swarm learning requires **one shared target**: identical label, identical
 `STAMP_NUM_CLASSES`, identical class order at every site. Everything below exists to
@@ -16,7 +16,7 @@ answer one question — *which target can all four sites actually supply?*
 | Universitätsklinikum Bonn | `UKB_1` | Islem Gammoudi | Islem.Gammoudi@ukbonn.de |
 | Universitätsmedizin Mainz | `Mainz_1` | Christina Glasner (+ Sebastian, pathology) | glasnerc@uni-mainz.de |
 | Universitätsklinikum Düsseldorf | `UKD_1` | Tobias Seraphin (+ Janik) | TobiasPaul.Seraphin@med.uni-duesseldorf.de |
-| Universitätsklinikum Heidelberg | `UKHD_1` | Christian Zoellner (GitHub: `Altrabeth`) | ckobrow@mailbox.org |
+| Universitätsklinikum Heidelberg | `UKHD_1` | Christian Zöllner (GitHub: `Altrabeth`) + Nina Nelius | ckobrow@mailbox.org, nina.nelius@med.uni-heidelberg.de |
 
 TU Dresden hosts **server + admin only** (no training client).
 
@@ -52,33 +52,58 @@ TU Dresden hosts **server + admin only** (no training client).
   (`MLH1`, `MSH6`, `MLH1, PMS2`, …) — **do not use as-is**; use `MSI-High`.
 - **~11 % positives ⇒ judge on AUROC, not accuracy** (predicting "no" for everyone
   already scores ~89 %).
+- **Multi-slide site** (719 slides > 569 patients): needs a **slide table**
+  (`STAMP_SLIDE_TABLE` + `STAMP_FILENAME_LABEL`), which loaded 0 patients until #437.
+  The 61/508 figures are **patients**, 119/600 are **slides** — decide which unit the
+  run trains/evaluates on.
 
 ### Düsseldorf (`UKD_1`) — pending
 Returning from holiday; will report **by Wed 2026-07-22 at the latest**.
 
-### Heidelberg (`UKHD_1`) — pending
-Still working through the setup steps (see §4).
+### Heidelberg (`UKHD_1`) — MSI available
+
+MSI-High status, **one slide per patient**:
+
+| Cohort | yes (MSI-High) | no | not provided |
+|---|---|---|---|
+| Stage I–III | **342** | **262** | 845 |
+| Adenomas | 1 | 2 | 424 |
+
+- **Usable MSI cohort ≈ 604 patients (342 pos / 262 neg)** from Stage I–III; the
+  adenoma cohort has essentially no MSI labels (1/2) and would be dropped.
+- Prevalence **~57 % positive** — very different from Mainz's ~11 %. That is a real
+  cross-site label-distribution shift (likely cohort selection: Stage I–III vs full).
+  Fine for swarm learning, but worth noting for the analysis.
+- Exact column name / values still to confirm with Christian.
 
 ---
 
 ## 3. ⚠️ The open conflict
 
-**Bonn cannot currently supply MSI.** So the proposed shared target (MSI-High,
-binary) is **not yet achievable across all four sites**. The realistic options:
+**Two of three responding sites can supply MSI; Bonn cannot.** MSI-High is now the
+clear front-runner for the shared target — the only blocker is Bonn.
 
-| option | target | classes | Bonn | Mainz | notes |
-|---|---|---|---|---|---|
-| **A** | `MSI-High` | 2 | ❌ not available | ✅ 569 pts | blocked unless Bonn finds MSI/MMR data |
-| **B** | Lynch vs. Sporadic | 2 | ✅ 1174 | ❓ | Mainz would need a germline label |
-| **C** | dMMR/pMMR | 2 | ❌ `not provided` | ✅ (≡ MSI-High) | same blocker as A |
+| option | target | classes | Bonn | Mainz | Heidelberg | notes |
+|---|---|---|---|---|---|---|
+| **A** | `MSI-High` | 2 | ❌ all `not provided` | ✅ 569 pts (11% pos) | ✅ ~604 pts (57% pos) | blocked only by Bonn |
+| **B** | Lynch vs. Sporadic | 2 | ✅ 1174 | ❓ needs germline | ❓ needs germline | flips the blocker to Mainz+Heidelberg |
+| **C** | dMMR/pMMR | 2 | ❌ `not provided` | ✅ (≡ MSI-High) | ❓ | same as A |
+
+Düsseldorf (pending, by Wed 2026-07-22) is the remaining unknown for option A.
 
 **Do not** approximate MSI from Lynch status: Lynch is a *germline* syndrome and MSI
 is a *tumour* phenotype. Most Lynch tumours are MSI-High, but sporadic MSI-High
 (usually MLH1-hypermethylated) exists and would be mislabelled. That is a different
 study, not a relabelling.
 
-**Blocked on:** (a) Bonn confirming with Dr. Robert / Dr. Jacob whether any MSI or
-MMR data exists; (b) Düsseldorf and Heidelberg reporting.
+**Blocked on:** (a) **Bonn** confirming with Dr. Robert / Dr. Jacob whether any real
+MSI/MMR data exists — this is now the only site that cannot do MSI; (b) **Düsseldorf**
+reporting (by Wed 2026-07-22). Heidelberg has reported (MSI available).
+
+**If Bonn has no MSI:** the honest choices are (i) run MSI with Mainz + Heidelberg
+(+ Düsseldorf if available) and leave Bonn out of the first run, or (ii) pick a
+target Bonn shares — but Lynch-vs-sporadic would then require Mainz and Heidelberg to
+supply a germline label they have not mentioned. Operator/PI decision.
 
 ---
 
@@ -89,7 +114,7 @@ MMR data exists; (b) Düsseldorf and Heidelberg reporting.
 | **UKB_1** (Bonn) | ✅ | ✅ | ✅ | ✅ 32 epochs, val_loss 0.350→0.031 (3-class) | germline only |
 | **Mainz_1** | ✅ | ✅ | ✅ | ✅ 32 epochs (kit `6bc06c4`) | `MSI-High` ✅ |
 | **UKD_1** (Düsseldorf) | ? | ❌ | ❌ | ❌ | pending |
-| **UKHD_1** (Heidelberg) | ? | ❌ | Step 1 blocked (empty `$SCRATCHDIR`, see #443) | ❌ | pending |
+| **UKHD_1** (Heidelberg) | ✅ ping ok | ✅ | Step 1 ✅ (dummy training ran) | ❌ | `MSI-High` ✅ (see §2) |
 
 ---
 


### PR DESCRIPTION
Updates the site registry after Heidelberg's reply: dummy training + ping work, SSH key authorized, and **MSI-High is available** (Stage I-III: 342 pos / 262 neg, ~604 usable patients).

Two of three responding sites (Mainz, Heidelberg) can now supply MSI-High; **Bonn is the only site that cannot** (all `not provided`). MSI is the clear front-runner target; Düsseldorf still pending (by Wed 2026-07-22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)