### PR TITLE
CI: give manual builds and deploy tests the same host lock as CI (#448)

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -43,6 +43,23 @@ jobs:
 
 
     steps:
+      - name: Wait for any manual build / deploy test on this host (#448)
+        run: |
+          # This runner shares its GPU, Docker daemon and ports 8002/8003 with
+          # DECADE image builds and deploy tests that are started by hand and
+          # belong to no concurrency group. Critically, the cleanup step below
+          # kills every container matching odelia|stamp|nvflare -- which would
+          # destroy a manual deploy test mid-run -- so wait for the host lock
+          # BEFORE touching any container. Manual runs hold this same lock via
+          # scripts/ci/host_gpu_lock.sh. Inlined rather than sourced because the
+          # repository has not been checked out at this point.
+          command -v flock >/dev/null 2>&1 || { echo "flock unavailable; skipping"; exit 0; }
+          if flock -w 3600 /tmp/mediswarm-host-gpu.lock true; then
+            echo "host is free; proceeding"
+          else
+            echo "host still busy after 3600s; proceeding anyway (CI must not hang forever)"
+          fi
+
       - name: Clean up root-owned files from previous Docker runs
         run: |
           # Canceled self-hosted runs can leave GPU/NVFlare containers alive

--- a/scripts/build/buildDockerImageAndStartupKits.sh
+++ b/scripts/build/buildDockerImageAndStartupKits.sh
@@ -40,6 +40,12 @@ if [ ! -f "$DOCKERFILE" ]; then
     exit 1
 fi
 
+# This box also hosts the self-hosted CI runner. A multi-GB build landing on top of
+# a running validate-swarm job starves it and fails unrelated PRs (#448, #388), so
+# queue behind any other GPU/Docker job instead of interleaving.
+. "$SCRIPT_DIR/../ci/host_gpu_lock.sh"
+acquire_host_lock "image build ($(basename "$PROJECT_FILE"))" || exit 1
+
 VERSION=`"$SCRIPT_DIR/getVersionNumber.sh"`
 CONTAINER_VERSION_ID=`git rev-parse --short HEAD`
 

--- a/scripts/ci/host_gpu_lock.sh
+++ b/scripts/ci/host_gpu_lock.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# ============================================================================
+# host_gpu_lock.sh — host-wide mutex for GPU/Docker-heavy MediSwarm work (#448)
+#
+# The self-hosted CI runner and our DECADE image builds / deploy tests are the
+# SAME machine. They share one GPU, one Docker daemon, and ports 8002/8003.
+# #445 made CI *tolerant* of that contention (longer liveness/poll timeouts); it
+# did not remove it.
+#
+# CI already serialises itself through the `mediswarm-self-hosted-gpu-validation`
+# concurrency group. The gap #448 names is the other side: image builds and
+# deploy tests are started BY HAND and belong to no group, so nothing stops them
+# landing on top of a running CI job. "Check the runner is idle first" is exactly
+# the discipline that lapses under time pressure -- it lapsed during the 1.6.0
+# rollout, which is why this exists.
+#
+# Two entry points:
+#
+#   source scripts/ci/host_gpu_lock.sh && acquire_host_lock "what I am"
+#       Takes the lock for the REST OF THE CALLING PROCESS (released on exit).
+#       Used by the manual build / deploy-test scripts.
+#
+#   scripts/ci/host_gpu_lock.sh wait [timeout_s]
+#       Blocks until the lock is free, then returns WITHOUT holding it. Used as a
+#       CI step so a job defers to a manual build already in flight instead of
+#       racing it.
+#
+# Scope, honestly: this removes the "manual run lands on top of CI" collision and
+# makes CI yield to an in-flight manual run. It does NOT make the two fully
+# mutually exclusive for a whole CI job, because each GitHub Actions step is its
+# own process and cannot hold a file descriptor across steps. Closing #448
+# properly still wants a dedicated runner (option 1 in the issue).
+#
+# Escape hatch: MEDISWARM_SKIP_HOST_LOCK=1 (expect flaky CI if you use it).
+# ============================================================================
+
+MEDISWARM_HOST_LOCK="${MEDISWARM_HOST_LOCK:-/tmp/mediswarm-host-gpu.lock}"
+
+# Wait up to this long for a peer to finish. A DECADE image build + push is ~10
+# min and a 2-node deploy test can run an hour, so the default is generous: we
+# would rather queue than interleave and produce a false CI failure.
+MEDISWARM_LOCK_WAIT="${MEDISWARM_LOCK_WAIT:-3600}"
+
+_host_lock_available() {
+    if [ -n "${MEDISWARM_SKIP_HOST_LOCK:-}" ]; then
+        echo "[host-lock] disabled via MEDISWARM_SKIP_HOST_LOCK" >&2
+        return 1
+    fi
+    if ! command -v flock >/dev/null 2>&1; then
+        # Non-Linux dev boxes: degrade to a no-op rather than block a build.
+        echo "[host-lock] flock not available; continuing unguarded" >&2
+        return 1
+    fi
+    return 0
+}
+
+# acquire_host_lock <description> [timeout_s]
+# Holds the lock until the calling process exits. Returns non-zero on timeout so
+# the caller can abort rather than silently interleave.
+acquire_host_lock() {
+    local what="${1:-MediSwarm job}"
+    local wait_s="${2:-$MEDISWARM_LOCK_WAIT}"
+
+    _host_lock_available || return 0
+
+    exec {MEDISWARM_LOCK_FD}>"$MEDISWARM_HOST_LOCK" 2>/dev/null || {
+        echo "[host-lock] cannot open $MEDISWARM_HOST_LOCK; continuing unguarded" >&2
+        return 0
+    }
+
+    if flock -n "$MEDISWARM_LOCK_FD"; then
+        echo "[host-lock] acquired for: $what"
+        return 0
+    fi
+
+    echo "[host-lock] another GPU/Docker job holds the host; waiting up to ${wait_s}s for: $what" >&2
+    if flock -w "$wait_s" "$MEDISWARM_LOCK_FD"; then
+        echo "[host-lock] acquired for: $what"
+        return 0
+    fi
+
+    echo "[host-lock] TIMEOUT after ${wait_s}s. Refusing to run '$what' concurrently with" >&2
+    echo "            another GPU/Docker job on this host -- that is the #388 flake (#448)." >&2
+    echo "            Override with MEDISWARM_SKIP_HOST_LOCK=1 if you accept the risk." >&2
+    return 1
+}
+
+# Blocks until the lock is free, then releases immediately. For CI, which cannot
+# hold a descriptor across steps but can at least refuse to start on top of a
+# manual build that is already running.
+wait_for_host_lock() {
+    local wait_s="${1:-$MEDISWARM_LOCK_WAIT}"
+    _host_lock_available || return 0
+    echo "[host-lock] waiting for any in-flight GPU/Docker job (up to ${wait_s}s)..."
+    if flock -w "$wait_s" "$MEDISWARM_HOST_LOCK" true; then
+        echo "[host-lock] host is free; proceeding"
+        return 0
+    fi
+    echo "[host-lock] still busy after ${wait_s}s; proceeding anyway (CI must not hang forever)" >&2
+    return 0
+}
+
+# Allow direct invocation: `host_gpu_lock.sh wait [timeout]`
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    case "${1:-}" in
+        wait) wait_for_host_lock "${2:-}" ;;
+        *) echo "Usage: $0 wait [timeout_seconds]" >&2; exit 2 ;;
+    esac
+fi

--- a/scripts/deploy/run_deploy_test.sh
+++ b/scripts/deploy/run_deploy_test.sh
@@ -38,6 +38,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=scripts/deploy/deploy_common.sh
 source "$SCRIPT_DIR/deploy_common.sh"
 
+# Shares a host with the self-hosted CI runner: same GPU, same Docker daemon,
+# same 8002/8003. Queue behind any other GPU/Docker job rather than interleaving
+# and failing an unrelated PR (#448, root cause behind #388).
+. "$SCRIPT_DIR/../ci/host_gpu_lock.sh"
+acquire_host_lock "ODELIA deploy test" || exit 1
+
 # ── Parse arguments ────────────────────────────────────────────────────────
 RUN_ALL=false
 SINGLE_MODEL=""

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -52,6 +52,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=scripts/deploy/deploy_common.sh
 source "$SCRIPT_DIR/deploy_common.sh"
 
+# Shares a host with the self-hosted CI runner: same GPU, same Docker daemon,
+# same 8002/8003. Queue behind any other GPU/Docker job rather than interleaving
+# and failing an unrelated PR (#448, root cause behind #388).
+. "$SCRIPT_DIR/../ci/host_gpu_lock.sh"
+acquire_host_lock "STAMP/DECADE 2-node deploy test" || exit 1
+
 # ── Parse arguments ────────────────────────────────────────────────────────
 CONF_FILE=""
 TIMEOUT_MINUTES=120   # 2 hours for a quick 2-round test


### PR DESCRIPTION
Partial mitigation of #448 — **not a full close**, see Scope.

## Problem

`validate-swarm` serialises itself via the `mediswarm-self-hosted-gpu-validation` concurrency group. But DECADE image builds and 2-node deploy tests are started **by hand** and belong to no group, so nothing stopped them landing on top of a running CI job. They share one GPU, one Docker daemon, and ports 8002/8003 — the contention behind #388. #445 made CI *tolerant*; it did not remove the contention.

This is not hypothetical: it happened during the 1.6.0 rollout, which is what prompted the fix.

## What this does

`scripts/ci/host_gpu_lock.sh` — one flock-based host mutex.

- **Manual side** (`buildDockerImageAndStartupKits.sh`, `run_stamp_deploy_test.sh`, `run_deploy_test.sh`) holds it for the whole run, so heavy jobs queue instead of interleaving.
- **CI side** waits for it as the **first** step — deliberately *before* the container cleanup, because that step kills every container matching `odelia|stamp|nvflare` and would otherwise **destroy a manual deploy test mid-run**. Inlined rather than sourced (repo isn't checked out yet), and it proceeds after the timeout rather than hanging a job forever.

## Scope (honest)

Removes the manual-vs-CI collision and makes CI yield to an in-flight manual run. It **cannot** make a whole CI job mutually exclusive with a manual one — each Actions step is its own process and can't hold a descriptor across steps. Fully closing #448 still wants the dedicated runner (option 1 in the issue). Leaving #448 open.

Escape hatch: `MEDISWARM_SKIP_HOST_LOCK=1`. Degrades to a no-op where `flock` is unavailable.

## Verified

Lock refuses acquisition while held (exit 1) and acquires after release; workflow YAML parses; all three patched scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)