### PR TITLE
docs(decade): server moves to the dl3 node (100.64.4.103), split from ODELIA

### DIFF
--- a/docs/DECADE_SITE_REGISTRY.md
+++ b/docs/DECADE_SITE_REGISTRY.md
@@ -1,7 +1,7 @@
 # DECADE — site registry (data, targets, contacts, status)
 
 **Single source of truth for what each centre can actually provide.**
-Update this whenever a site reports new numbers. Last updated: **2026-07-15**.
+Update this whenever a site reports new numbers. Last updated: **2026-07-21**.
 
 Swarm learning requires **one shared target**: identical label, identical
 `STAMP_NUM_CLASSES`, identical class order at every site. Everything below exists to
@@ -132,9 +132,10 @@ supply a germline label they have not mentioned. Operator/PI decision.
 
 - **Feature extractor:** UNI, `STAMP_DIM_INPUT=1024`, extracted with **STAMP 2.5.0**.
 - **Model:** `vit`. (`barspoon` unavailable — see #432.)
-- **Current kit/image:** `jefftud/decade:1.5.0-dev.260713.6bc06c4`
-  (kits carry fresh certificates — older kits cannot connect).
-- **Server:** `dl3.tud.de` → `100.100.101.100` (Tailscale), ports 8002/8003.
+- **Current kit/image:** `jefftud/decade:1.6.0` (ACTIVE; validated on a 2-node dl0/dl2
+  run 2026-07-20). Kits follow the `jefftud/decade:current` channel via
+  `startup/image.conf`; 1.6.0 was the last forced certificate swap.
+- **Server:** `dl3.tud.de` → `100.64.4.103` (Tailscale; the dl3 node, separate from ODELIA on Cosmos), ports 8002/8003.
 - Sites must **never** send us `--log_dataset_details` output (contains patient IDs).
 
 ---

--- a/docs/consortium_decade/PARTNER_HANDBOOK.md
+++ b/docs/consortium_decade/PARTNER_HANDBOOK.md
@@ -40,10 +40,10 @@ Accept the Tailscale invitation we emailed and connect. Then add the server to
 `/etc/hosts`:
 
 ```
-100.100.101.100  dl3.tud.de  dl3
+100.64.4.103  dl3.tud.de  dl3
 ```
 
-Check it: `ping dl3.tud.de` should reply from `100.100.101.100`. If your node is on
+Check it: `ping dl3.tud.de` should reply from `100.64.4.103`. If your node is on
 your *personal* tailnet instead of the DECADE one, `ping` fails even with the hosts
 line correct — re-accept the invitation.
 

--- a/docs/consortium_decade/sheet_1_run_schedule.csv
+++ b/docs/consortium_decade/sheet_1_run_schedule.csv
@@ -11,6 +11,6 @@ Image for this run,jefftud/decade:1.6.0,"Pin the exact tag. docker.sh re-pulls i
 Release channel,jefftud/decade:current,"What kits follow by default (startup/image.conf). Re-tag :current to move every site on its next start — no kit re-issue. Sites can pin a version by editing that file"
 Rounds,20,Set at job-prep time — no kit or image rebuild needed
 Quorum (configure/min/responses),4 / 4 / 4,"No fault tolerance for the benchmark: every site must register and finish"
-Server,dl3.tud.de:8002,Tailscale only. Map dl3.tud.de -> 100.100.101.100 in /etc/hosts
+Server,dl3.tud.de:8002,Tailscale only. Map dl3.tud.de -> 100.64.4.103 in /etc/hosts (the dl3 node, NOT Cosmos which runs ODELIA)
 Deadline for site confirmation,TBC,Sites tick their row in the 'Site checklist' tab
 Live monitor,Internal only,"NOT partner-accessible: no auth, no per-site scoping — do not link it"

--- a/docs/consortium_decade/sheet_3_site_checklist.csv
+++ b/docs/consortium_decade/sheet_3_site_checklist.csv
@@ -1,5 +1,5 @@
 Site,Step,Command / how,Confirmed (Y/N),Date,Notes / status
-UKB_1,1. Tailscale connected + /etc/hosts maps dl3.tud.de,ping dl3.tud.de replies from 100.100.101.100,Y,2026-07-13,~8ms
+UKB_1,1. Tailscale connected + /etc/hosts maps dl3.tud.de,ping dl3.tud.de replies from 100.64.4.103,Y,2026-07-13,~8ms
 UKB_1,2. SSH public key shared + authorized,ssh-keygen ... ; send id_ed25519.pub,Y,2026-07-13,authorized
 UKB_1,3. Target values sent (NUM_CLASSES + column),reply to operator,PARTIAL,2026-07-13,"Has germline (3-class) only; NO MSI (all 'not provided') — target undecided"
 UKB_1,4. On ACTIVE kit 6bc06c4,sha256sum <SITE>_<ver>.zip vs Kit registry,N,,Was on a295c6b; must switch (new certs)


### PR DESCRIPTION
The DECADE swarm server now runs on the **real dl3 node** (`100.64.4.103`), not on Cosmos (`100.100.101.100`).

## Why

Cosmos runs the **ODELIA** server on the same ports 8002/8003, with a cert that shares `CN=dl3.tud.de` but is issued by a **different CA** (`odelia_allsites` vs `decade_allsites`). A DECADE client pointed at Cosmos therefore fails with `ClientConnectorCertificateError`. **Mainz hit exactly this** — its client looped on that error for ~20h.

## What changed

- Handbook §1.2, Run Board "Server" row, site-checklist ping note, and site-registry §5 → `100.64.4.103`.
- Sites must update **one line** in `/etc/hosts`; **no new kit** (the cert is bound to the name, not the IP).
- Refreshed the stale "current kit" line to `1.6.0` (ACTIVE, validated 2026-07-20).

## Infra (done outside this PR)

dl3 is now the complete DECADE hub — swarm server + admin + the `mediswarm-upload` live-sync ingest (forced-command guarded, **DECADE site keys only**: Bonn, Mainz, Heidelberg). Verified: uploads land, arbitrary commands / path traversal / out-of-root `rm` all rejected. Fully separate from ODELIA on Cosmos.

The matching `.docx`/`.xlsx` in `workspace/` are updated too (for re-upload to Google).

🤖 Generated with [Claude Code](https://claude.com/claude-code)