### PR TITLE
DECADE: follow a release channel, and stop the injector handing it ODELIA's image

### DIFF
--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -741,6 +741,7 @@ docker_cln_sh: |
           --data_dir)            _need_value "$1" "${2:-}"; MY_DATA_DIR="$2"; shift ;;
           --scratch_dir)         _need_value "$1" "${2:-}"; MY_SCRATCH_DIR="$2"; shift ;;
           --GPU)                 _need_value "$1" "${2:-}"; GPU2USE="$2"; shift ;;
+          --image)               _need_value "$1" "${2:-}"; CLI_IMAGE="$2"; shift ;;
           --no_pull)             NOPULL="1" ;;
           --dummy_training)      DUMMY_TRAINING="1" ;;
           --preflight_check)     PREFLIGHT_CHECK="1" ;;
@@ -788,7 +789,31 @@ docker_cln_sh: |
   rm -rf ../pid.fl ../daemon_pid.fl
 
   # Docker image and container name
+  #
+  # The provisioned tag below is only the DEFAULT. The backbone, the training code
+  # and the job configs all ship in the IMAGE (not in this kit), and docker.sh pulls
+  # by tag on every run -- so a site can move to a new image WITHOUT a new kit:
+  #
+  #   startup/image.conf   ->  MEDISWARM_IMAGE=jefftud/decade:1.6.0    (persistent)
+  #   ./docker.sh --image jefftud/decade:1.6.0 ...                     (one-off)
+  #
+  # Point image.conf at a release channel (e.g. :current) to pick up releases with no
+  # action at all. Precedence: --image > MEDISWARM_IMAGE env > image.conf > default.
+  #
+  # image.conf is written per project by _injectLiveSyncIntoStartupKits.sh and follows
+  # THIS project's image repository (jefftud/decade for DECADE), never the other
+  # consortium's -- see tests/unit_tests/test_image_conf_channel_per_project.py.
   DOCKER_IMAGE={~~docker_image~~}
+  # Capture a pre-exported MEDISWARM_IMAGE BEFORE sourcing image.conf, so a one-off
+  # env override wins over the persistent file (documented precedence: --image > env
+  # > image.conf > default). Without this, image.conf's assignment would clobber the
+  # env var (#449 follow-up).
+  ENV_IMAGE="${MEDISWARM_IMAGE:-}"
+  if [ -f "$DIR/image.conf" ]; then
+      . "$DIR/image.conf"
+  fi
+  MEDISWARM_IMAGE="${ENV_IMAGE:-${MEDISWARM_IMAGE:-}}"
+  DOCKER_IMAGE="${CLI_IMAGE:-${MEDISWARM_IMAGE:-$DOCKER_IMAGE}}"
   if [[ -z "$NOPULL" ]]; then
       echo "Updating docker image"
       docker pull "$DOCKER_IMAGE"

--- a/docs/consortium_decade/README.md
+++ b/docs/consortium_decade/README.md
@@ -38,16 +38,30 @@ Both consortia ship plain `.zip` kits now (ODELIA dropped its per-site encryptio
 2026-07-16). The DECADE build does not emit a `kit_manifest.csv`, so compute the
 `sha256` yourself with `sha256sum` for the registry.
 
-- **DECADE kits still churn certificates on rebuild.** ODELIA has a cert-stability fix
-  (#449) so its kits survive image updates; that fix is **not yet applied to STAMP**.
-  Until it is, a new fix means a new ACTIVE kit that everyone must switch to (the old
-  one can no longer authenticate). Track that on the Run Board.
+- **Certificates: one last churn, then stable.** #449 keys the PKI off a *stable* project
+  name, and `decade_allsites` is one of the two production projects it covers — so the
+  fix does apply to DECADE. But the deployed `6bc06c4` kits were provisioned under the
+  old *versioned* name, so the first build under `decade_allsites` starts a fresh state
+  directory and mints a new CA. That is **one final forced kit swap**; every build after
+  it reuses the same CA and keys.
+
+  Measured, not assumed: the 7 legacy versioned DECADE builds produced 7 different root
+  CAs, while ODELIA's 4 provisioning runs under its stable name all share one
+  (`c1a208118806…`).
 
 ## Shipping a software update without a new kit
 
-If a fix lives in the **image** and does not touch the certificates, publish the image
-and put its tag in the run-schedule row — sites pick it up on their next
-`start_client` (`docker.sh` re-pulls). If a fix requires a rebuilt kit (new certs),
+Kits ship `startup/image.conf` pinning a **release channel** (`jefftud/decade:current`).
+`docker.sh` sources it on every run, so re-tagging `:current` centrally moves every site
+on its next start — no kit re-issue, and we never pull or restart under a site.
+Precedence is `--image` > `MEDISWARM_IMAGE` env > `image.conf` > the provisioned tag.
+
+The channel follows **this** consortium's repository. DECADE kits get
+`jefftud/decade:current` and ODELIA kits `jefftud/odelia:current`; the injector derives
+it from the project YAML rather than hardcoding one, so a DECADE rebuild can never hand
+sites the ODELIA image.
+
+Only a change to the certificates or to `docker.sh` itself needs a rebuilt kit — then
 mark the new kit ACTIVE and the old one DEPRECATED.
 
 ## ⚠️ Before pointing partners at any of this

--- a/scripts/build/_injectLiveSyncIntoStartupKits.sh
+++ b/scripts/build/_injectLiveSyncIntoStartupKits.sh
@@ -10,6 +10,29 @@ PROJECT_YML="$1"
 OUTPUT_FOLDER="workspace/$(grep '^name: ' "$PROJECT_YML" | sed 's/name: //')"
 TARGET_FOLDER="$(ls -d "$OUTPUT_FOLDER"/prod_* | tail -n 1)"
 
+# Image repository this project's kits follow, taken from the project YAML rather than
+# hardcoded: this script provisions BOTH consortia (ODELIA -> jefftud/odelia, DECADE ->
+# jefftud/decade). A hardcoded repo here writes the wrong channel into the other
+# consortium's image.conf, pointing every one of its sites at a foreign image.
+_docker_image_value="$(grep -m1 -E '^[[:space:]]*docker_image:' "$PROJECT_YML" \
+  | sed -E 's/^[[:space:]]*docker_image:[[:space:]]*//; s/[[:space:]]*$//' || true)"
+if [ -z "$_docker_image_value" ]; then
+  echo "Could not read docker_image from $PROJECT_YML -- cannot pick a release channel."
+  exit 1
+fi
+# Strip the tag to get the bare repository. Only treat the trailing ':...' as a tag when
+# it is not a registry port (a port segment still contains a '/', e.g. host:5000/repo).
+case "${_docker_image_value##*:}" in
+  */*|"") IMAGE_REPO="$_docker_image_value" ;;
+  *)      IMAGE_REPO="${_docker_image_value%:*}" ;;
+esac
+
+# Only used to make the "pin a specific version" example in image.conf concrete.
+PINNED_EXAMPLE_TAG="$(grep -m1 -E '^[0-9]' odelia_image.version 2>/dev/null | tr -d '[:space:]' || true)"
+PINNED_EXAMPLE_TAG="${PINNED_EXAMPLE_TAG:-1.6.0}"
+
+echo "Release channel for these kits: ${IMAGE_REPO}:current"
+
 HELPER_SOURCE_DIR="kit_live_sync"
 SYNC_CONF_SOURCE="$HELPER_SOURCE_DIR/sync.conf"
 SYNC_CONF_EXAMPLE_SOURCE="$HELPER_SOURCE_DIR/sync.conf.example"
@@ -65,18 +88,24 @@ find "$TARGET_FOLDER" -mindepth 1 -maxdepth 1 -type d | while read -r KIT_DIR; d
   # sources this on every run, so re-tagging :current centrally updates every node on
   # its next start -- no action at the site. (A site still chooses WHEN to run; we
   # never pull or restart under them.) Don't clobber a site's own edit on re-issue.
+  #
+  # The channel MUST follow this project's own image repository. We run two consortia
+  # off this one build script (ODELIA -> jefftud/odelia, DECADE -> jefftud/decade), so
+  # a hardcoded repo here silently hands one consortium the other's image. $IMAGE_REPO
+  # is derived from the project YAML's docker_image line for exactly that reason.
   if [ ! -f "$STARTUP_DIR/image.conf" ]; then
-    cat > "$STARTUP_DIR/image.conf" <<'IMAGECONF'
-# Which ODELIA image this node runs. Read by docker.sh on every run.
+    cat > "$STARTUP_DIR/image.conf" <<IMAGECONF
+# Which image this node runs. Read by docker.sh on every run.
 #
-# Default: the release channel. When a new ODELIA release ships, we re-tag
-# :current and this node picks it up the next time you start it -- nothing to do
-# here. The Run Board's "Run schedule" tab always names the exact tag of a run.
+# Default: the release channel. When a new release ships, we re-tag
+# ${IMAGE_REPO}:current and this node picks it up the next time you start it --
+# nothing to do here. The Run Board's "Run schedule" tab always names the exact
+# tag of a run.
 #
 # To pin a specific version instead, replace the line below, e.g.
-#   MEDISWARM_IMAGE=jefftud/odelia:1.6.0
+#   MEDISWARM_IMAGE=${IMAGE_REPO}:${PINNED_EXAMPLE_TAG}
 # For a one-off without editing this file:  ./docker.sh --image <ref> ...
-MEDISWARM_IMAGE=jefftud/odelia:current
+MEDISWARM_IMAGE=${IMAGE_REPO}:current
 IMAGECONF
   fi
 

--- a/tests/unit_tests/test_image_conf_channel_per_project.py
+++ b/tests/unit_tests/test_image_conf_channel_per_project.py
@@ -1,0 +1,100 @@
+"""The release channel in a kit's image.conf must follow that project's own image.
+
+We provision two consortia from one build script: ODELIA (jefftud/odelia) and DECADE
+(jefftud/decade). _injectLiveSyncIntoStartupKits.sh used to hardcode
+`MEDISWARM_IMAGE=jefftud/odelia:current` into every kit it touched, which meant a DECADE
+rebuild shipped all four DECADE sites a channel pointing at the ODELIA image. It was
+inert only because the STAMP docker.sh did not yet source image.conf -- the moment it
+did, every DECADE node would pull the wrong image.
+
+These tests run the real injector against a throwaway workspace and assert the rendered
+image.conf follows the project YAML's docker_image line.
+"""
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INJECTOR = REPO_ROOT / "scripts" / "build" / "_injectLiveSyncIntoStartupKits.sh"
+
+
+def _run_injector(tmp_path, project_name, docker_image):
+    """Provision a minimal fake kit tree, run the injector, return image.conf text."""
+    workspace = REPO_ROOT / "workspace" / project_name
+    startup = workspace / "prod_00" / "SITE_1" / "startup"
+    startup.mkdir(parents=True, exist_ok=True)
+    # The injector only treats a directory as a kit if it holds a docker.sh.
+    (startup / "docker.sh").write_text("#!/usr/bin/env bash\n")
+
+    project_yml = tmp_path / "project.yml"
+    project_yml.write_text(
+        textwrap.dedent(
+            f"""\
+            name: {project_name}
+            participants:
+              - name: SITE_1
+                type: client
+                docker_image: {docker_image}
+            """
+        )
+    )
+
+    try:
+        subprocess.run(
+            ["bash", str(INJECTOR), str(project_yml)],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return (startup / "image.conf").read_text()
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "project_name,docker_image,expected_repo,foreign_repo",
+    [
+        ("test_channel_odelia", "jefftud/odelia:1.6.0", "jefftud/odelia", "jefftud/decade"),
+        ("test_channel_decade", "jefftud/decade:1.6.0", "jefftud/decade", "jefftud/odelia"),
+    ],
+)
+def test_channel_follows_project_image(
+    tmp_path, project_name, docker_image, expected_repo, foreign_repo
+):
+    conf = _run_injector(tmp_path, project_name, docker_image)
+
+    assert f"MEDISWARM_IMAGE={expected_repo}:current" in conf
+    # The regression that motivated this file: the other consortium's repo must not
+    # appear anywhere in the rendered file, not even in the "pin a version" example.
+    assert foreign_repo not in conf
+
+
+def test_unversioned_placeholder_image_still_yields_a_channel(tmp_path):
+    """Production YAMLs carry a substitution placeholder as the tag, not a real version."""
+    conf = _run_injector(
+        tmp_path,
+        "test_channel_placeholder",
+        "jefftud/decade:__REPLACED_BY_CURRENT_VERSION_NUMBER_WHEN_BUILDING_STARTUP_KITS__",
+    )
+    assert "MEDISWARM_IMAGE=jefftud/decade:current" in conf
+    assert "__REPLACED_BY" not in conf
+
+
+def test_real_project_yamls_map_to_their_own_consortium(tmp_path):
+    """Guard the two production rosters themselves, not just synthetic inputs."""
+    for yml_name, expected in [
+        ("project_Odelia_allsites.yml", "jefftud/odelia:current"),
+        ("project_DECADE_allsites.yml", "jefftud/decade:current"),
+    ]:
+        yml = REPO_ROOT / "application" / "provision" / yml_name
+        line = next(
+            l for l in yml.read_text().splitlines() if l.strip().startswith("docker_image:")
+        )
+        value = line.split("docker_image:", 1)[1].strip()
+        repo = value.rsplit(":", 1)[0] if "/" not in value.rsplit(":", 1)[-1] else value
+        assert f"{repo}:current" == expected, f"{yml_name} would follow the wrong channel"

--- a/tests/unit_tests/test_stamp_image_conf.py
+++ b/tests/unit_tests/test_stamp_image_conf.py
@@ -1,0 +1,98 @@
+"""The STAMP/DECADE kit must follow a release channel, with ODELIA's precedence.
+
+DECADE kits previously pinned whatever tag they were provisioned with: every software
+fix meant re-issuing four startup kits. ODELIA solved this with startup/image.conf plus
+a documented precedence (--image > MEDISWARM_IMAGE env > image.conf > provisioned
+default); the STAMP template had none of it.
+
+These tests execute the rendered resolution logic rather than grepping for it, so a
+future edit that reorders the chain (e.g. sourcing image.conf after capturing the env)
+fails here instead of silently changing which image four hospitals run.
+"""
+
+import re
+import subprocess
+import textwrap
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "docker_config" / "master_template_STAMP.yml"
+
+PROVISIONED = "jefftud/decade:1.5.0-provisioned"
+
+
+@pytest.fixture(scope="module")
+def resolution_snippet():
+    """The image-resolution block from the client docker.sh, ready to execute."""
+    script = yaml.safe_load(TEMPLATE.read_text())["docker_cln_sh"]
+    script = script.replace("{~~docker_image~~}", PROVISIONED)
+
+    start = script.index("DOCKER_IMAGE=" + PROVISIONED)
+    end = script.index('DOCKER_IMAGE="${CLI_IMAGE:-${MEDISWARM_IMAGE:-$DOCKER_IMAGE}}"')
+    snippet = script[start : end + len('DOCKER_IMAGE="${CLI_IMAGE:-${MEDISWARM_IMAGE:-$DOCKER_IMAGE}}"')]
+    return textwrap.dedent(snippet)
+
+
+def _resolve(snippet, tmp_path, image_conf=None, env_image=None, cli_image=None):
+    """Run the block with a given combination of overrides; return the chosen image."""
+    if image_conf is not None:
+        (tmp_path / "image.conf").write_text(f"MEDISWARM_IMAGE={image_conf}\n")
+
+    prelude = f'DIR="{tmp_path}"\n'
+    prelude += f'CLI_IMAGE="{cli_image}"\n' if cli_image else 'CLI_IMAGE=""\n'
+    if env_image:
+        prelude += f'export MEDISWARM_IMAGE="{env_image}"\n'
+
+    result = subprocess.run(
+        ["bash", "-c", prelude + snippet + '\necho "RESOLVED=$DOCKER_IMAGE"'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return re.search(r"RESOLVED=(\S+)", result.stdout).group(1)
+
+
+def test_defaults_to_provisioned_tag(resolution_snippet, tmp_path):
+    assert _resolve(resolution_snippet, tmp_path) == PROVISIONED
+
+
+def test_image_conf_channel_beats_the_provisioned_default(resolution_snippet, tmp_path):
+    """The whole point: re-tagging :current moves a site with no kit re-issue."""
+    got = _resolve(resolution_snippet, tmp_path, image_conf="jefftud/decade:current")
+    assert got == "jefftud/decade:current"
+
+
+def test_env_beats_image_conf(resolution_snippet, tmp_path):
+    """Regression for the #449 follow-up: sourcing image.conf must not clobber the env."""
+    got = _resolve(
+        resolution_snippet,
+        tmp_path,
+        image_conf="jefftud/decade:current",
+        env_image="jefftud/decade:pinned-by-env",
+    )
+    assert got == "jefftud/decade:pinned-by-env"
+
+
+def test_cli_flag_wins_over_everything(resolution_snippet, tmp_path):
+    got = _resolve(
+        resolution_snippet,
+        tmp_path,
+        image_conf="jefftud/decade:current",
+        env_image="jefftud/decade:pinned-by-env",
+        cli_image="jefftud/decade:one-off",
+    )
+    assert got == "jefftud/decade:one-off"
+
+
+def test_image_flag_is_accepted_by_the_arg_parser():
+    """--image must be parseable, or the one-off override is unreachable."""
+    script = yaml.safe_load(TEMPLATE.read_text())["docker_cln_sh"]
+    assert "--image)" in script, "STAMP docker.sh does not accept --image"
+    # It takes a value, so it must be guarded like the other value-taking flags (#443):
+    # a bare `--image` with an empty variable would otherwise swallow the next flag.
+    assert re.search(r"--image\)\s+_need_value", script)


### PR DESCRIPTION
Prep for the DECADE 1.6.0 rollout, mirroring what ODELIA just shipped. Two consortia now build from this repo and the kit tooling still assumed one.

## 1. The landmine (fix first — it gates everything else)

`_injectLiveSyncIntoStartupKits.sh` hardcoded:

```
MEDISWARM_IMAGE=jefftud/odelia:current
```

It is called unconditionally for **every** project (`_buildStartupKits.sh`), so a DECADE rebuild ships all four DECADE sites a channel pointing at the **ODELIA** image. It is inert today only because the STAMP `docker.sh` never sourced `image.conf` — doing part 2 without this would have pointed every DECADE node at the wrong image at once.

Now derived from the project YAML's `docker_image` line:

| project | channel |
|---|---|
| `project_Odelia_allsites.yml` | `jefftud/odelia:current` |
| `project_DECADE_allsites.yml` | `jefftud/decade:current` |

## 2. `image.conf` for STAMP/DECADE

Ported with ODELIA's precedence — `--image` > `MEDISWARM_IMAGE` env > `image.conf` > provisioned tag — including the capture-before-source ordering from the #449 follow-up, plus an `--image` flag guarded by `_need_value` like the other value-taking flags (#443). DECADE sites can now take a release **without a kit re-issue**.

## 3. Docs correction

The DECADE hub claimed #449 was "not yet applied to STAMP". It **does** apply — `decade_allsites` is one of the two stable-named production projects. But the deployed `6bc06c4` kits predate the rename, so the next build is **one final forced cert swap**, then stable.

Measured rather than assumed:
- 7 legacy versioned DECADE builds → **7 different root CAs**
- ODELIA's 4 runs under its stable name → **one shared CA** (`c1a208118806…`)

## Tests

`test_image_conf_channel_per_project.py` runs the real injector against a throwaway workspace and asserts neither consortium can be handed the other's repository (mutation-checked: reintroducing the hardcode fails it). `test_stamp_image_conf.py` **executes** the resolution chain rather than grepping for it.

Full suite: **322 passed, 4 skipped** — ODELIA unaffected by the shared-script change (it already has `image.conf`, and the injector does not clobber an existing one).

⚠️ Touches `master_template_STAMP.yml` → **requires a DECADE kit rebuild** (already required by #464). ODELIA kits unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)