### PR TITLE
fix(deploy-test): size the scheduler from the job's num_rounds (#503)

### DIFF
--- a/scripts/deploy/run_stamp_deploy_test.sh
+++ b/scripts/deploy/run_stamp_deploy_test.sh
@@ -242,6 +242,30 @@ EVAL_SCRATCH_DIR="${EVAL_SCRATCH_DIR:-$RESULTS_DIR/eval_scratch}"
 # The STAMP master template's env var forwarding loop (for _var in STAMP_*)
 # picks them up and passes them into the Docker container.
 
+# ── Rounds the submitted job will actually run (#503) ────────────────────
+# STAMP sizes its OneCycleLR scheduler from STAMP_NUM_ROUNDS, but the number of
+# rounds actually executed comes from num_rounds in the job's config_fed_server.conf
+# (baked into the image). Hardcoding STAMP_NUM_ROUNDS here meant the scheduler could
+# be sized for fewer rounds than the server runs, and training died mid-run with
+# "Tried to step N times. The specified number of total steps is M" -- which aborts
+# the whole run and names neither variable. Read the job's value from the image so
+# there is one source of truth: a CI build using --num-rounds stays fast, and a
+# release image (num_rounds = 20) is sized correctly.
+_JOB_NUM_ROUNDS=""
+job_num_rounds() {
+    if [[ -z "$_JOB_NUM_ROUNDS" ]]; then
+        _JOB_NUM_ROUNDS=$(docker run --rm "$DOCKER_IMAGE" bash -lc \
+            "grep -oE 'num_rounds[[:space:]]*=[[:space:]]*[0-9]+' \
+             /MediSwarm/application/jobs/${JOB_NAME}/app/config/config_fed_server.conf \
+             | grep -oE '[0-9]+' | head -1" 2>/dev/null | tr -d '[:space:]')
+        if [[ ! "$_JOB_NUM_ROUNDS" =~ ^[0-9]+$ ]]; then
+            _JOB_NUM_ROUNDS=20
+            warn "Could not read num_rounds from $DOCKER_IMAGE; using $_JOB_NUM_ROUNDS for scheduler sizing (#503)" >&2
+        fi
+    fi
+    printf '%s' "$_JOB_NUM_ROUNDS"
+}
+
 setup_stamp_env() {
     local site_name="$1"
     local model_name="$2"
@@ -260,7 +284,7 @@ export STAMP_MAX_EPOCHS="2"
 export STAMP_PATIENCE="2"
 export STAMP_NUM_WORKERS="0"
 export STAMP_SEED="42"
-export STAMP_NUM_ROUNDS="2"
+export STAMP_NUM_ROUNDS="$(job_num_rounds)"
 export STAMP_EPOCHS_PER_ROUND="2"
 export STAMP_EPOCHS_REFERENCE_DATASET_SIZE="15"
 export STAMP_EPOCHS_MAX_CAP="4"


### PR DESCRIPTION
Harness half of #503, found while validating the 1.7.0 release image.

`setup_stamp_env` exported `STAMP_NUM_ROUNDS="2"` unconditionally. STAMP sizes its OneCycleLR scheduler from that, but the rounds actually executed come from `num_rounds` in the job's `config_fed_server.conf` (baked into the image). They agreed only by luck — test images were built with `--num-rounds 3`.

1.7.0 ships the correct production default `num_rounds = 20`, so the scheduler was sized for 2 rounds, exhausted at **round 4**, and the run aborted after ~59 minutes:

```
ValueError: Tried to step 9 times. The specified number of total steps is 8
 -> EXECUTION_EXCEPTION -> Aborting current RUN due to FATAL_SYSTEM_ERROR
```

**Fix:** derive `STAMP_NUM_ROUNDS` from the image under test. Verified: release image → `20`, CI-style `--num-rounds 3` build → `3`. Falls back to 20 with a warning if unreadable, so CI stays fast and a release image is sized correctly.

**#503 stays open** for the real fix — the client should take the round count from the workflow rather than a separate env var, or fail fast naming both values. Note this class of bug hides indefinitely: oversizing is harmless, so a mismatch only bites when someone *raises* `num_rounds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)