### PR TITLE
docker.sh: predict-only external-validation node (closes #412)

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -737,6 +737,9 @@ docker_cln_sh: |
           --config)              CLI_CONFIG="$2"; shift ;;
           --container_name)      CONTAINER_NAME="$2"; shift ;;
           --docker_options)      CLI_DOCKER_OPTIONS="$2"; shift ;;
+          --external_validation) EXTERNAL_VALIDATION="1" ;;
+          --checkpoint)          CLI_CHECKPOINT="$2"; shift ;;
+          --split)               CLI_SPLIT="$2"; shift ;;
           *) echo "Unknown parameter passed: $1"; exit 1 ;;
       esac
       shift
@@ -1014,7 +1017,7 @@ docker_cln_sh: |
   }
 
   # Run pre-run host checks for the GPU-using modes
-  if [ -n "$DUMMY_TRAINING" ] || [ -n "$PREFLIGHT_CHECK" ] || [ -n "$START_CLIENT" ]; then
+  if [ -n "$DUMMY_TRAINING" ] || [ -n "$PREFLIGHT_CHECK" ] || [ -n "$START_CLIENT" ] || [ -n "$EXTERNAL_VALIDATION" ]; then
       _preflight_host_checks
   fi
 
@@ -1049,6 +1052,18 @@ docker_cln_sh: |
       --health-interval=120s --health-start-period=180s --health-retries=3 \
       $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=swarm $DOCKER_IMAGE \
       /bin/bash -c "nohup ./start.sh >> nohup.out 2>&1 && /bin/bash"
+
+  elif [ -n "$EXTERNAL_VALIDATION" ]; then
+      # Predict-only external validation (#412): run a delivered global model on this
+      # site's local test/ext split. No swarm, no aggregation, no network -- metrics and
+      # per-sample predictions are written under /scratch and stay on the node. Only the
+      # aggregate metrics in prediction_results.json need to be shared back.
+      EV_CHECKPOINT="${CLI_CHECKPOINT:-/scratch/FL_global_model.pt}"
+      EV_SPLIT="${CLI_SPLIT:-test}"
+      echo "[INFO] External validation: model=${CLI_MODEL_NAME:-${MODEL_NAME:-MST}} checkpoint=$EV_CHECKPOINT split=$EV_SPLIT"
+      docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training \
+      --env EV_CHECKPOINT="$EV_CHECKPOINT" --env EV_SPLIT="$EV_SPLIT" $DOCKER_IMAGE \
+      /bin/bash -c 'python3 /MediSwarm/scripts/evaluation/predict.py --checkpoint "$EV_CHECKPOINT" --model-name "$MODEL_NAME" --output-dir /scratch --split "$EV_SPLIT"'
 
   elif [ -n "$LIST_LICENSES" ]; then
       docker run --rm --name=$CONTAINER_NAME $DOCKER_IMAGE \
@@ -1092,6 +1107,12 @@ docker_cln_sh: |
       echo "--docker_options \"<opts>\" extra options passed straight to 'docker run' (e.g."
       echo "                         \"--cpus 8 --cpuset-cpus 0-7\"). Persist with"
       echo "                         MEDISWARM_DOCKER_OPTIONS in startup/image.conf."
+      echo "--external_validation    predict-only external validation on your local"
+      echo "                         test/ext split with a delivered global model (no"
+      echo "                         swarm). Writes metrics + predictions to your scratch."
+      echo "--checkpoint <path>      model for --external_validation, a container path under"
+      echo "                         /scratch (default: /scratch/FL_global_model.pt)"
+      echo "--split <name>           dataset split for --external_validation (default: test)"
       exit 1
   fi
 

--- a/docs/EXTERNAL_VALIDATION.md
+++ b/docs/EXTERNAL_VALIDATION.md
@@ -1,0 +1,63 @@
+# External validation (predict-only node)
+
+A center can validate a released ODELIA global model on **its own data** without joining
+the swarm — no VPN, no aggregation, no network traffic. Predictions and per-sample
+outputs stay on the node; **only the aggregate metrics need to be shared back.** This is
+the privacy-preserving way to add an external-validation site (#412).
+
+## What the node needs
+
+1. The ODELIA Docker image (pulled automatically by `docker.sh`, like any node).
+2. The delivered global model checkpoint (e.g. `best_FL_global_model.pt`).
+3. Local data with a **`test`** (or `ext`) split in `split.csv` — the same layout a
+   training site uses (`annotation.csv` / `split.csv` under the data dir).
+
+An external-validation node does **not** need a provisioned swarm kit: it never
+authenticates to the server, so it needs no certificates. Any current ODELIA kit works
+(its `docker.sh` carries the mode), or ship just `docker.sh` + `predict.py` in the image.
+
+## One command
+
+Put the delivered model in your scratch dir (mounted at `/scratch`), then:
+
+```bash
+scripts/deploy/run_external_validation.sh \
+    --data_dir    "$DATADIR" \
+    --scratch_dir "$SCRATCHDIR" \
+    --model_name  <released model name> \
+    --split test
+# optional: --checkpoint /scratch/<file>.pt   (default: /scratch/FL_global_model.pt)
+#           --GPU device=0   --kit_dir <kit>/startup   --skip_preflight
+```
+
+It runs the **data-integrity + GPU preflight** first (rejects a corrupt/degenerate
+dataset before predicting — the guard that caught a site's corrupt inputs), then the
+prediction.
+
+### Or directly, via the kit
+
+```bash
+# 1) integrity gate
+./docker.sh --data_dir "$DATADIR" --scratch_dir "$SCRATCHDIR" --GPU device=0 \
+            --model_name <name> --preflight_check
+# 2) predict-only external validation
+./docker.sh --data_dir "$DATADIR" --scratch_dir "$SCRATCHDIR" --GPU device=0 \
+            --model_name <name> --split test --external_validation
+```
+
+## Outputs (all local, in your scratch dir)
+
+| File | Contents | Share back? |
+|---|---|---|
+| `prediction_results.json` | aggregate metrics (accuracy, AUC-ROC, per-class F1, confusion matrix) | **yes — this is all you send** |
+| `predictions_*.csv` | per-sample predictions | no — keep on the node |
+
+Because the metric set matches the training-site evaluation, the external numbers are
+directly comparable to the swarm's internal results.
+
+## Notes
+
+- `--model_name` must match the released model's architecture, or the checkpoint won't
+  load. The board's kit registry names the model for each released global model.
+- Data is mounted **read-only** at `/data`; scratch is writable at `/scratch`. Nothing
+  leaves the container except what you choose to share from `prediction_results.json`.

--- a/scripts/deploy/run_external_validation.sh
+++ b/scripts/deploy/run_external_validation.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# One-command external validation for a predict-only node (#412).
+#
+# A center can validate a released ODELIA global model on its OWN data without
+# joining the swarm: no VPN, no aggregation, no network. This wrapper just chains the
+# two kit commands a site would otherwise run by hand --
+#
+#   1. docker.sh --preflight_check       (the same data-integrity/GPU guard that caught
+#                                          CAM's corrupt inputs -- reject a bad dataset
+#                                          BEFORE predicting)
+#   2. docker.sh --external_validation   (run predict.py on the local test/ext split)
+#
+# Metrics and per-sample predictions are written under your scratch dir and stay on the
+# node. Only the aggregate metrics in prediction_results.json need to be shared back.
+#
+# Usage:
+#   run_external_validation.sh \
+#       --data_dir    /path/to/your/data \
+#       --scratch_dir /path/to/scratch \
+#       --model_name  <released model name> \
+#       [--checkpoint /scratch/FL_global_model.pt]   # container path; default shown
+#       [--split test] [--GPU device=0] [--kit_dir /path/to/kit/startup]
+#
+# Put the delivered global model where --checkpoint points (default: drop
+# FL_global_model.pt into your scratch dir, which is mounted at /scratch).
+
+set -euo pipefail
+
+DATA_DIR="" SCRATCH_DIR="" MODEL_NAME="" CHECKPOINT="" SPLIT="test"
+GPU="device=0" KIT_DIR=""
+SKIP_PREFLIGHT=""
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --data_dir)       DATA_DIR="$2"; shift ;;
+        --scratch_dir)    SCRATCH_DIR="$2"; shift ;;
+        --model_name)     MODEL_NAME="$2"; shift ;;
+        --checkpoint)     CHECKPOINT="$2"; shift ;;
+        --split)          SPLIT="$2"; shift ;;
+        --GPU)            GPU="$2"; shift ;;
+        --kit_dir)        KIT_DIR="$2"; shift ;;
+        --skip_preflight) SKIP_PREFLIGHT="1" ;;
+        -h|--help)        grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown parameter: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+# Locate docker.sh: --kit_dir wins, else next to this script (a site can copy this
+# wrapper into its kit's startup/ dir), else the current directory.
+SELF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+for cand in "$KIT_DIR/docker.sh" "$SELF_DIR/docker.sh" "./docker.sh"; do
+    [ -n "$cand" ] && [ -f "$cand" ] && { DOCKER_SH="$cand"; break; }
+done
+: "${DOCKER_SH:?could not find docker.sh -- pass --kit_dir <kit>/startup}"
+
+for req in DATA_DIR SCRATCH_DIR MODEL_NAME; do
+    [ -n "${!req}" ] || { echo "--${req,,} is required" >&2; exit 1; }
+done
+
+echo "== External validation =="
+echo "   docker.sh:   $DOCKER_SH"
+echo "   model:       $MODEL_NAME    split: $SPLIT"
+echo "   data (ro):   $DATA_DIR"
+echo "   scratch:     $SCRATCH_DIR"
+
+if [ -z "$SKIP_PREFLIGHT" ]; then
+    echo "-- Step 1/2: preflight (data-integrity + GPU) --"
+    "$DOCKER_SH" --data_dir "$DATA_DIR" --scratch_dir "$SCRATCH_DIR" --GPU "$GPU" \
+        --model_name "$MODEL_NAME" --preflight_check
+fi
+
+echo "-- Step 2/2: predict-only external validation --"
+EV_ARGS=(--data_dir "$DATA_DIR" --scratch_dir "$SCRATCH_DIR" --GPU "$GPU"
+         --model_name "$MODEL_NAME" --split "$SPLIT" --external_validation)
+[ -n "$CHECKPOINT" ] && EV_ARGS+=(--checkpoint "$CHECKPOINT")
+"$DOCKER_SH" "${EV_ARGS[@]}"
+
+echo
+echo "== Done. Results are LOCAL, under: $SCRATCH_DIR =="
+echo "   prediction_results.json   <- aggregate metrics (the only file to share back)"
+echo "   predictions_*.csv         <- per-sample predictions (keep on the node)"

--- a/tests/unit_tests/test_docker_sh_external_validation.py
+++ b/tests/unit_tests/test_docker_sh_external_validation.py
@@ -1,0 +1,81 @@
+"""docker.sh must offer a first-class predict-only external-validation mode (#412).
+
+A center can validate a released global model on its OWN data without joining the
+swarm -- no VPN, no aggregation, no network. The capability existed only ad-hoc
+(predict.py driven by an internal smoke script); this makes it a documented kit mode:
+`--external_validation` runs predict.py on the local test/ext split against a delivered
+checkpoint, writing metrics + predictions locally (only the metrics need to be shared).
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "docker_config" / "master_template.yml"
+WRAPPER = REPO_ROOT / "scripts" / "deploy" / "run_external_validation.sh"
+
+
+@pytest.fixture(scope="module")
+def docker_sh():
+    template = yaml.safe_load(TEMPLATE.read_text())
+    return re.sub(r"\{~~[a-z_]+~~\}", "TESTSITE", template["docker_cln_sh"])
+
+
+def test_external_validation_flag_is_accepted(docker_sh):
+    assert "--external_validation)" in docker_sh
+
+
+def test_it_runs_predict_only_not_the_swarm(docker_sh):
+    """External validation must invoke predict.py, and must NOT join the swarm."""
+    branch = docker_sh[docker_sh.index('elif [ -n "$EXTERNAL_VALIDATION" ]'):]
+    branch = branch[: branch.index("elif ", 1)]
+    assert "scripts/evaluation/predict.py" in branch
+    assert "TRAINING_MODE=swarm" not in branch, "external validation must not join the swarm"
+    assert "start.sh" not in branch, "external validation must not launch the swarm client"
+
+
+def test_checkpoint_defaults_to_a_scratch_path(docker_sh):
+    """The site drops the delivered model in scratch (mounted at /scratch)."""
+    assert 'EV_CHECKPOINT="${CLI_CHECKPOINT:-/scratch/FL_global_model.pt}"' in docker_sh
+
+
+def test_split_defaults_to_test(docker_sh):
+    assert 'EV_SPLIT="${CLI_SPLIT:-test}"' in docker_sh
+
+
+def test_output_stays_local_under_scratch(docker_sh):
+    branch = docker_sh[docker_sh.index('elif [ -n "$EXTERNAL_VALIDATION" ]'):]
+    branch = branch[: branch.index("elif ", 1)]
+    assert "--output-dir /scratch" in branch, "predictions must be written to the local scratch dir"
+
+
+def test_external_validation_runs_the_preflight_host_checks(docker_sh):
+    """It uses the GPU + reads real data, so it gets the same host preflight as training."""
+    assert re.search(
+        r'if \[ -n "\$DUMMY_TRAINING" \].*\$EXTERNAL_VALIDATION.*then\s*\n\s*_preflight_host_checks',
+        docker_sh,
+    )
+
+
+def test_generated_script_is_valid_bash(docker_sh):
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+        handle.write(docker_sh)
+        path = handle.name
+    result = subprocess.run(["bash", "-n", path], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_the_one_command_wrapper_exists_and_is_valid_bash():
+    assert WRAPPER.is_file(), "scripts/deploy/run_external_validation.sh missing"
+    result = subprocess.run(["bash", "-n", str(WRAPPER)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    text = WRAPPER.read_text()
+    assert "--preflight_check" in text and "--external_validation" in text, (
+        "the wrapper must chain preflight then external validation"
+    )


### PR DESCRIPTION
## What
A first-class **predict-only external-validation** workflow: a center validates a
released global model on its own data **without joining the swarm** (no VPN, no
aggregation, no network). Predictions stay local; only aggregate metrics are shared.

## Why
The capability existed only ad-hoc — `predict.py` driven by an internal smoke script
(#412). New sites had no clean, documented, no-swarm path.

## Changes
- **`docker.sh --external_validation`** — runs `predict.py` on the local `test`/`ext`
  split against a delivered checkpoint (`--checkpoint`, default
  `/scratch/FL_global_model.pt`; `--split`, default `test`), after the same
  data-integrity + GPU preflight as training. Output to `/scratch`, local only.
  **No PKI** — a predict-only node never authenticates to the server.
- **`scripts/deploy/run_external_validation.sh`** — one-command wrapper: preflight →
  validate, with metric-only reporting called out.
- **`docs/EXTERNAL_VALIDATION.md`** — operator/site docs.
- **8 unit tests** (`test_docker_sh_external_validation.py`); asserts it runs predict.py,
  does *not* join the swarm, keeps output local, and the wrapper is valid.

Touches `master_template.yml` **before** the #392 2.8.0 re-port, alongside `--fold`
(#427) and `--docker_options` (#460).

Completes Phase 0 of the pre-send kit program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)