### PR TITLE
fix(ci): tag a local :current alias for local-registry test images (#479)

### DIFF
--- a/scripts/build/buildDockerImageAndStartupKits.sh
+++ b/scripts/build/buildDockerImageAndStartupKits.sh
@@ -102,6 +102,17 @@ echo $CONTAINER_NAME
 
 docker build $DOCKER_BUILD_ARGS -t $CONTAINER_NAME $CLEAN_SOURCE_DIR -f $DOCKERFILE
 
+# #479: the startup kits generated below get an image.conf on the ':current'
+# channel (see _injectLiveSyncIntoStartupKits.sh), so docker.sh in the kits
+# resolves e.g. localhost:5000/odelia:current -- but only the versioned tag was
+# built. For LOCAL-registry test images, add a local ':current' alias so the
+# kits' docker.sh finds the image without a running registry. Productive images
+# (jefftud/*) get ':current' re-tagged on Docker Hub at release, so skip those.
+if [[ "$CONTAINER_NAME" == localhost:5000/* ]]; then
+    docker tag "$CONTAINER_NAME" "${CONTAINER_NAME%:*}:current"
+    echo "Tagged local channel alias ${CONTAINER_NAME%:*}:current -> $CONTAINER_NAME"
+fi
+
 echo "Docker image $CONTAINER_NAME built successfully"
 echo "scripts/build/_buildStartupKits.sh $PROJECT_FILE $VERSION $CONTAINER_NAME"
 "$SCRIPT_DIR/_buildStartupKits.sh" $PROJECT_FILE $VERSION $CONTAINER_NAME


### PR DESCRIPTION
Fixes #479 — `validate-swarm` fails with `Unable to find image 'localhost:5000/odelia:current'` / `connection refused to localhost:5000`.

## Cause
`buildDockerImageAndStartupKits.sh` builds `localhost:5000/odelia:$VERSION`, but the startup kits it then generates get an `image.conf` on the **`:current`** channel (from `_injectLiveSyncIntoStartupKits.sh`). So `docker.sh` inside the test kits resolves `localhost:5000/odelia:current`, which was never created — `docker run` tries to pull it from the (absent) local registry and fails. This breaks `run_list_licenses` and every other `docker.sh`-based integration step.

## Fix
After building, tag a local `:current` alias of the just-built image **for `localhost:5000/*` (test) images only**. Productive `jefftud/*` images get `:current` re-tagged on Docker Hub at release and are untouched. One-line, scoped, no injector/unit-test changes.

## Verification
This PR touches a build script, so `pr-test` runs the full `validate-swarm` GPU job — which is exactly the check that was red on #479. It should now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
