### PR TITLE
docker.sh: --docker_options passthrough for extra docker run options (closes #218)

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -736,6 +736,7 @@ docker_cln_sh: |
           --image)               CLI_IMAGE="$2"; shift ;;
           --config)              CLI_CONFIG="$2"; shift ;;
           --container_name)      CONTAINER_NAME="$2"; shift ;;
+          --docker_options)      CLI_DOCKER_OPTIONS="$2"; shift ;;
           *) echo "Unknown parameter passed: $1"; exit 1 ;;
       esac
       shift
@@ -810,11 +811,20 @@ docker_cln_sh: |
   # > image.conf > default). Without this, image.conf's assignment would clobber the
   # env var (#449 follow-up).
   ENV_IMAGE="${MEDISWARM_IMAGE:-}"
+  # Same capture-before-source trick for extra docker options (#218): a pre-exported
+  # MEDISWARM_DOCKER_OPTIONS must beat an image.conf assignment.
+  ENV_DOCKER_OPTIONS="${MEDISWARM_DOCKER_OPTIONS:-}"
   if [ -f "$DIR/image.conf" ]; then
       . "$DIR/image.conf"
   fi
   MEDISWARM_IMAGE="${ENV_IMAGE:-${MEDISWARM_IMAGE:-}}"
   DOCKER_IMAGE="${CLI_IMAGE:-${MEDISWARM_IMAGE:-$DOCKER_IMAGE}}"
+  # Extra options to pass through to `docker run` (#218): partners needed to add
+  # host-specific options (e.g. --cpus / --cpuset-cpus) without hand-editing this
+  # script. Precedence mirrors the image: --docker_options CLI > MEDISWARM_DOCKER_OPTIONS
+  # env > image.conf. Appended last below so a site option can override a built-in.
+  MEDISWARM_DOCKER_OPTIONS="${ENV_DOCKER_OPTIONS:-${MEDISWARM_DOCKER_OPTIONS:-}}"
+  EXTRA_DOCKER_OPTIONS="${CLI_DOCKER_OPTIONS:-${MEDISWARM_DOCKER_OPTIONS:-}}"
   if [[ -z "$NOPULL" ]]; then
       echo "Updating docker image"
       docker pull "$DOCKER_IMAGE"
@@ -830,7 +840,7 @@ docker_cln_sh: |
       DOCKER_MOUNTS+=" -v $MY_DATA_DIR:/data/:ro"
   fi
   DOCKER_OPTIONS_B="-w /startupkit/startup/ --ipc=host $NETARG"
-  DOCKER_OPTIONS="${DOCKER_OPTIONS_A} ${DOCKER_MOUNTS} ${DOCKER_OPTIONS_B}"
+  DOCKER_OPTIONS="${DOCKER_OPTIONS_A} ${DOCKER_MOUNTS} ${DOCKER_OPTIONS_B} ${EXTRA_DOCKER_OPTIONS}"
 
   # Common ENV vars
   # CLI flags (--model_name, --num_epochs, --config, --fold) take priority over env
@@ -1079,6 +1089,9 @@ docker_cln_sh: |
       echo "                         is ignored by --start_client."
       echo "--config <name>          set config name (default: unilateral)"
       echo "--container_name <name>  set name for the Docker container to override default using version number"
+      echo "--docker_options \"<opts>\" extra options passed straight to 'docker run' (e.g."
+      echo "                         \"--cpus 8 --cpuset-cpus 0-7\"). Persist with"
+      echo "                         MEDISWARM_DOCKER_OPTIONS in startup/image.conf."
       exit 1
   fi
 

--- a/tests/unit_tests/test_docker_sh_docker_options.py
+++ b/tests/unit_tests/test_docker_sh_docker_options.py
@@ -1,0 +1,68 @@
+"""docker.sh must let a site pass extra `docker run` options without editing it (#218).
+
+Partners reported needing host-specific `docker run` options (e.g. --cpus /
+--cpuset-cpus to pin CPUs). Hand-editing the generated docker.sh is error-prone and
+gets lost on the next kit, so the script takes them as a `--docker_options` flag (or a
+persistent MEDISWARM_DOCKER_OPTIONS env / image.conf line) and appends them to the
+`docker run` invocation. Appended LAST, so a site option can override a built-in.
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "docker_config" / "master_template.yml"
+
+
+@pytest.fixture(scope="module")
+def docker_sh():
+    """The client docker.sh exactly as the lighter generates it into a startup kit."""
+    template = yaml.safe_load(TEMPLATE.read_text())
+    script = template["docker_cln_sh"]
+    return re.sub(r"\{~~[a-z_]+~~\}", "TESTSITE", script)
+
+
+def test_docker_options_flag_is_accepted(docker_sh):
+    assert "--docker_options)" in docker_sh, "docker.sh does not accept --docker_options"
+
+
+def test_extra_options_are_appended_to_the_docker_run_options(docker_sh):
+    """They must reach `docker run`, appended last so they can override a built-in."""
+    assert "${EXTRA_DOCKER_OPTIONS}" in docker_sh
+    assert '${DOCKER_OPTIONS_B} ${EXTRA_DOCKER_OPTIONS}"' in docker_sh, (
+        "extra options must be appended last so a site can override a built-in option"
+    )
+
+
+def test_precedence_is_cli_over_env(docker_sh):
+    assert 'EXTRA_DOCKER_OPTIONS="${CLI_DOCKER_OPTIONS:-${MEDISWARM_DOCKER_OPTIONS:-}}"' in docker_sh
+
+
+def test_env_is_captured_before_image_conf_is_sourced(docker_sh):
+    """A one-off MEDISWARM_DOCKER_OPTIONS must beat image.conf, same as the image var."""
+    cap = docker_sh.index('ENV_DOCKER_OPTIONS="${MEDISWARM_DOCKER_OPTIONS:-}"')
+    srcconf = docker_sh.index('. "$DIR/image.conf"')
+    restore = docker_sh.index('MEDISWARM_DOCKER_OPTIONS="${ENV_DOCKER_OPTIONS:-')
+    assert cap < srcconf, "env must be captured BEFORE image.conf is sourced"
+    assert srcconf < restore, "the captured env must be re-applied AFTER sourcing"
+
+
+def test_no_extra_options_by_default(docker_sh):
+    """With nothing passed, EXTRA_DOCKER_OPTIONS is empty -- behavior is unchanged."""
+    # neither CLI nor env set -> both `:-` fallbacks yield the empty string
+    assert "CLI_DOCKER_OPTIONS" in docker_sh
+    assert '--docker_options)      CLI_DOCKER_OPTIONS="$2"' in docker_sh
+
+
+def test_generated_script_is_valid_bash(docker_sh):
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+        handle.write(docker_sh)
+        path = handle.name
+    result = subprocess.run(["bash", "-n", path], capture_output=True, text=True)
+    assert result.returncode == 0, f"generated docker.sh is not valid bash:\n{result.stderr}"


### PR DESCRIPTION
## What
Adds `--docker_options "<opts>"` to the client `docker.sh`, passing arbitrary options
straight through to `docker run`. Persist with `MEDISWARM_DOCKER_OPTIONS` (env or a line
in `startup/image.conf`).

## Why
Partners needed host-specific options (e.g. `--cpus 8 --cpuset-cpus 0-7` to pin CPUs).
The only prior route was hand-editing the generated `docker.sh` — error-prone and wiped
by the next kit (#218).

## Design
- Precedence `--docker_options` CLI > `MEDISWARM_DOCKER_OPTIONS` env > `image.conf`,
  mirroring the image override (env captured before sourcing `image.conf` so a one-off
  env beats the file).
- Appended **last** to `DOCKER_OPTIONS`, so a site option can override a built-in
  (docker takes the last value for a repeated flag).
- Usage block updated; 6 unit tests (`test_docker_sh_docker_options.py`), all docker.sh
  tests green (23 passed), rendered script passes `bash -n`.

Touches `master_template.yml` deliberately **before** the #392 2.8.0 re-port, so that
file is re-ported once already carrying `--fold` (#427) and `--docker_options`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)