### PR TITLE
STAMP/DECADE kit: run the pre-run host checks the docs promise (closes #451)

### DIFF
--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -912,6 +912,69 @@ docker_cln_sh: |
     fi
   }
 
+  # Pre-run host checks (#451): the STAMP/DECADE kit shipped none while three docs
+  # promised them, so DECADE sites got a --preflight_check that checked nothing. Ported
+  # from the ODELIA kit, minus the ODELIA-only preprocess-cache check (STAMP reads
+  # pre-extracted H5 features, no /data-writable cache); the swarm-scoped checks use the
+  # STAMP container name.
+  _preflight_host_checks() {
+      local fail=0
+      echo "──────────────── Pre-run checks ────────────────"
+
+      # F2: GPU usable inside a container (catches 'NVML: Unknown Error')
+      if timeout 90 docker run --rm --gpus=$GPU2USE $DOCKER_IMAGE nvidia-smi -L >/dev/null 2>&1; then
+          echo "[PASS] GPU usable inside the container."
+      else
+          echo "[FAIL] GPU NOT usable inside the container (likely 'NVML: Unknown Error')."
+          echo "       Fix: run  scripts/client_node_setup/fix_docker_cgroupfs.sh  then recreate the client (docs: F2)."
+          fail=1
+      fi
+
+      # F2 (preventive): systemd cgroup driver -> daemon-reload can strip the GPU mid-run
+      local cgdrv; cgdrv=$(docker info 2>/dev/null | sed -n 's/.*Cgroup Driver: //p' | head -1)
+      if [ "$cgdrv" = "systemd" ]; then
+          echo "[WARN] Docker cgroup driver is 'systemd'. A daily 'systemctl daemon-reload' (e.g. apt"
+          echo "       auto-upgrade) can strip the GPU from RUNNING containers mid-run. Recommended:"
+          echo "       scripts/client_node_setup/fix_docker_cgroupfs.sh  (switches to cgroupfs; docs: F2)."
+      fi
+
+      # Checks that only matter when actually joining the swarm
+      if [ -n "$START_CLIENT" ]; then
+          # F6: swarm server reachable over the VPN (best-effort parse of host:port from kit config)
+          local ep host port
+          ep=$(grep -hoE '[A-Za-z0-9][A-Za-z0-9.-]+\.[A-Za-z]{2,}:80[0-9][0-9]' "$DIR"/*.json 2>/dev/null | head -1)
+          if [ -n "$ep" ]; then
+              host=${ep%%:*}; port=${ep##*:}
+              if timeout 6 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
+                  echo "[PASS] Swarm server $ep reachable."
+              else
+                  echo "[WARN] Swarm server $ep NOT reachable — check the VPN and /etc/hosts (docs: F6)."
+              fi
+          fi
+          # F3: a stale daemon_pid.fl blocks start.sh ("one instance running") after an unclean stop
+          local lock="$DIR/../daemon_pid.fl"
+          if [ -f "$lock" ]; then
+              if docker ps --filter "name=stamp_swarm_client" --format '{{.Names}}' | grep -q .; then
+                  echo "[WARN] $lock present and a client container is running; leaving it in place."
+              else
+                  echo "[INFO] Removing stale daemon_pid.fl (no client container running) so start.sh can launch (docs: F3)."
+                  rm -f "$lock"
+              fi
+          fi
+      fi
+
+      echo "─────────────────────────────────────────────────"
+      if [ "$fail" = "1" ]; then
+          echo "[ABORT] Pre-run checks failed — fix the [FAIL] item(s) above and retry."
+          exit 2
+      fi
+  }
+
+  # Run pre-run host checks for the GPU-using modes
+  if [ -n "$DUMMY_TRAINING" ] || [ -n "$PREFLIGHT_CHECK" ] || [ -n "$START_CLIENT" ]; then
+      _preflight_host_checks
+  fi
+
   # Execution modes
   if [ -n "$DUMMY_TRAINING" ]; then
       docker run --rm $TTY_OPT $DOCKER_OPTIONS $ENV_VARS --env TRAINING_MODE=local_training $DOCKER_IMAGE \

--- a/tests/unit_tests/test_stamp_preflight_checks.py
+++ b/tests/unit_tests/test_stamp_preflight_checks.py
@@ -1,0 +1,69 @@
+"""The STAMP/DECADE kit must run the same pre-run host checks the docs promise (#451).
+
+The ODELIA kit's docker.sh has `_preflight_host_checks()` (GPU-usable-in-container,
+cgroup driver, server reachability, stale daemon_pid.fl). The STAMP/DECADE kit shipped
+NONE of them, yet three docs told sites `docker.sh --preflight_check` runs checks -- so
+the four DECADE sites got a preflight that checked nothing. This asserts the checks are
+now present in the STAMP template, adapted for STAMP (no ODELIA-only preprocess-cache
+check; the STAMP container name).
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP_TEMPLATE = REPO_ROOT / "docker_config" / "master_template_STAMP.yml"
+
+
+@pytest.fixture(scope="module")
+def stamp_sh():
+    template = yaml.safe_load(STAMP_TEMPLATE.read_text())
+    return re.sub(r"\{~~[a-z_]+~~\}", "TESTSITE", template["docker_cln_sh"])
+
+
+def test_stamp_kit_has_preflight_host_checks(stamp_sh):
+    assert "_preflight_host_checks()" in stamp_sh, "STAMP kit still ships no pre-run checks"
+
+
+def test_preflight_runs_for_the_gpu_using_modes(stamp_sh):
+    assert re.search(
+        r'if \[ -n "\$DUMMY_TRAINING" \] \|\| \[ -n "\$PREFLIGHT_CHECK" \] \|\| \[ -n "\$START_CLIENT" \]; then\s*\n\s*_preflight_host_checks',
+        stamp_sh,
+    ), "preflight is defined but never called before the execution modes"
+
+
+def test_gpu_check_is_present_and_aborts_on_failure(stamp_sh):
+    """The load-bearing check: GPU usable in the container, and a [FAIL] aborts."""
+    assert "nvidia-smi -L" in stamp_sh and "GPU usable inside the container" in stamp_sh
+    assert "[ABORT] Pre-run checks failed" in stamp_sh
+    assert re.search(r'if \[ "\$fail" = "1" \]; then\s*\n\s*echo "\[ABORT\]', stamp_sh)
+
+
+def test_prints_a_pre_run_checks_block(stamp_sh):
+    """Matches the docs' promise of a 'Pre-run checks' block with [PASS]/[FAIL]."""
+    assert "Pre-run checks" in stamp_sh
+    assert "[PASS]" in stamp_sh and "[FAIL]" in stamp_sh
+
+
+def test_uses_the_stamp_container_name_not_odelia(stamp_sh):
+    assert "stamp_swarm_client" in stamp_sh
+    assert "odelia_swarm_client" not in stamp_sh, "copied the ODELIA container name verbatim"
+
+
+def test_does_not_port_the_odelia_only_preprocess_cache_check(stamp_sh):
+    """STAMP reads pre-extracted H5 features -- it has no ODELIA_PREPROCESS_CACHE_DIR."""
+    assert "ODELIA_PREPROCESS_CACHE_DIR" not in stamp_sh
+
+
+def test_generated_stamp_script_is_valid_bash(stamp_sh):
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+        handle.write(stamp_sh)
+        path = handle.name
+    result = subprocess.run(["bash", "-n", path], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What
Ports `_preflight_host_checks()` into the STAMP/DECADE kit's `docker.sh`
(`master_template_STAMP.yml`). It previously ran **no** pre-run checks.

## Why
Three docs (`SWARM_FAILURE_MODES.md`, `README.participant.md`, `ROLLOUT_v1.5.0.md`) tell
sites `docker.sh --preflight_check` runs checks — but the STAMP kit had none, so the four
DECADE sites (Bonn, Mainz, Düsseldorf, Heidelberg) got a preflight that checked nothing,
and the consortium handbook checklist was invalid for them. This makes the promise true.

## Adaptation from ODELIA
- **Kept:** GPU-usable-in-container (F2, `[ABORT]`s), cgroup-driver warning (F2),
  server-reachability (F6), stale `daemon_pid.fl` cleanup (F3).
- **Dropped:** the ODELIA-only `ODELIA_PREPROCESS_CACHE_DIR` check (STAMP reads
  pre-extracted H5 features — no `/data`-writable cache).
- **Changed:** the running-client probe uses the STAMP container name.

Called before the execution modes for the GPU-using modes, mirroring ODELIA.

## Tests
7 parity unit tests (`test_stamp_preflight_checks.py`), all green; rendered script passes
`bash -n`. Runtime check (seeded GPU-visible failure → `[ABORT]`) to confirm on the next
STAMP image build.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)