### PR TITLE
docs(decade): fill kit registry with per-site sha256 hashes

### DIFF
--- a/docs/consortium_decade/README.md
+++ b/docs/consortium_decade/README.md
@@ -18,7 +18,7 @@ kit am I on, what do I run, and when is the run?"* This folder is that single pl
 1. **Doc** ← paste `PARTNER_HANDBOOK.md` into a new Google Doc, share view-only.
 2. **Sheet** ← import the four CSVs, one per tab:
    - `sheet_1_run_schedule.csv` — set the date, the **shared target**, and the image tag
-   - `sheet_2_kit_registry.csv` — fill each kit's `sha256`; mark superseded kits **DEPRECATED**
+   - `sheet_2_kit_registry.csv` — one row per site per kit, each with its own `sha256` (per-site certs → per-site hash); mark superseded kits **DEPRECATED**
    - `sheet_3_site_checklist.csv` — 4 sites × 9 steps; **sites tick their own rows** (pre-filled with what we know)
    - `sheet_4_known_issues.csv` — cumulative. **Append, never rewrite** — this is the debugging memory
 3. Share the Doc + Sheet once. Then stop emailing instructions: change them here.
@@ -29,7 +29,8 @@ kit am I on, what do I run, and when is the run?"* This folder is that single pl
   (`STAMP_NUM_CLASSES` + `STAMP_GROUND_TRUTH_LABEL`). See `docs/DECADE_SITE_REGISTRY.md`
   for who can supply what — MSI-High is the front-runner; Bonn is the only site that
   cannot yet, and Düsseldorf replies by 2026-07-22.
-- **Kit registry:** each kit's **`sha256`** (`sha256sum <SITE>_<version>.zip`).
+
+(The kit registry's per-site `sha256` values are now filled in from the built kits.)
 
 ## DECADE vs ODELIA — two real differences
 

--- a/docs/consortium_decade/sheet_2_kit_registry.csv
+++ b/docs/consortium_decade/sheet_2_kit_registry.csv
@@ -1,4 +1,13 @@
-Kit version,Released,Status,Applies to,sha256 (of the .zip),What changed,Action required
-1.5.0-dev.260706.9b0148b,2026-07-06,DEPRECATED,All DECADE sites,(fill from build),First distributed kit,Superseded — do not use
-1.5.0-dev.260710.a295c6b,2026-07-10,DEPRECATED,All DECADE sites,(fill from build),"Reads STAMP 2.5.0 features; column names with spaces; sudo detection",Superseded — do not use
-1.5.0-dev.260713.6bc06c4,2026-07-13,ACTIVE,All DECADE sites,(fill from build),"Multi-slide slide table (loaded 0 patients before); local training now 32 epochs not 1; model no longer trains with dropout disabled; empty-var arg validation",Install this and re-run the local baseline
+Kit version,Released,Status,Site,sha256 (of your .zip),What changed,Action required
+1.5.0-dev.260706.9b0148b,2026-07-06,DEPRECATED,UKB_1,fc994ee51f3b8e7b0792b95f516906e88d892ba09eb453312ef95dfae9a7eb42,First distributed kit,Superseded — do not use
+1.5.0-dev.260706.9b0148b,2026-07-06,DEPRECATED,Mainz_1,cc7c185c9a3516b1cbfce2ba6b0f700b1295bc397a5f5a8f627cb96152f85584,First distributed kit,Superseded — do not use
+1.5.0-dev.260706.9b0148b,2026-07-06,DEPRECATED,UKD_1,1b4ba5fd658839dabf4fba7ddc5803dd79925ad1ee829b633b75e44b91c7a3ce,First distributed kit,Superseded — do not use
+1.5.0-dev.260706.9b0148b,2026-07-06,DEPRECATED,UKHD_1,fd8285ac629fd8dcd541036a4ddb492acd962e0430da70aa13dc7f3a3e18ef5f,First distributed kit,Superseded — do not use
+1.5.0-dev.260710.a295c6b,2026-07-10,DEPRECATED,UKB_1,7aabb89b604205bc9a94141fbd26e37bf0ec920bc96d694f151a3091c9f838fe,"Reads STAMP 2.5.0 features; column names with spaces; sudo detection",Superseded — do not use
+1.5.0-dev.260710.a295c6b,2026-07-10,DEPRECATED,Mainz_1,0a27a34af6281db3359aa6e30be9ae9f94484922aef45278cee3af7331bc6726,"Reads STAMP 2.5.0 features; column names with spaces; sudo detection",Superseded — do not use
+1.5.0-dev.260710.a295c6b,2026-07-10,DEPRECATED,UKD_1,ccb66970c9564adc64bd28ca5b03d80ccef76ed50650bc2831184727e97bdc21,"Reads STAMP 2.5.0 features; column names with spaces; sudo detection",Superseded — do not use
+1.5.0-dev.260710.a295c6b,2026-07-10,DEPRECATED,UKHD_1,6e0a650a968e2d4761f32cc5a2b3ea71a9ddf20ebb439d2cc048f45a3790dfb5,"Reads STAMP 2.5.0 features; column names with spaces; sudo detection",Superseded — do not use
+1.5.0-dev.260713.6bc06c4,2026-07-13,ACTIVE,UKB_1,b89a3d356d5bcc3128b01c9b11393f522e6b590789c094781b68d3102af46004,"Multi-slide slide table (loaded 0 patients before); local training now 32 epochs not 1; model no longer trains with dropout disabled; empty-var arg validation",Install this and re-run the local baseline
+1.5.0-dev.260713.6bc06c4,2026-07-13,ACTIVE,Mainz_1,4702028c2bf7bcaee8d21ddedd24ce2391c67a4c7f6e4f4c1a9cda26cce49a53,"Multi-slide slide table (loaded 0 patients before); local training now 32 epochs not 1; model no longer trains with dropout disabled; empty-var arg validation",Install this and re-run the local baseline
+1.5.0-dev.260713.6bc06c4,2026-07-13,ACTIVE,UKD_1,47d93a1512d2bb5970dc964076476fb528c9b260d4ffbb1ff33c66dfc027d095,"Multi-slide slide table (loaded 0 patients before); local training now 32 epochs not 1; model no longer trains with dropout disabled; empty-var arg validation",Install this and re-run the local baseline
+1.5.0-dev.260713.6bc06c4,2026-07-13,ACTIVE,UKHD_1,b2def15f5989d3f50edbd424b5a383b441822dcdb0b20673a2c7296f8907108e,"Multi-slide slide table (loaded 0 patients before); local training now 32 epochs not 1; model no longer trains with dropout disabled; empty-var arg validation",Install this and re-run the local baseline


### PR DESCRIPTION
The DECADE Run Board's Kit registry tab had `(fill from build)` in every sha256 cell.

Because each site's startup kit contains its own certificates, each `<SITE>_<version>.zip` has a **distinct** hash — so a single sha256 per version cannot back the Site-checklist step *"sha256sum <SITE>_<ver>.zip vs Kit registry"*. This restructures the registry to **one row per (kit version, site)** and fills the real hashes computed with `sha256sum` from the distributed kits.

Covers all three distributed versions × 4 sites:
- `9b0148b` (2026-07-06, DEPRECATED)
- `a295c6b` (2026-07-10, DEPRECATED)
- `6bc06c4` (2026-07-13, **ACTIVE**)

README note updated to describe the per-site structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)