### PR TITLE
Post-#449 fixes from dl-server validation: image.conf precedence + version-skew KeyError

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -804,9 +804,15 @@ docker_cln_sh: |
   # Point image.conf at a release channel (e.g. :current) to pick up releases with no
   # action at all. Precedence: --image > MEDISWARM_IMAGE env > image.conf > default.
   DOCKER_IMAGE={~~docker_image~~}
+  # Capture a pre-exported MEDISWARM_IMAGE BEFORE sourcing image.conf, so a one-off
+  # env override wins over the persistent file (documented precedence: --image > env
+  # > image.conf > default). Without this, image.conf's assignment would clobber the
+  # env var (#449 follow-up).
+  ENV_IMAGE="${MEDISWARM_IMAGE:-}"
   if [ -f "$DIR/image.conf" ]; then
       . "$DIR/image.conf"
   fi
+  MEDISWARM_IMAGE="${ENV_IMAGE:-${MEDISWARM_IMAGE:-}}"
   DOCKER_IMAGE="${CLI_IMAGE:-${MEDISWARM_IMAGE:-$DOCKER_IMAGE}}"
   if [[ -z "$NOPULL" ]]; then
       echo "Updating docker image"

--- a/server_tools/app.py
+++ b/server_tools/app.py
@@ -325,12 +325,12 @@ def compute_version_skew(rows):
     for row in live:
         key = identity(row)
         if key and key != majority:
-            skew[row["name"]] = f"running {row.get('image_ref') or key}, swarm majority is on a different image"
+            skew[row["site"]] = f"running {row.get('image_ref') or key}, swarm majority is on a different image"
             continue
         expected = row.get("expected_version") or ""
         seen = row.get("kit_version") or ""
         if expected and seen and expected != seen:
-            skew[row["name"]] = f"kit {seen}, expected {expected}"
+            skew[row["site"]] = f"kit {seen}, expected {expected}"
     return skew
 
 
@@ -835,7 +835,7 @@ def rows(*, force: bool = False) -> list[dict[str, Any]]:
     # Stamp version skew here -- the single choke point every view goes through.
     skew = compute_version_skew(value)
     for row in value:
-        row["version_skew"] = skew.get(row["name"], "")
+        row["version_skew"] = skew.get(row["site"], "")
     _ROWS_CACHE["value"] = value
     _ROWS_CACHE["expires_at"] = now + ROWS_CACHE_TTL_SECONDS
     return list(value)

--- a/tests/unit_tests/test_image_override_and_skew.py
+++ b/tests/unit_tests/test_image_override_and_skew.py
@@ -47,6 +47,20 @@ def test_image_precedence_is_cli_then_env_then_default(docker_sh):
     assert 'DOCKER_IMAGE="${CLI_IMAGE:-${MEDISWARM_IMAGE:-$DOCKER_IMAGE}}"' in docker_sh
 
 
+def test_env_is_captured_before_image_conf_is_sourced(docker_sh):
+    """--image > env > image.conf: a pre-exported MEDISWARM_IMAGE must beat image.conf.
+
+    image.conf is `source`d, so if the env is not captured first, a MEDISWARM_IMAGE=
+    line in image.conf silently clobbers the operator's env override (#449 follow-up).
+    """
+    src = docker_sh
+    cap = src.index('ENV_IMAGE="${MEDISWARM_IMAGE:-}"')
+    srcconf = src.index('. "$DIR/image.conf"')
+    restore = src.index('MEDISWARM_IMAGE="${ENV_IMAGE:-')
+    assert cap < srcconf, "env must be captured BEFORE image.conf is sourced"
+    assert srcconf < restore, "the captured env must be re-applied AFTER sourcing"
+
+
 def test_provisioned_tag_is_still_the_default(docker_sh):
     """With no override, a kit must behave exactly as before."""
     assert "DOCKER_IMAGE=jefftud/odelia:1.5.0-provisioned" in docker_sh

--- a/tests/unit_tests/test_image_override_and_skew.py
+++ b/tests/unit_tests/test_image_override_and_skew.py
@@ -84,7 +84,7 @@ def skew():
 
 def _site(name, image_id, kit_version="1.5.0", expected=""):
     return {
-        "name": name,
+        "site": name,
         "image_id": image_id,
         "image_ref": f"jefftud/odelia:{kit_version}",
         "kit_version": kit_version,
@@ -123,4 +123,4 @@ def test_a_single_site_cannot_be_skewed(skew):
 
 
 def test_sites_without_version_data_are_ignored(skew):
-    assert skew([{"name": "X", "image_id": "", "kit_version": ""}]) == {}
+    assert skew([{"site": "X", "image_id": "", "kit_version": ""}]) == {}


### PR DESCRIPTION
Two small #449 follow-ups found while validating the merged kit-lifecycle features on the dl servers.

### 1. `docker.sh` env override must beat `image.conf`
The image-resolution block sourced `image.conf` **after** reading `MEDISWARM_IMAGE`, so a `MEDISWARM_IMAGE=` line in the file clobbered a one-off env override — opposite of the documented `--image > env > image.conf > default`. Fixed by capturing the env before sourcing. Verified on dl0: `env=A / image.conf=B` now runs A.

### 2. Version-skew crashed the monitor (`KeyError: 'name'`)
`compute_version_skew` / `rows()` indexed rows by `row["name"]`, but `_collect_rows` keys them by `"site"` — so the dashboard **500-ed the instant two sites reported different versions** (exactly when skew must show). The #449 unit test missed it by fabricating rows with a `"name"` key the real collector never produces. Fixed to `row["site"]`; the test now uses the real key.

**Validated on the dl servers:** a throwaway monitor fed crafted heartbeats 500-ed before the fix and, after it, renders the red skew chip for the odd-image-out site with zero server errors (majority clean, single site never flags).

Part of the #449 dl-server validation (PKI stability, encrypted-kit round-trip, image override, skew all passing — full report to follow). Deploy-orchestrator `.zip.enc` gap tracked in #456.