### PR TITLE
feat(kit): add --institution flag and same-path data mount (#478)

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -721,6 +721,7 @@ docker_cln_sh: |
           --run_script)          SCRIPT_TO_RUN="$2"; shift ;;
           --job)                 JOB_NAME="$2"; shift ;;
           --log_dataset_details) LOG_DATASET_DETAILS="1";;
+          --institution)         CLI_INSTITUTION="$2"; shift ;;
           --model_name)          CLI_MODEL_NAME="$2"; shift ;;
           --num_epochs)          CLI_NUM_EPOCHS="$2"; shift ;;
           --fold)                CLI_FOLD="$2"; shift ;;
@@ -832,6 +833,16 @@ docker_cln_sh: |
   DOCKER_MOUNTS="-v /etc/passwd:/etc/passwd -v /etc/group:/etc/group -v $DIR/..:/startupkit/ -v $MY_SCRATCH_DIR:/scratch/"
   if [ -n "$MY_DATA_DIR" ]; then
       DOCKER_MOUNTS+=" -v $MY_DATA_DIR:/data/:ro"
+      # #478/#481: some sites store exams as symlinks pointing at an ABSOLUTE host path
+      # (e.g. UKA_2/<uid> -> /home/swarm/.../UKA_1/<uid>, to avoid duplicating TBs of
+      # images). Inside the container that absolute path does not exist, so every link
+      # dangles and the loader sees zero images. Mounting the data dir a second time at
+      # its own host path makes any link that stays WITHIN the tree resolve. Targets
+      # outside $MY_DATA_DIR still need an explicit extra mount, e.g. via
+      # MEDISWARM_DOCKER_OPTIONS="-v /abs/target:/abs/target:ro" in startup/image.conf.
+      if [ "$MY_DATA_DIR" != "/data" ]; then
+          DOCKER_MOUNTS+=" -v $MY_DATA_DIR:$MY_DATA_DIR:ro"
+      fi
   fi
   DOCKER_OPTIONS_B="-w /startupkit/startup/ --ipc=host $NETARG"
   DOCKER_OPTIONS="${DOCKER_OPTIONS_A} ${DOCKER_MOUNTS} ${DOCKER_OPTIONS_B} ${EXTRA_DOCKER_OPTIONS}"
@@ -860,6 +871,21 @@ docker_cln_sh: |
 
   if [ -n "$LOG_DATASET_DETAILS" ]; then
      ENV_VARS+=" --env LOG_DATASET_DETAILS=1"
+  fi
+
+  # #478: a site whose data folder differs from its swarm identity. SITE_NAME above is
+  # baked at kit-generation time and is the NVFlare client identity (it must match the
+  # certificate), but the loader reads /data/$INSTITUTION/..., which defaults to
+  # SITE_NAME. INSTITUTION lets the two vary independently -- e.g. UKA registers as
+  # UKA_1 while training on the curated /data/UKA_2. Precedence: --institution CLI >
+  # INSTITUTION env (the CLI form survives `sudo`, an exported var does not).
+  INSTITUTION_RESOLVED="${CLI_INSTITUTION:-${INSTITUTION:-}}"
+  if [ -n "$INSTITUTION_RESOLVED" ]; then
+      ENV_VARS+=" --env INSTITUTION=$INSTITUTION_RESOLVED"
+      if [ "$INSTITUTION_RESOLVED" != "{~~client_name~~}" ]; then
+          echo "[INFO] Reading data as INSTITUTION='$INSTITUTION_RESOLVED' (/data/$INSTITUTION_RESOLVED/...);"
+          echo "       swarm identity stays SITE_NAME='{~~client_name~~}'."
+      fi
   fi
 
   # Optional ODELIA loader/hash/cache tuning knobs.
@@ -1090,6 +1116,7 @@ docker_cln_sh: |
       echo "                         Available: challenge_1DivideAndConquer, ODELIA_ternary_classification,"
       echo "                         challenge_2BCN_AIM, challenge_3agaldran, challenge_4abmil, challenge_5pimed"
       echo "--model_name <name>      set model name (default: auto-derived from --job). Use this instead of 'export MODEL_NAME=...'"
+      echo "--institution <name>     read data from /data/<name>/ instead of /data/{~~client_name~~}/ (swarm identity is unchanged)"
       echo "                         when running with sudo, as sudo resets environment variables"
       echo "--num_epochs <n>         set number of training epochs (default: 100)"
       echo "--image <ref>            run a specific image instead of the one this kit was"

--- a/tests/unit_tests/test_template_institution_passthrough.py
+++ b/tests/unit_tests/test_template_institution_passthrough.py
@@ -1,0 +1,55 @@
+"""The client `docker.sh` must be able to pass INSTITUTION into the container.
+
+`SITE_NAME` is substituted at kit-generation time and is the NVFlare client identity --
+it has to match the certificate, so it cannot be changed per run. But the data loader
+reads `/data/$INSTITUTION/...`, and `INSTITUTION` defaults to `SITE_NAME`
+(`env_config.py`, `threedcnn_ptl.py`). A site whose data folder differs from its swarm
+identity therefore has no way to select it.
+
+That is not hypothetical: UKA registers as `UKA_1` but was asked to train on the curated
+`UKA_2` tree. `export INSTITUTION=UKA_2` looked like it should work and silently did
+nothing -- only variables named in the template's `--env` list cross the container
+boundary, and `INSTITUTION` was not one of them (#478). The run kept reading
+`/data/UKA_1`, failed with an empty split, and the error named an institution the site
+had not selected. Two people spent a morning on it.
+
+These tests pin the passthrough (and the accompanying same-path data mount, #481) so it
+cannot be dropped again.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "docker_config" / "master_template.yml"
+
+
+def _client_script() -> str:
+    return yaml.safe_load(TEMPLATE.read_text())["docker_cln_sh"]
+
+
+def test_institution_is_forwarded_into_the_container():
+    """Only vars explicitly listed as --env reach the container."""
+    assert "--env INSTITUTION=" in _client_script()
+
+
+def test_institution_accepts_a_cli_flag():
+    """A CLI flag survives `sudo`; an exported variable does not."""
+    script = _client_script()
+    assert "--institution)" in script
+    assert "CLI_INSTITUTION" in script
+
+
+def test_cli_institution_takes_precedence_over_the_environment():
+    assert "${CLI_INSTITUTION:-${INSTITUTION:-}}" in _client_script()
+
+
+def test_site_name_remains_the_baked_swarm_identity():
+    """INSTITUTION must not be wired to SITE_NAME -- the identity is fixed by the cert."""
+    assert "--env SITE_NAME={~~client_name~~}" in _client_script()
+
+
+def test_data_dir_is_also_mounted_at_its_own_host_path():
+    """Absolute symlinks inside the data tree only resolve if that path exists too (#481)."""
+    assert "-v $MY_DATA_DIR:$MY_DATA_DIR:ro" in _client_script()


### PR DESCRIPTION
Fixes #478.

## Problem
`SITE_NAME` is baked at kit-generation time and is the NVFlare client identity (it must match the certificate). But the loader reads `/data/$INSTITUTION/...`, and `INSTITUTION` defaults to `SITE_NAME`. A site whose data folder differs from its swarm identity had **no way to select it** — `export INSTITUTION=UKA_2` looked right and silently did nothing, because only variables named in the template's `--env` list cross the container boundary. The run kept reading `/data/UKA_1` and failed with an empty split naming an institution the site hadn't chosen.

## Changes
- **`--institution <name>` CLI flag** + `INSTITUTION` env passthrough. Precedence `--institution` > `INSTITUTION` env — the CLI form survives `sudo`, an exported variable does not.
- **Log the resolved data root** when it differs from `SITE_NAME`, so a mis-set value is visible immediately.
- **Mount `$MY_DATA_DIR` at its own host path too** (#481): sites storing exams as absolute symlinks otherwise see every link dangle inside the container. Targets *outside* the data dir still need an explicit mount via `MEDISWARM_DOCKER_OPTIONS`.
- **Unit test** pinning the passthrough, the precedence expression, that `SITE_NAME` stays the baked identity, and the same-path mount.

## Verification
`master_template.yml` still parses as YAML and all three generated scripts (`docker_cln_sh`, `docker_svr_sh`, `docker_adm_sh`) pass `bash -n`. New test assertions all pass (run manually — no pytest on the dev host; CI will run them).

## ⚠️ Needs a kit rebuild
This touches `master_template.yml`, so it only reaches sites via newly generated startup kits — it should ride along with the next kit release rather than shipping on its own. Until then the documented workaround stands: `MEDISWARM_DOCKER_OPTIONS="--env INSTITUTION=UKA_2 -v /abs/UKA_1:/abs/UKA_1:ro"` in `startup/image.conf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
