### PR TITLE
fix(stamp): make swarm eval metrics usable — AUROC + best-model selection (#492, #493)

### DIFF
--- a/application/jobs/STAMP_classification/app/config/config_fed_client.conf
+++ b/application/jobs/STAMP_classification/app/config/config_fed_client.conf
@@ -150,7 +150,11 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        key_metric = "accuracy"
+        # The training subprocess logs ``val_auroc`` each round (higher is better),
+        # which flare.patch forwards as the selection metric. Previously this was
+        # "accuracy", which STAMP never logs, so best-model selection never fired
+        # and the final broadcast model was always the last round (#493).
+        key_metric = "val_auroc"
       }
     }
     {

--- a/application/jobs/STAMP_classification/app/custom/stamp_metrics_callback.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_metrics_callback.py
@@ -41,6 +41,80 @@ FILENAME_GT_PREDPROB_AGGREGATED_VALIDATION = "stamp_gt_predprob_aggregated_model
 
 
 # ---------------------------------------------------------------------------
+# AUROC helper (pure Python — no sklearn/torch dependency, unit-testable in CI)
+# ---------------------------------------------------------------------------
+# STAMP's Lightning model does not expose AUROC under a ``callback_metrics`` key
+# we can rely on, so ``val_auroc`` in the summary CSV was always blank (#492).
+# We instead compute AUROC directly from the validation predictions the
+# prediction callback already gathers each epoch.
+
+def _binary_auroc(scores, labels):
+    """AUROC for one binary problem via the rank (Mann-Whitney U) statistic.
+
+    ``scores``: iterable of floats (predicted score for the positive class).
+    ``labels``: iterable of 0/1 (1 = positive).
+    Ties in ``scores`` receive averaged ranks, matching sklearn's
+    ``roc_auc_score``. Returns ``None`` if either class is absent.
+    """
+    scores = list(scores)
+    labels = list(labels)
+    n_pos = sum(1 for l in labels if l == 1)
+    n_neg = len(labels) - n_pos
+    if n_pos == 0 or n_neg == 0:
+        return None
+    order = sorted(range(len(scores)), key=lambda i: scores[i])
+    ranks = [0.0] * len(scores)
+    i = 0
+    while i < len(order):
+        j = i
+        while j < len(order) and scores[order[j]] == scores[order[i]]:
+            j += 1
+        avg_rank = (i + j - 1) / 2.0 + 1.0  # 1-based average rank for the tie group
+        for k in range(i, j):
+            ranks[order[k]] = avg_rank
+        i = j
+    sum_pos_ranks = sum(ranks[idx] for idx, l in enumerate(labels) if l == 1)
+    return (sum_pos_ranks - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg)
+
+
+def _true_class_index(gt):
+    """Normalise a ground-truth entry (scalar index or one-hot list) to an int."""
+    if isinstance(gt, (list, tuple)):
+        best_i, best_v = 0, gt[0]
+        for i, v in enumerate(gt):
+            if v > best_v:
+                best_i, best_v = i, v
+        return best_i
+    return int(gt)
+
+
+def macro_ovr_auroc(ground_truths, prob_rows):
+    """Macro one-vs-rest AUROC.
+
+    ``ground_truths``: list of ground-truth entries (int class index or one-hot list).
+    ``prob_rows``: list of per-class probability lists (one row per sample).
+
+    Returns the unweighted mean of each class's one-vs-rest AUROC over the classes
+    for which both positives and negatives are present, or ``None`` if none qualify.
+    For the binary case this is the standard AUROC.
+    """
+    if not prob_rows:
+        return None
+    n_classes = len(prob_rows[0])
+    true_idx = [_true_class_index(gt) for gt in ground_truths]
+    per_class = []
+    for c in range(n_classes):
+        scores = [row[c] for row in prob_rows]
+        labels = [1 if t == c else 0 for t in true_idx]
+        auc = _binary_auroc(scores, labels)
+        if auc is not None:
+            per_class.append(auc)
+    if not per_class:
+        return None
+    return sum(per_class) / len(per_class)
+
+
+# ---------------------------------------------------------------------------
 # 1. Per-epoch metrics summary
 # ---------------------------------------------------------------------------
 
@@ -55,10 +129,14 @@ class STAMPMetricsSummaryCallback(Callback):
 
     HEADER = ["epoch", "train_loss", "val_loss", "val_auroc", "learning_rate"]
 
-    def __init__(self, output_dir: Path):
+    def __init__(self, output_dir: Path, metric_holder=None):
         super().__init__()
         self.csv_path = output_dir / FILENAME_METRICS_SUMMARY
         self._header_written = self.csv_path.exists()
+        # Optional object exposing ``last_val_auroc`` (populated by the
+        # prediction callback). Used as a fallback when STAMP does not log
+        # AUROC into ``callback_metrics`` — which is the usual case (#492).
+        self.metric_holder = metric_holder
 
     def _write_header_if_needed(self):
         if not self._header_written:
@@ -76,13 +154,16 @@ class STAMPMetricsSummaryCallback(Callback):
         val_loss = metrics.get("validation_loss")
         learning_rate = metrics.get("learning_rate")
 
-        # AUROC — try multiple keys STAMP might log
+        # AUROC — prefer a value STAMP logged into callback_metrics; otherwise
+        # fall back to the AUROC computed by the prediction callback (#492).
         val_auroc = None
         for key in ("val_auroc", "val_MulticlassAUROC"):
             v = metrics.get(key)
             if v is not None:
                 val_auroc = v
                 break
+        if val_auroc is None and self.metric_holder is not None:
+            val_auroc = getattr(self.metric_holder, "last_val_auroc", None)
 
         # Convert tensors to Python floats
         def _to_float(v):
@@ -128,12 +209,18 @@ class STAMPPredictionCallback(Callback):
         train_dl: torch.utils.data.DataLoader,
         valid_dl: torch.utils.data.DataLoader,
         output_dir: Path,
+        metric_holder=None,
     ):
         super().__init__()
         self.train_dl = train_dl
         self.valid_dl = valid_dl
         self.csv_train = output_dir / FILENAME_GT_PREDPROB_SITE_TRAIN
         self.csv_valid = output_dir / FILENAME_GT_PREDPROB_SITE_VALIDATION
+        # Latest validation-set AUROC of the locally trained (site) model.
+        self.last_val_auroc = None
+        # Optional object whose ``last_val_auroc`` we also update, so the summary
+        # callback and NVFlare model selection can read it (#492 / #493).
+        self.metric_holder = metric_holder
 
     def on_train_epoch_end(self, trainer: Any, pl_module: Any) -> None:
         """Run inference on train/val sets and write prediction CSVs.
@@ -151,6 +238,16 @@ class STAMPPredictionCallback(Callback):
         try:
             self._write_predictions(pl_module, self.train_dl, epoch, self.csv_train)
             self._write_predictions(pl_module, self.valid_dl, epoch, self.csv_valid)
+            # Publish val AUROC to Lightning's metric store so NVFlare's
+            # IntimeModelSelector (key_metric=val_auroc) can select the best
+            # round instead of always keeping the last (#493). Fail-safe: any
+            # error here leaves selection at its prior (no-metric) behaviour.
+            if self.last_val_auroc is not None:
+                try:
+                    pl_module.log("val_auroc", float(self.last_val_auroc),
+                                  prog_bar=False, on_epoch=True)
+                except Exception as le:
+                    logger.debug(f"could not log val_auroc metric: {le}")
         except Exception as e:
             # Don't crash training if prediction CSV writing fails
             logger.warning(f"STAMPPredictionCallback failed at epoch {epoch}: {e}")
@@ -264,3 +361,19 @@ class STAMPPredictionCallback(Callback):
                 writer.writerows(rows)
 
             logger.debug(f"Wrote {len(rows)} predictions to {csv_path}")
+
+        # For the validation set, compute AUROC from the just-gathered predictions
+        # (row layout: [epoch, patient_id, ground_truth, pred_class, prob_0, ...]).
+        # This is the site (locally-trained) model's val AUROC for this epoch.
+        if rows and csv_path == getattr(self, "csv_valid", None):
+            try:
+                ground_truths = [r[2] for r in rows]
+                prob_rows = [r[4:] for r in rows]
+                auroc = macro_ovr_auroc(ground_truths, prob_rows)
+                if auroc is not None:
+                    self.last_val_auroc = auroc
+                    holder = getattr(self, "metric_holder", None)
+                    if holder is not None:
+                        holder.last_val_auroc = auroc
+            except Exception as e:
+                logger.debug(f"AUROC computation failed: {e}")

--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -440,6 +440,10 @@ def prepare_training(
 
     logger.info(f"MediSwarm version: {env['mediswarm_version']}")
     logger.info(f"Output directory: {output_dir}")
+    # Emit the run directory in the phrasing live-sync's nohup parser recognises,
+    # so swarm-mode syncing can locate this run's CSVs even before the directory
+    # listing fallback kicks in (#492).
+    logger.info(f"Run directory: {output_dir}")
 
     # Load patient data
     patient_to_data, feature_type = load_stamp_data(env)
@@ -480,12 +484,18 @@ def prepare_training(
 
     metric_callback = ValidationMetricCallback()
 
-    callbacks = [checkpointing, metric_callback]
-
     # Per-epoch metrics summary CSV + per-patient prediction CSVs.
+    # The prediction callback computes the site model's validation AUROC and
+    # publishes it to ``metric_callback`` (shared holder); it must run BEFORE the
+    # summary callback so each summary row carries this epoch's AUROC (#492), and
+    # it logs ``val_auroc`` so NVFlare's IntimeModelSelector can pick the best
+    # round rather than the last (#493).
     from stamp_metrics_callback import STAMPMetricsSummaryCallback, STAMPPredictionCallback
-    callbacks.append(STAMPMetricsSummaryCallback(output_dir))
-    callbacks.append(STAMPPredictionCallback(train_dl, valid_dl, output_dir))
+    prediction_callback = STAMPPredictionCallback(
+        train_dl, valid_dl, output_dir, metric_holder=metric_callback,
+    )
+    summary_callback = STAMPMetricsSummaryCallback(output_dir, metric_holder=metric_callback)
+    callbacks = [prediction_callback, summary_callback, metric_callback, checkpointing]
     logger.info(f"Metrics CSV output enabled in {output_dir}")
 
     # FedProx proximal term: penalise local model deviation from global model.

--- a/kit_live_sync/live_sync.sh
+++ b/kit_live_sync/live_sync.sh
@@ -197,6 +197,23 @@ find_latest_local_run_name() {
   printf '%s' "$result"
 }
 
+find_latest_swarm_run_name() {
+  # Swarm mode writes its STAMP run under the same runs/$SITE_NAME/ tree as local
+  # mode (stamp_training.load_stamp_environment). Locate it by directory listing —
+  # the robust approach local mode already uses — instead of relying only on
+  # nohup parsing, which failed because training logged "Output directory:" rather
+  # than the phrase extract_run_name_from_nohup matched, so the run dir (and its
+  # metrics/predprob CSVs) never synced (#492). Names are timestamped, so a
+  # lexicographic sort is chronological.
+  local base result=""
+  for base in "${SCRATCHDIR:+$SCRATCHDIR/runs/$SITE_NAME}" "$STARTUP_DIR/runs/$SITE_NAME"; do
+    [ -n "$base" ] && [ -d "$base" ] || continue
+    result="$(find "$base" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null | sort | tail -n 1 || true)"
+    [ -n "$result" ] && break
+  done
+  printf '%s' "$result"
+}
+
 build_remote_dir() {
   local run_id="$1"
   printf '%s/%s/%s/%s' "$REMOTE_BASE" "$SITE_NAME" "$MODE" "$run_id"
@@ -277,6 +294,8 @@ sync_local() {
       --include='last.ckpt' \
       --include='epoch=*.ckpt' \
       --include='*_model_gt_and_classprob_*.csv' \
+      --include='stamp_metrics_summary.csv' \
+      --include='stamp_gt_predprob_*.csv' \
       --exclude='*' \
       "$run_dir/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
     echo "$now" > "$LAST_CKPT_SYNC_FILE" 2>/dev/null || true
@@ -305,6 +324,7 @@ sync_swarm() {
   ssh_cmd "${REMOTE_USER}@${REMOTE_HOST}" "rm -rf '$(build_remote_dir "_active")'" || true
 
   run_name="$(extract_run_name_from_nohup || true)"
+  [ -n "$run_name" ] || run_name="$(find_latest_swarm_run_name || true)"
   remote_dir="$(build_remote_dir "$job_id")"
   ensure_remote_dir "$remote_dir"
 
@@ -352,6 +372,8 @@ sync_swarm() {
         --include='last.ckpt' \
         --include='epoch=*.ckpt' \
         --include='*_model_gt_and_classprob_*.csv' \
+        --include='stamp_metrics_summary.csv' \
+        --include='stamp_gt_predprob_*.csv' \
         --exclude='*' \
         "$run_dir_for_sync/" "${REMOTE_USER}@${REMOTE_HOST}:${remote_dir}/run_dir/" || true
       echo "$now" > "$LAST_CKPT_SYNC_FILE" 2>/dev/null || true
@@ -388,6 +410,7 @@ final_sync() {
     local job_id run_name remote_dir hb_file
     job_id="$(find_latest_job_id || true)"
     run_name="$(extract_run_name_from_nohup || true)"
+    [ -n "$run_name" ] || run_name="$(find_latest_swarm_run_name || true)"
     if [ -n "$job_id" ]; then
       remote_dir="$(build_remote_dir "$job_id")"
       hb_file="$STATE_DIR/swarm_heartbeat_final.json"

--- a/tests/unit_tests/test_stamp_metrics_auroc.py
+++ b/tests/unit_tests/test_stamp_metrics_auroc.py
@@ -1,0 +1,128 @@
+"""Unit tests for the AUROC helpers in ``stamp_metrics_callback`` (#492).
+
+STAMP does not log AUROC into Lightning's ``callback_metrics`` under any key we
+can rely on, so ``val_auroc`` in the metrics summary was always blank. We now
+compute AUROC directly from the validation predictions. These tests validate
+that computation, including tie handling, against scikit-learn where available.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# stamp_metrics_callback imports torch + lightning at module import time.
+pytest.importorskip("torch")
+pytest.importorskip("lightning")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP_CUSTOM_DIR = (
+    REPO_ROOT / "application" / "jobs" / "STAMP_classification" / "app" / "custom"
+)
+if str(STAMP_CUSTOM_DIR) not in sys.path:
+    sys.path.insert(0, str(STAMP_CUSTOM_DIR))
+
+import stamp_metrics_callback as smc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _binary_auroc
+# ---------------------------------------------------------------------------
+
+def test_binary_auroc_perfect_separation():
+    assert smc._binary_auroc([0.1, 0.2, 0.8, 0.9], [0, 0, 1, 1]) == pytest.approx(1.0)
+
+
+def test_binary_auroc_perfectly_wrong():
+    assert smc._binary_auroc([0.9, 0.8, 0.2, 0.1], [0, 0, 1, 1]) == pytest.approx(0.0)
+
+
+def test_binary_auroc_all_ties_is_half():
+    # Every positive/negative pair is a tie -> 0.5.
+    assert smc._binary_auroc([0.5, 0.5, 0.5, 0.5], [0, 1, 0, 1]) == pytest.approx(0.5)
+
+
+def test_binary_auroc_single_class_returns_none():
+    assert smc._binary_auroc([0.1, 0.2, 0.3], [1, 1, 1]) is None
+    assert smc._binary_auroc([0.1, 0.2, 0.3], [0, 0, 0]) is None
+    assert smc._binary_auroc([], []) is None
+
+
+def test_binary_auroc_matches_sklearn_random():
+    sk = pytest.importorskip("sklearn.metrics")
+    import random
+    rng = random.Random(0)
+    labels = [rng.randint(0, 1) for _ in range(200)]
+    if sum(labels) in (0, len(labels)):  # guarantee both classes present
+        labels[0], labels[1] = 0, 1
+    scores = [l * 0.3 + rng.random() for l in labels]
+    assert smc._binary_auroc(scores, labels) == pytest.approx(
+        sk.roc_auc_score(labels, scores), abs=1e-9
+    )
+
+
+def test_binary_auroc_matches_sklearn_with_ties():
+    sk = pytest.importorskip("sklearn.metrics")
+    labels = [0, 0, 1, 1, 0, 1, 1, 0]
+    scores = [0.2, 0.2, 0.2, 0.9, 0.5, 0.5, 0.5, 0.1]  # deliberate ties
+    assert smc._binary_auroc(scores, labels) == pytest.approx(
+        sk.roc_auc_score(labels, scores), abs=1e-9
+    )
+
+
+# ---------------------------------------------------------------------------
+# _true_class_index
+# ---------------------------------------------------------------------------
+
+def test_true_class_index_scalar_and_onehot():
+    assert smc._true_class_index(1) == 1
+    assert smc._true_class_index(0) == 0
+    assert smc._true_class_index([1.0, 0.0]) == 0
+    assert smc._true_class_index([0.0, 1.0]) == 1
+    assert smc._true_class_index([0.1, 0.2, 0.7]) == 2
+
+
+# ---------------------------------------------------------------------------
+# macro_ovr_auroc
+# ---------------------------------------------------------------------------
+
+def test_macro_ovr_auroc_binary_onehot_ground_truth():
+    # Ground truth as one-hot [neg, pos], prob rows [p0, p1] — the exact layout
+    # the prediction callback produces.
+    gts = [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]
+    probs = [[0.9, 0.1], [0.8, 0.2], [0.3, 0.7], [0.2, 0.8]]
+    assert smc.macro_ovr_auroc(gts, probs) == pytest.approx(1.0)
+
+
+def test_macro_ovr_auroc_binary_scalar_ground_truth():
+    gts = [0, 0, 1, 1]
+    probs = [[0.9, 0.1], [0.8, 0.2], [0.3, 0.7], [0.2, 0.8]]
+    assert smc.macro_ovr_auroc(gts, probs) == pytest.approx(1.0)
+
+
+def test_macro_ovr_auroc_empty_returns_none():
+    assert smc.macro_ovr_auroc([], []) is None
+
+
+def test_macro_ovr_auroc_single_class_returns_none():
+    # Only negatives present for every class -> no computable class AUROC.
+    gts = [0, 0, 0]
+    probs = [[0.9, 0.1], [0.8, 0.2], [0.7, 0.3]]
+    assert smc.macro_ovr_auroc(gts, probs) is None
+
+
+def test_macro_ovr_auroc_matches_sklearn_multiclass():
+    sk = pytest.importorskip("sklearn.metrics")
+    import random
+    rng = random.Random(1)
+    n, k = 180, 3
+    gts, probs = [], []
+    for _ in range(n):
+        true = rng.randint(0, k - 1)
+        row = [rng.random() for _ in range(k)]
+        row[true] += 1.5  # bias toward the true class so it's learnable
+        s = sum(row)
+        probs.append([x / s for x in row])
+        gts.append(true)
+    expected = sk.roc_auc_score(gts, probs, multi_class="ovr", average="macro")
+    assert smc.macro_ovr_auroc(gts, probs) == pytest.approx(expected, abs=1e-9)


### PR DESCRIPTION
Fixes #492 and #493 — the two eval-plumbing gaps found from the first full 20-round MSI-High swarm run (the run trained and converged fine, but its results were not usable).

## Root causes
- **#492 — AUROC not obtainable centrally:**
  - `live_sync.sh:sync_swarm` located the run dir only via `extract_run_name_from_nohup` (which greps `"Run name:"/"Run directory:"`), but training logged `"Output directory:"` → the run dir (and its `stamp_metrics_summary.csv` / `stamp_gt_predprob_*.csv`) never synced. Local mode worked only because it lists the runs dir directly.
  - The callbacks read `val_auroc` from `callback_metrics` under keys STAMP doesn't use → the `val_auroc` column was always blank.
- **#493 — keeps the last model, not the best:** `IntimeModelSelector` was keyed on `key_metric = "accuracy"`, which STAMP never logs, and the client reported no metric → best-metric `None` → final broadcast model = last round.

## Changes
**#492**
- New pure macro one-vs-rest AUROC helper (Mann–Whitney, tie-correct, **no sklearn dependency**); compute AUROC from the validation predictions the prediction callback already gathers and populate the `val_auroc` column.
- `live_sync.sh`: locate the swarm run dir by listing `runs/<site>/` (the robust approach local mode uses) as a fallback; add the STAMP CSV filenames to the rsync include filters; also emit a `Run directory:` log line so nohup parsing works too.

**#493**
- Log `val_auroc` each round so `flare.patch` forwards it; set `IntimeModelSelector key_metric = "val_auroc"` (higher = better).

## Safety / testing
- Every training-code change is **fail-safe** (guarded): if the metric doesn't flow, behaviour equals today's (no regression to run completion).
- Adds `tests/unit_tests/test_stamp_metrics_auroc.py` — AUROC math validated against scikit-learn (binary, ties, multiclass, one-hot GT). Full local suite: **342 passed, 7 skipped**.

## ⚠️ Validation caveat
CI (`unit-tests` + `pr-test`) does **not** run a real swarm training, so it cannot confirm the metric-reporting path end-to-end. "CI green" here means unit tests + build, **not** eval-verified on the swarm path. Real confirmation = rebuild the image and run a 2-site MSI-High smoke, then check `stamp_metrics_summary.csv` has AUROC, the CSVs sync, and best-model selection fires. Kits must be rebuilt/redeployed for sites to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)