### PR TITLE
chore(go-public): SECURITY.md + CONTRIBUTING.md; least-privilege apt-update token

### DIFF
--- a/.github/workflows/update-apt-versions.yml
+++ b/.github/workflows/update-apt-versions.yml
@@ -6,6 +6,13 @@ on:
    - cron: '0 4 * * *'
   workflow_dispatch:
 
+# Least-privilege token: this workflow pushes the ci/apt-update branch and opens
+# a PR, so it explicitly needs contents + pull-requests write. Declaring it here
+# lets the repository default GITHUB_TOKEN permission stay read-only.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-apt:
     runs-on: [self-hosted, ci]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to MediSwarm
+
+Thanks for your interest in improving MediSwarm — a privacy-preserving swarm /
+federated learning framework for medical imaging, built on
+[NVFlare](https://github.com/NVIDIA/NVFlare) and developed with the ODELIA
+consortium.
+
+## Ways to contribute
+
+- Report bugs and request features via [Issues](https://github.com/KatherLab/MediSwarm/issues).
+- Improve documentation.
+- Submit code via pull requests (see below).
+
+For anything security-related, **do not open a public issue** — follow
+[SECURITY.md](SECURITY.md).
+
+## Development setup
+
+MediSwarm runs entirely in Docker; you do not install the training stack on the
+host. Start with the [Developer guide](assets/readme/README.developer.md), which
+covers building the images, running a job, and the local test project.
+
+Unit tests run on GitHub-hosted runners and are quick to run locally:
+
+```bash
+python -m pytest tests/unit_tests
+```
+
+The heavier GPU integration / swarm-validation tests run in CI on self-hosted
+runners; you do not need a GPU to contribute most changes.
+
+## Pull requests
+
+1. **Fork** the repository and create a topic branch off `main`
+   (e.g. `fix/short-description` or `feat/short-description`).
+2. Keep each PR focused on a single change; write a clear description of **what**
+   and **why**.
+3. Make sure the checks pass:
+   - **Unit Tests** (`ubuntu-latest`) run on every PR.
+   - **PR Validation** (`pr-test`) runs a single-GPU swarm validation on the
+     self-hosted runner; it is **skipped for docs-only PRs** (`**/*.md`,
+     `docs/**`).
+   - Secret scanning / push protection is enabled — never commit credentials,
+     `.ovpn` files, or `deploy_sites*.conf` (these are git-ignored for a reason).
+4. Update or add tests under `tests/` when you change behaviour.
+5. Update relevant docs when you change user-facing behaviour.
+
+### A note for external contributors
+
+MediSwarm's CI uses **self-hosted runners on data-holding nodes**. For safety,
+workflows on pull requests from forks require **maintainer approval** before they
+run, and the workflow token is read-only by default. This is expected — a
+maintainer will review and approve CI for your PR.
+
+## Commit and review
+
+- Reference the issue a PR addresses (e.g. `Fixes #123`).
+- A maintainer will review; please be responsive to review comments.
+- By contributing, you agree your contributions are licensed under the
+  repository's [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+MediSwarm is a swarm/federated learning framework used by the ODELIA and DECADE
+medical-imaging consortia. Because it is deployed across hospital sites, we take
+security reports seriously.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's **"Report a vulnerability"** button on the
+[Security tab](https://github.com/KatherLab/MediSwarm/security/advisories/new)
+(Security → Advisories → Report a vulnerability). This opens a private advisory
+visible only to you and the maintainers.
+
+Please include:
+
+- a description of the issue and its impact,
+- steps to reproduce (a minimal proof-of-concept if possible),
+- affected version / commit and pipeline (ODELIA or STAMP), and
+- any suggested remediation.
+
+We aim to acknowledge a report within **5 working days** and to agree a
+disclosure timeline with you. Please give us a reasonable window to release a
+fix before any public disclosure.
+
+## Scope
+
+In scope:
+
+- the framework code in this repository (`application/`, `scripts/`,
+  `docker_config/`, provisioning, and the startup-kit tooling),
+- the container images built from this repository, and
+- the CI/CD workflows.
+
+Out of scope:
+
+- vulnerabilities in upstream dependencies (report those upstream — e.g.
+  [NVFlare](https://github.com/NVIDIA/NVFlare)), though we are glad to be told,
+- issues that require an already-compromised site host or valid VPN
+  credentials, and
+- site-specific data, credentials, or network configuration (those live outside
+  this repository and are managed by each participating institution).
+
+MediSwarm is designed so that **raw patient data never leaves a site** — only
+model updates are exchanged. Reports demonstrating a way to exfiltrate local
+data or training inputs through the framework are especially welcome.
+
+## Supported versions
+
+Security fixes target the latest released version on `main`. Older releases are
+not maintained; please upgrade to the current release before reporting.


### PR DESCRIPTION
Go-public repo hygiene + a token-scoping fix (checklist §5.F / §5.D).

## Changes
- **SECURITY.md** — private vulnerability reporting via GitHub advisories, scope, supported versions.
- **CONTRIBUTING.md** — PR flow, how to run tests, secret hygiene, and the self-hosted fork-PR approval note.
- **update-apt-versions.yml** — declares least-privilege `permissions: {contents: write, pull-requests: write}` (it pushes `ci/apt-update` and opens a PR). This is the prerequisite for setting the repo-wide default `GITHUB_TOKEN` permission to **read-only**.

## Follow-up after merge
Once this is on `main`, set the default token to read-only (safe now that the only write-needing workflow declares its own permissions):
```
gh api -X PUT repos/KatherLab/MediSwarm/actions/permissions/workflow \
  -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false
```

## CI note
Touches a workflow file, so `pr-test` runs its single-GPU `validate-swarm` job once (~60 min on a self-hosted `ci` runner). `unit-tests` (ubuntu) also runs. No repo behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
