### PR TITLE
STAMP/DECADE: the NVFlare 2.8.0 bump never reached the STAMP template

### DIFF
--- a/docker_config/master_template_STAMP.yml
+++ b/docker_config/master_template_STAMP.yml
@@ -90,9 +90,11 @@ local_client_resources: |
         "args": {}
       },
       {
-          "id": "error_log_sender",
-          "path": "nvflare.app_common.logging.log_sender.ErrorLogSender",
-          "args": {}
+          "id": "site_log_streamer",
+          "path": "nvflare.app_common.logging.site_log_streamer.SiteLogStreamer",
+          "args": {
+              "log_file_name": "error_log.txt"
+          }
       }
     ]
   }
@@ -116,12 +118,6 @@ fed_client: |
       "fqsn": "{~~fqsn~~}",
       "is_leaf": {~~is_leaf~~},
       "connection_security": "{~~conn_sec~~}"
-    },
-    "overseer_agent": {
-      "path": "nvflare.ha.dummy_overseer_agent.DummyOverseerAgent",
-      "args": {
-        "sp_end_point": "{~~sp_end_point~~}"
-      }
     }
   }
 
@@ -235,7 +231,7 @@ local_server_resources: |
           },
           {
               "id": "log_receiver",
-              "path": "nvflare.app_common.logging.log_receiver.LogReceiver",
+              "path": "nvflare.app_common.logging.job_log_receiver.JobLogReceiver",
               "args": {}
           }
       ]
@@ -272,13 +268,7 @@ fed_server: |
             "ssl_root_cert": "rootCA.pem",
             "connection_security": "{~~conn_sec~~}"
         }
-    ],
-    "overseer_agent": {
-      "path": "nvflare.ha.dummy_overseer_agent.DummyOverseerAgent",
-      "args": {
-        "sp_end_point": "{~~sp_end_point~~}"
-      }
-    }
+    ]
   }
 
 fed_admin: |

--- a/tests/unit_tests/test_template_nvflare_path_parity.py
+++ b/tests/unit_tests/test_template_nvflare_path_parity.py
@@ -1,0 +1,70 @@
+"""The two provisioning templates must reference the same NVFlare classes.
+
+`master_template.yml` (ODELIA) and `master_template_STAMP.yml` (DECADE) both describe
+the same NVFlare infrastructure -- resource managers, process launchers, log plumbing,
+the server/client config. Only the training application differs.
+
+The NVFlare 2.8.0 bump (#392/#462) updated the ODELIA template and missed the STAMP
+one, so DECADE kits kept pointing at 2.7.2 paths that no longer exist:
+
+    nvflare.app_common.logging.log_receiver.LogReceiver      (renamed)
+    nvflare.app_common.logging.log_sender.ErrorLogSender     (renamed)
+    nvflare.ha.dummy_overseer_agent.DummyOverseerAgent       (overseer removed in 2.8.0)
+
+Every DECADE server built from that template died on startup with a ConfigError, and it
+was caught only by a 2-node hardware run during the 1.6.0 rollout -- after the image had
+been built and pushed. This test makes the next such divergence fail in seconds instead.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ODELIA = REPO_ROOT / "docker_config" / "master_template.yml"
+STAMP = REPO_ROOT / "docker_config" / "master_template_STAMP.yml"
+
+PATH_RE = re.compile(r'"path":\s*"(nvflare\.[^"]+)"')
+
+
+def _nvflare_paths(template: Path) -> set[str]:
+    return set(PATH_RE.findall(template.read_text()))
+
+
+def test_stamp_declares_no_nvflare_class_odelia_does_not():
+    """A path only STAMP references is unreviewed against the current backbone.
+
+    Both templates are provisioned against the same image, so any NVFlare class the
+    STAMP template names on its own has, by construction, never been exercised by the
+    ODELIA deploy test. That is exactly how the 2.8.0 skew survived.
+    """
+    stamp_only = _nvflare_paths(STAMP) - _nvflare_paths(ODELIA)
+    assert not stamp_only, (
+        "master_template_STAMP.yml references NVFlare classes that "
+        "master_template.yml does not:\n  "
+        + "\n  ".join(sorted(stamp_only))
+        + "\nIf the backbone moved, update BOTH templates."
+    )
+
+
+def test_no_known_removed_nvflare_paths():
+    """Guard the specific 2.8.0 removals, so a revert is caught by name."""
+    removed = [
+        "nvflare.app_common.logging.log_receiver.LogReceiver",
+        "nvflare.app_common.logging.log_sender.ErrorLogSender",
+        "nvflare.ha.dummy_overseer_agent.DummyOverseerAgent",
+    ]
+    for template in (ODELIA, STAMP):
+        text = template.read_text()
+        for path in removed:
+            assert path not in text, (
+                f"{template.name} still references {path}, which NVFlare 2.8.0 removed."
+            )
+
+
+def test_overseer_agent_block_is_gone_from_both():
+    """NVFlare 2.8.0 dropped the overseer; a leftover block fails server startup."""
+    for template in (ODELIA, STAMP):
+        assert '"overseer_agent"' not in template.read_text(), (
+            f"{template.name} still declares an overseer_agent block; "
+            "NVFlare 2.8.0 removed the overseer."
+        )


### PR DESCRIPTION
## Impact

**Every DECADE server built since the 2.8.0 backbone bump (#392/#462) dies on startup.**

```
ConfigError: Error processing 'fed_server.json' in element
'{"id": "log_receiver", "path": "nvflare.app_common.logging.log_receiver.LogReceiver"}':
No module named 'nvflare.app_common.logging.log_receiver'
```

NVFlare 2.8.0 renamed the log plumbing and removed the overseer. `master_template.yml` was updated; **`master_template_STAMP.yml` was not**, so DECADE kits still declared three classes that no longer exist:

| STAMP template (broken) | replacement (already used by ODELIA) |
|---|---|
| `logging.log_receiver.LogReceiver` | `logging.job_log_receiver.JobLogReceiver` |
| `logging.log_sender.ErrorLogSender` | `logging.site_log_streamer.SiteLogStreamer` |
| `ha.dummy_overseer_agent.DummyOverseerAgent` | *removed* — both `overseer_agent` blocks deleted |

All 10 NVFlare paths in the STAMP template now import successfully inside `jefftud/decade:1.6.0` (verified by running the imports in the image).

## Why CI didn't catch it

The ODELIA deploy test exercises the **ODELIA** template. Nothing ever loaded these classes. It surfaced only in the 2-node dl0/dl2 hardware validation during the 1.6.0 rollout — after the image had already been built and pushed.

## The test

`test_template_nvflare_path_parity.py` encodes that gap: an NVFlare class referenced by only *one* of the two templates is, by construction, unexercised by the other's deploy test. Plus a by-name guard on the three 2.8.0 removals.

Verified against the pre-fix template — it flags all three. Full suite: **325 passed, 4 skipped**.

⚠️ Requires a DECADE image + kit rebuild; the pushed `1.6.0`/`current` are being rebuilt and re-validated on dl0/dl2 before any kit goes to a site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)