### PR TITLE
fix(stamp): finalize checkpoints in-loop (#480); don't report a skipped eval as PASS (#476)

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/main.py
+++ b/application/jobs/STAMP_classification/app/custom/main.py
@@ -115,13 +115,23 @@ def main():
                            if metric_callback.last_val_auroc is not None else "")
                     )
 
+                # Consolidate checkpoints every round. When the swarm loop ends,
+                # the launcher (launch_once=true) SIGTERMs this subprocess before
+                # the post-loop finalize can run, so finalize must happen in-loop
+                # (#480). It is idempotent — copies the latest best/last checkpoints
+                # — so repeating it each round is cheap, and the final round leaves
+                # the correct best/last artifacts behind.
+                stamp_training.finalize_training(model, checkpointing, trainer, output_dir)
+
         elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
             stamp_training.validate_and_train(
                 train_dl, valid_dl, model, trainer,
                 output_dir=output_dir,
             )
 
-        if TRAINING_MODE in [TM_LOCAL_TRAINING, TM_SWARM]:
+        # Swarm mode finalizes per-round inside the loop above (see #480); only
+        # local training reaches this post-loop path reliably.
+        if TRAINING_MODE == TM_LOCAL_TRAINING:
             stamp_training.finalize_training(model, checkpointing, trainer, output_dir)
 
     except Exception as e:

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -347,13 +347,61 @@ fix_remote_dns() {
     ok "DNS resolution verified on all remote machines"
 }
 
+# ── Container name filter, scoped to THIS test's kit (#472) ───────────────
+# stop_all() used to kill every container matching "stamp_swarm|nvflare" on every
+# site, so a retry (or a concurrently running deploy test) tore down containers
+# belonging to a run that was still training — clients died ~1s after round 0 was
+# dispatched, with no error in any log.
+#
+# Every built startup kit hardcodes its own container names as
+#   stamp_swarm_{client,server}_<name>_<git-short-hash>
+# so the trailing hash identifies the kit this test drives. Scope the filter to it.
+# If it cannot be derived we fall back to the old broad pattern (and say so) —
+# a silently no-op cleanup would leave containers behind and break later runs.
+KIT_CONTAINER_SUFFIX=""
+KIT_SUFFIX_RESOLVED=false
+
+resolve_kit_container_suffix() {
+    [[ "$KIT_SUFFIX_RESOLVED" == true ]] && return 0
+    KIT_SUFFIX_RESOLVED=true
+
+    local prod_dir docker_sh
+    prod_dir=$(find_latest_prod 2>/dev/null || true)
+    [[ -n "$prod_dir" && -d "$prod_dir" ]] || return 0
+
+    docker_sh=$(find "$prod_dir" -mindepth 3 -maxdepth 3 -path '*/startup/docker.sh' 2>/dev/null | head -1)
+    [[ -n "$docker_sh" ]] || return 0
+
+    KIT_CONTAINER_SUFFIX=$(grep -hoE '^CONTAINER_NAME=stamp_swarm_.*_[0-9a-f]{7,40}$' "$docker_sh" 2>/dev/null \
+        | head -1 | sed -E 's/.*_([0-9a-f]{7,40})$/\1/')
+
+    if [[ -n "$KIT_CONTAINER_SUFFIX" ]]; then
+        info "Container cleanup scoped to this kit: *_${KIT_CONTAINER_SUFFIX} (#472)"
+    else
+        warn "Could not derive this kit's container suffix — cleanup falls back to the"
+        warn "  broad 'stamp_swarm|nvflare' filter, which can disturb a concurrent run (#472)."
+    fi
+}
+
+# Extended-regex matching only this test's containers (or the broad legacy filter).
+container_filter() {
+    resolve_kit_container_suffix
+    if [[ -n "$KIT_CONTAINER_SUFFIX" ]]; then
+        printf 'stamp_swarm_.*_%s$' "$KIT_CONTAINER_SUFFIX"
+    else
+        printf 'stamp_swarm|nvflare'
+    fi
+}
+
 # ── Stop all containers ───────────────────────────────────────────────────
 stop_all() {
-    info "Stopping all STAMP/NVFlare containers..."
+    local filter
+    filter=$(container_filter)
+    info "Stopping STAMP/NVFlare containers (filter: $filter)..."
 
     # Stop local containers on Cosmos (server + admin)
     local local_containers
-    local_containers=$(docker ps --format '{{.Names}}' | grep -E "stamp_swarm|nvflare" || true)
+    local_containers=$(docker ps --format '{{.Names}}' | grep -E "$filter" || true)
     if [[ -n "$local_containers" ]]; then
         echo "$local_containers" | xargs docker kill 2>/dev/null || true
         echo "$local_containers" | xargs docker rm -f 2>/dev/null || true
@@ -369,8 +417,8 @@ stop_all() {
         fi
         visited_hosts[$host]=1
         remote_exec "$site" \
-            "docker ps --format '{{.Names}}' | grep -E 'stamp_swarm|nvflare' | xargs -r docker kill 2>/dev/null; \
-             docker ps -a --format '{{.Names}}' | grep -E 'stamp_swarm|nvflare' | xargs -r docker rm -f 2>/dev/null" \
+            "docker ps --format '{{.Names}}' | grep -E '$filter' | xargs -r docker kill 2>/dev/null; \
+             docker ps -a --format '{{.Names}}' | grep -E '$filter' | xargs -r docker rm -f 2>/dev/null" \
             2>/dev/null || warn "  Could not stop containers on $host"
     done
 
@@ -494,7 +542,7 @@ start_server() {
     info "Waiting 15s for server to initialize..."
     sleep 15
 
-    if docker ps --format '{{.Names}}' | grep -qE "stamp_swarm|nvflare"; then
+    if docker ps --format '{{.Names}}' | grep -qE "$(container_filter)"; then
         ok "Server container is running"
     else
         warn "Server container not detected — it may still be starting"
@@ -693,7 +741,7 @@ wait_for_completion() {
         fi
 
         # Check if the server container died
-        if ! docker ps --format '{{.Names}}' | grep -qE "stamp_swarm|nvflare"; then
+        if ! docker ps --format '{{.Names}}' | grep -qE "$(container_filter)"; then
             if [[ -f "$server_log" ]]; then
                 local new_lines
                 new_lines=$(tail -n +"$((start_line + 1))" "$server_log" 2>/dev/null || true)

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -73,11 +73,13 @@ TEST_MODELS=()
 # Populated by run_single_model(); drive the script's exit status.
 PASSED_MODELS=()
 FAILED_MODELS=()
+TRAINING_ONLY_MODELS=()  # passed training, but a requested evaluation did not verify (#476)
 EVALUATE=false          # run the post-training evaluation step (#270)
 EVAL_SITE_ARG=""        # site whose data to evaluate on (default: first client site)
 EVAL_DATA_DIR_ARG=""    # host path to eval data on this (server) machine
 TASK="classification"   # STAMP task: classification | survival | regression (#271)
 COMPARE_LOCAL=false     # also train a local-only baseline and compare (#275)
+STRICT=false            # treat a requested-but-skipped/failed evaluation as a failure (#476)
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -87,6 +89,7 @@ while [[ $# -gt 0 ]]; do
         --task)          TASK="$2"; shift ;;
         --evaluate)      EVALUATE=true ;;
         --compare-local) COMPARE_LOCAL=true ;;
+        --strict)        STRICT=true ;;
         --eval-site)     EVAL_SITE_ARG="$2"; shift ;;
         --eval-data-dir) EVAL_DATA_DIR_ARG="$2"; shift ;;
         -h|--help)
@@ -105,6 +108,9 @@ while [[ $# -gt 0 ]]; do
             echo "                   stamp_predict.py to record task metrics (#270)."
             echo "  --compare-local  With --evaluate: also train a local-only baseline on the"
             echo "                   eval site and compare federated vs local (#275)."
+            echo "  --strict         With --evaluate: fail (non-zero exit) if evaluation was"
+            echo "                   requested but skipped or errored, instead of reporting a"
+            echo "                   plain PASS. Otherwise such a model is 'PASSED (training only)' (#476)."
             echo "  --eval-site      Site whose data (on this machine) to evaluate on"
             echo "                   (default: first client site; needs its data locally)"
             echo "  --eval-data-dir  Host dir mounted as /data for evaluation"
@@ -1002,12 +1008,25 @@ run_single_model() {
     record_result "$model_name" "$job_name" "$train_status" "$duration" "$eval_status"
 
     echo ""
-    if [[ "$train_status" == "pass" ]]; then
-        ok "PASSED: $model_name in ${duration}s (evaluation: $eval_status)"
-        PASSED_MODELS+=("$model_name")
-    else
+    if [[ "$train_status" != "pass" ]]; then
         err "FAILED: $model_name in ${duration}s"
         FAILED_MODELS+=("$model_name")
+    elif [[ "$EVALUATE" == true && "$eval_status" != "pass" ]]; then
+        # Evaluation was explicitly requested but did not produce a result. Never
+        # report this as a plain PASS — a skipped evaluation previously looked
+        # identical to a verified one (#476).
+        if [[ "$STRICT" == true ]]; then
+            err "FAILED: $model_name in ${duration}s — evaluation requested but ${eval_status} (--strict)"
+            FAILED_MODELS+=("$model_name")
+        else
+            warn "PASSED (training only): $model_name in ${duration}s — evaluation ${eval_status}, NOT verified"
+            warn "  Re-run with --strict to treat this as a failure."
+            TRAINING_ONLY_MODELS+=("$model_name")
+            PASSED_MODELS+=("$model_name")
+        fi
+    else
+        ok "PASSED: $model_name in ${duration}s (evaluation: $eval_status)"
+        PASSED_MODELS+=("$model_name")
     fi
 
     # Always return 0 so the caller keeps testing the remaining models; the
@@ -1059,9 +1078,23 @@ done
 # Previously the script always exited 0, so a failing model (e.g. barspoon,
 # which the shipped STAMP cannot instantiate) still reported success to CI.
 step "STAMP deploy test summary"
-for m in "${PASSED_MODELS[@]:-}"; do [[ -n "$m" ]] && ok "  PASS  $m"; done
+for m in "${PASSED_MODELS[@]:-}"; do
+    [[ -n "$m" ]] || continue
+    # Mark models whose requested evaluation never verified, so a training-only
+    # result is never mistaken for a fully verified pass (#476).
+    if [[ " ${TRAINING_ONLY_MODELS[*]:-} " == *" $m "* ]]; then
+        warn "  PASS  $m  (training only — evaluation NOT verified)"
+    else
+        ok "  PASS  $m"
+    fi
+done
 for m in "${FAILED_MODELS[@]:-}"; do [[ -n "$m" ]] && err "  FAIL  $m"; done
 info "  ${#PASSED_MODELS[@]} passed, ${#FAILED_MODELS[@]} failed (results: $RESULTS_DIR)"
+
+if [[ ${#TRAINING_ONLY_MODELS[@]} -gt 0 ]]; then
+    warn "  Evaluation was requested but not verified for: ${TRAINING_ONLY_MODELS[*]}"
+    warn "  These passed TRAINING only. Re-run with --strict to fail on this."
+fi
 
 if [[ ${#FAILED_MODELS[@]} -gt 0 ]]; then
     err "Deploy test FAILED for: ${FAILED_MODELS[*]}"


### PR DESCRIPTION
Two DECADE/STAMP fixes found while validating the first full MSI-High swarm run.

## Fixes #480 — `finalize_training` never ran in swarm mode
`SubprocessLauncher` runs `main.py` once per job (`launch_once = true`) and SIGTERMs it on job end (`shutdown_timeout` defaults to `0.0`), so the training subprocess is killed while blocked in the `flare.is_running()` poll — the `finalize_training()` call *after* the loop never executed and the best/last checkpoint consolidation was silently lost.

**Fix:** call `finalize_training()` **inside** the swarm loop (idempotent — it copies the already-written best/last checkpoints, so repeating it per round is cheap and the final round leaves the right artifacts). The post-loop call is kept for `local_training`, which does reach it.

This is the STAMP counterpart of the mechanism #480 documents for the ODELIA job.

## Addresses #476 (the false-PASS half) — a skipped evaluation reported as PASS
`--evaluate` degraded silently: if the eval data wasn't on the orchestrator host, evaluation was skipped and the model still printed `PASSED`, making a skipped evaluation indistinguishable from a verified one.

**Fix:**
- A requested-but-unverified evaluation is now reported as **`PASSED (training only) — evaluation NOT verified`**, and flagged again in the summary.
- New **`--strict`** flag turns that into a real failure (non-zero exit) — suitable for CI.
- A plain `PASS` now means training passed **and** (when requested) evaluation verified.

**Left open in #476:** actually running the evaluation on the eval site over SSH (where the data and a compatible GPU are). That's the larger half and is unchanged here, so #476 stays open.

## Testing
- Full unit suite: **342 passed, 7 skipped**.
- `bash -n` clean; no shellcheck errors; `--help` documents `--strict`; `main.py` parses.
- ⚠️ Neither change is exercised end-to-end by CI (no real swarm run / no eval data on the runner). The #480 fix is verified by the next real 2-site smoke; the #476 change is reporting logic only and cannot affect training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)