### PR TITLE
docs(decade): 1.6.0 rollout — release channel, final cert swap, partner email

### DIFF
--- a/docs/DECADE_kit_1.6.0_email.md
+++ b/docs/DECADE_kit_1.6.0_email.md
@@ -1,0 +1,89 @@
+# DECADE consortium email — v1.6.0 kits
+
+**To:** Islem.Gammoudi@ukbonn.de; glasnerc@uni-mainz.de;
+TobiasPaul.Seraphin@med.uni-duesseldorf.de; ckobrow@mailbox.org;
+nina.nelius@med.uni-heidelberg.de
+
+**Subject:** DECADE — new startup kits (v1.6.0), and the last kit swap you'll need
+
+---
+
+Dear all,
+
+New DECADE startup kits (**v1.6.0**) are ready, along with a Handbook and a Run Board
+that replace the instructions we have been sending by email.
+
+**Handbook:** `<DOC_LINK>`
+
+**Run Board:** `<SHEET_LINK>`
+
+**Startup kits download link:** `<DRIVE_FOLDER_LINK>`
+
+## Getting your kit
+
+Open the download link above and take **only your own site's file**, e.g.
+`UKB_1_1.6.0.zip`. The folder is members-only and each kit contains that site's private
+key, so please don't repost it anywhere.
+
+Check it matches the **Kit registry** tab of the Run Board. Each site's kit has its
+**own** hash (it contains your certificates), so compare against the row for your site:
+
+```bash
+sha256sum <SITE>_1.6.0.zip
+```
+
+Unzip it — that's the whole install:
+
+```bash
+unzip <SITE>_1.6.0.zip
+```
+
+## Worth knowing
+
+**Software updates now reach you automatically.** Your kit includes
+`startup/image.conf` pointing at our release channel. When we publish a new version,
+your node picks it up the next time you start it — nothing to install, and we never
+pull or restart anything on your machine. The Run Board's **Run schedule** tab always
+names the exact image a run uses (currently `jefftud/decade:1.6.0`).
+
+**This is the last kit swap you will need.** Until now every rebuild regenerated your
+certificates, which is why you have received a new kit almost weekly. That is fixed
+from 1.6.0 onward — but because the fix changes how the certificates are stored,
+moving to 1.6.0 requires one final switch. After this, a software fix reaches you
+through the channel above, with no new kit.
+
+**`--preflight_check` now actually checks your host.** Three of our documents promised
+pre-run checks that the DECADE kit never ran — it verified nothing beyond loading your
+data. It now checks that the GPU is usable inside the container, warns about a Docker
+cgroup-driver setting that can strip the GPU from a running job, and (for
+`--start_client`) checks it can reach the swarm server. **Please re-run
+`--preflight_check` on the new kit** even if it passed before, and re-tick your row.
+
+## Before the next run
+
+Please work through your row in the **Site checklist** tab (Handbook §1–2 has the
+commands) and tick it off. If something fails, check **Known issues** first — it is
+cumulative, and the fix is usually already there.
+
+Two notes on what we are still waiting for:
+
+- **The shared target is not settled yet.** MSI-High is the front-runner (Mainz and
+  Heidelberg can supply it). Islem — thank you for the update from Dr. Robert; we have
+  recorded that UKB has no cohort-wide MSI and that Heidelberg is checking the adenoma
+  subset. Tobias, we look forward to your numbers.
+- Because of that, **no run date is set**. We will put it on the Run Board rather than
+  send another email.
+
+Thanks,
+Jeff
+
+---
+
+## Operator notes (not part of the email)
+
+Fill before sending:
+- `<DOC_LINK>` / `<SHEET_LINK>` — the DECADE Handbook + Run Board (already published)
+- `<DRIVE_FOLDER_LINK>` — members-only Drive folder holding the four `*_1.6.0.zip` kits
+
+Do **not** attach kits to the email: one kit per site, shared folder only.
+Do **not** link the live monitor — it has no auth and no per-site scoping.

--- a/docs/consortium_decade/PARTNER_HANDBOOK.md
+++ b/docs/consortium_decade/PARTNER_HANDBOOK.md
@@ -167,20 +167,38 @@ output.
 
 ---
 
-## 5. About kits and certificates (read this once)
+## 5. About kits, updates and certificates (read this once)
 
-**A DECADE kit currently contains site-specific TLS certificates, and a rebuild of
-the image regenerates them.** So when we ship a new ACTIVE kit, your old kit can no
-longer connect — you must switch. The Run Board's **Kit registry** is the source of
-truth for which kit is ACTIVE and its `sha256`; verify yours matches:
+**Software updates now reach you automatically.** Your kit contains
+`startup/image.conf`, which names a release channel:
+
+```
+MEDISWARM_IMAGE=jefftud/decade:current
+```
+
+`docker.sh` reads it on every run. When we publish a new version we re-tag
+`:current`, and your node picks it up **the next time you start it** — nothing to
+install. We never pull or restart anything on your machine: we choose *which*
+version, you still choose *when* to run. The Run Board's **Run schedule** tab always
+names the exact image a given run uses.
+
+To pin a specific version instead, edit that line (e.g.
+`MEDISWARM_IMAGE=jefftud/decade:1.6.0`). For a one-off, pass `--image <ref>` to
+`docker.sh`. Re-issuing a kit never overwrites an `image.conf` you have edited.
+
+**Certificates — one last swap.** Kits contain site-specific TLS certificates. Until
+now every rebuild regenerated them, which is why you received a new kit almost weekly.
+That is fixed: from **1.6.0** onward, rebuilds reuse the same certificates. Because the
+fix changes how they are stored, moving to 1.6.0 is the **final forced kit swap** —
+after it, a software fix reaches you through the channel above, with no new kit.
+
+The Run Board's **Kit registry** is the source of truth for which kit is ACTIVE and
+its `sha256`. Each site's `.zip` has its **own** hash (it contains your certificates),
+so check the row for *your* site:
 
 ```bash
 sha256sum <SITE_NAME>_<version>.zip
 ```
-
-(ODELIA has a certificate-stability fix so its kits survive image updates; that fix
-is **not yet applied to STAMP/DECADE**. Until it is, expect an occasional kit
-re-issue when we ship a fix — the operator will say so on the Board.)
 
 ---
 

--- a/docs/consortium_decade/sheet_1_run_schedule.csv
+++ b/docs/consortium_decade/sheet_1_run_schedule.csv
@@ -2,12 +2,13 @@ Field,Value,Notes
 Programme,DECADE,Computational pathology (STAMP) swarm — 4 sites
 Status,POSTPONED,Not scheduled | Sites preparing | Ready | Running | Complete | Aborted | Postponed
 Next run date,TBC,"Blocked on the shared target (below). Set it here and tell sites here — not by email"
-Shared target,UNDECIDED,"Proposed: MSI-High (binary). Mainz + Heidelberg can supply it; Bonn cannot (all 'not provided'); Düsseldorf pending"
+Shared target,UNDECIDED,"Proposed: MSI-High (binary). Mainz + Heidelberg can supply it. Bonn confirmed 2026-07-15 it has no cohort-wide MSI; Heidelberg is cross-matching Bonn's 1174 slides for an adenoma subset (yield unknown). Düsseldorf reports by 2026-07-22"
 STAMP_NUM_CLASSES,TBC,"Follows the target — 2 for binary MSI-High"
 STAMP_GROUND_TRUTH_LABEL,TBC,"Per-site exact column name; sent with the target decision"
 Feature extractor,"UNI, dim 1024",All sites identical; extracted with standalone STAMP 2.5.0
 Model,vit,"Also available: mlp, trans_mil, linear. barspoon is NOT available (needs STAMP 2.5.0)"
-Image for this run,jefftud/decade:1.5.0-dev.260713.6bc06c4,"Pin the exact tag. docker.sh re-pulls it; contains backbone + training code + job configs"
+Image for this run,jefftud/decade:1.6.0,"Pin the exact tag. docker.sh re-pulls it; contains backbone + training code + job configs"
+Release channel,jefftud/decade:current,"What kits follow by default (startup/image.conf). Re-tag :current to move every site on its next start — no kit re-issue. Sites can pin a version by editing that file"
 Rounds,20,Set at job-prep time — no kit or image rebuild needed
 Quorum (configure/min/responses),4 / 4 / 4,"No fault tolerance for the benchmark: every site must register and finish"
 Server,dl3.tud.de:8002,Tailscale only. Map dl3.tud.de -> 100.100.101.100 in /etc/hosts


### PR DESCRIPTION
Partner-facing half of the DECADE 1.6.0 rollout (code half: #464, #467).

- **Handbook §5** rewritten around the release channel: kits ship `startup/image.conf` → `jefftud/decade:current`, so a fix reaches sites on their next start with no kit re-issue. Documents precedence and that a re-issued kit never clobbers an edited `image.conf`.
- Says plainly that **1.6.0 is the last forced kit swap** — #449 keys the PKI off a stable project name, but the deployed kits predate the rename, so this build mints new certs and every later build reuses them.
- Notes each site's `.zip` has its **own** sha256 (it contains that site's certificates), matching the per-site Kit registry from #454.
- **Run schedule**: image → `1.6.0`, new `Release channel` row, shared-target note updated with Bonn's 2026-07-15 finding.
- Adds the **consortium email draft**, mirroring the ODELIA 1.6.0 one, including the ask to re-run `--preflight_check` now that it actually checks the host (#451/#464).

Docs only — no kit or image impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)