### PR TITLE
fix(stamp): correct swarm selection metric key (#493) + make the deploy test actually valid

### DIFF
--- a/application/jobs/STAMP_classification/app/config/config_fed_client.conf
+++ b/application/jobs/STAMP_classification/app/config/config_fed_client.conf
@@ -150,11 +150,18 @@
       id = "model_selector"
       path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
       args {
-        # The training subprocess logs ``val_auroc`` each round (higher is better),
-        # which flare.patch forwards as the selection metric. Previously this was
-        # "accuracy", which STAMP never logs, so best-model selection never fired
-        # and the final broadcast model was always the last round (#493).
-        key_metric = "val_auroc"
+        # Must match a key actually present in the metrics submitted with the result.
+        # Otherwise IntimeModelSelector never fires GLOBAL_BEST_MODEL_AVAILABLE,
+        # SwarmClientController.best_metric stays None, and the LAST round's model is
+        # broadcast instead of the best (#493).
+        #
+        # The keys that actually arrive are ['validation_loss', 'validation_auroc'],
+        # confirmed from a real 2-node run where the selector logged:
+        #   validation metric `val_auroc` not in metrics from Mainz_1:
+        #   ['validation_loss', 'validation_auroc']
+        # ("accuracy" and "val_auroc" were both wrong guesses.) Higher AUROC is
+        # better, so negate_key_metric stays off.
+        key_metric = "validation_auroc"
       }
     }
     {

--- a/application/jobs/STAMP_classification/app/custom/stamp_metrics_callback.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_metrics_callback.py
@@ -157,7 +157,9 @@ class STAMPMetricsSummaryCallback(Callback):
         # AUROC — prefer a value STAMP logged into callback_metrics; otherwise
         # fall back to the AUROC computed by the prediction callback (#492).
         val_auroc = None
-        for key in ("val_auroc", "val_MulticlassAUROC"):
+        # "validation_auroc" is the key STAMP actually logs (confirmed from a real
+        # 2-node run); the others are kept as fallbacks for other STAMP versions.
+        for key in ("validation_auroc", "val_auroc", "val_MulticlassAUROC"):
             v = metrics.get(key)
             if v is not None:
                 val_auroc = v

--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -334,7 +334,8 @@ class ValidationMetricCallback(Callback):
             self.last_val_loss = self.last_val_loss.item()
 
         # Try to get AUROC if available (classification only)
-        for key in ["val_auroc", "val_MulticlassAUROC"]:
+        # "validation_auroc" is what STAMP actually logs (confirmed from a real run).
+        for key in ["validation_auroc", "val_auroc", "val_MulticlassAUROC"]:
             val = metrics.get(key)
             if val is not None:
                 self.last_val_auroc = val.item()

--- a/application/provision/project_decade_2site_test.yml
+++ b/application/provision/project_decade_2site_test.yml
@@ -10,8 +10,15 @@ participants:
   - name: dl3.tud.de
     type: server
     org: TUD
-    fed_learn_port: 8002
-    admin_port: 8003
+    # Deliberately NOT 8002/8003. The orchestrator host also runs the long-lived
+    # ODELIA swarm server on 8002/8003, so this test server could not bind
+    # ("address already in use", retried forever). Clients and admin then reached
+    # the ODELIA server instead — same host, same ports — and failed with
+    # ClientConnectorCertificateError, because that server's certificate is signed
+    # by the ODELIA CA rather than this project's. Symptoms look like a DECADE cert
+    # problem but are a port collision; a dedicated port pair removes it for good.
+    fed_learn_port: 8102
+    admin_port: 8103
   - name: UKB_1
     type: client
     org: UKB
@@ -37,6 +44,6 @@ builders:
         path: nvflare.ha.dummy_overseer_agent.DummyOverseerAgent
         overseer_exists: false
         args:
-          sp_end_point: dl3.tud.de:8002:8003
+          sp_end_point: dl3.tud.de:8102:8103
   - path: nvflare.lighter.impl.cert.CertBuilder
   - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -570,10 +570,17 @@ start_clients() {
         local stamp_exports
         stamp_exports=$(setup_stamp_env "$site_name" "$model_name")
 
+        # Pin the client to the image this test actually built and pre-pulled.
+        # Client kits ship an image.conf pinning the release channel (:current), and
+        # docker.sh's precedence is --image > MEDISWARM_IMAGE > image.conf > built-in
+        # default. Without --image, image.conf won and every client ran :current --
+        # i.e. the deploy test pre-pulled the new image and then trained with the old
+        # one, so a "passing" deploy test said nothing about the build under test.
+        # (Server/admin kits do not source image.conf, so they were already correct.)
         remote_exec "$site" \
             "$stamp_exports && \
              cd '$deploy_dir/$site_name/startup' && \
-             ./docker.sh --no_pull --data_dir '$datadir' --scratch_dir '$scratchdir' --GPU '$gpu' --start_client"
+             ./docker.sh --no_pull --image '$DOCKER_IMAGE' --data_dir '$datadir' --scratch_dir '$scratchdir' --GPU '$gpu' --start_client"
 
         ok "  Client started: $site_name"
     done


### PR DESCRIPTION
Three fixes, **all found by running a real 2-node swarm** — none of them were reachable by unit tests or CI.

## Fixes #493 — best-model selection still didn't fire after #498
`SwarmClientController.best_metric` is set only when `IntimeModelSelector` fires `GLOBAL_BEST_MODEL_AVAILABLE`, which needs `key_metric` to exist in the submitted metrics. The run told us exactly what arrives:

```
IntimeModelSelector - WARNING - validation metric `val_auroc` not in metrics
from Mainz_1: ['validation_loss', 'validation_auroc']
```

The metric was flowing all along under **`validation_auroc`**. Both prior values — original `"accuracy"` and #498's `"val_auroc"` — were wrong guesses. Set `key_metric = "validation_auroc"`, and add that name as the first fallback in both metrics callbacks.

**Verified on real hardware (job `8156e59f`, 3 rounds, dl0+dl2):**
```
got GLOBAL_BEST_MODEL_AVAILABLE: best metric=1.0
global best metric is 1.0 from client UKB_1 at round 1
gatherer starting with previous best result from client UKB_1 with metric 1.0 at round 1
broadcasting best result with metric 1.0 at round 1 to clients ['Mainz_1']
```
and `best_FL_global_model.pt` (14.7 MB) now exists on both clients — it did **not** exist before this change. `No global best result!` is gone.

## The deploy test ran the wrong image
Client kits ship an `image.conf` pinning the release channel, and `docker.sh` precedence is `--image > MEDISWARM_IMAGE > image.conf > built-in default`. With no `--image`, every client ran **`:current`** while the test pre-pulled the newly built image — so a passing STAMP deploy test said nothing about the build under test (true since `image.conf` shipped in #479). Clients are now pinned to `--image "$DOCKER_IMAGE"`. Server/admin kits don't source `image.conf` and were already correct.

## The deploy test collided with the co-hosted ODELIA server
The orchestrator also runs the long-lived ODELIA swarm server on 8002/8003, so this project's server could never bind (`address already in use`, retried forever). Admin and clients then reached the **ODELIA** server on those ports and failed with `ClientConnectorCertificateError` — a port collision that looks exactly like a DECADE certificate problem (same signature as D9, different cause). Moved the DECADE test project to **8102/8103** (verified free on all three hosts). The ODELIA server was left running throughout.

## Validation summary (image `1.6.0-dev.260729.dc771e9`, dl0+dl2)
| Item | Result |
|---|---|
| #492 `val_auroc` in `stamp_metrics_summary.csv` | ✅ populated at both sites |
| #493 best-model selection | ✅ fires; `best_FL_global_model.pt` produced |
| #480 `finalize_training` runs | ✅ best/last checkpoints written |
| #472 scoped cleanup | ✅ filter `stamp_swarm_.*_<hash>$`; ODELIA untouched |
| #476 no false PASS | ✅ `PASSED (training only) — evaluation NOT verified` |

Unit suite: 342 passed, 7 skipped. `:current` / `:1.6.0` untouched throughout — DECADE sites remain on 1.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)