### PR TITLE
build/ci: prune unused hub docs (#408), run all-model preflight weekly (#352), badge hygiene (#390)

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -3,6 +3,9 @@ name: MediSwarm PR Validation
 on:
   schedule:
     - cron: '0 5 * * 0'
+  # Lets a maintainer re-run validation on demand — e.g. to refresh a stale README
+  # badge after an infrastructure fix, without pushing an empty commit (#390).
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -217,6 +220,18 @@ jobs:
         continue-on-error: false
         run: |
           ./scripts/ci/runIntegrationTests.sh run_data_access_preflight_check
+
+      # #352: PRs only exercise the default model, so a break in one of the other
+      # five productive models is invisible until a deploy test or a real run hits
+      # it. run_all_models_preflight_check() already existed and was dispatchable,
+      # but was wired into no workflow at all. Run it on the weekly schedule and on
+      # manual dispatch — not on every PR, since it preflights all six models on the
+      # one shared GPU.
+      - name: Run preflight check for all productive models (weekly / manual)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        continue-on-error: false
+        run: |
+          ./scripts/ci/runIntegrationTests.sh run_all_models_preflight_check
 
       - name: Run dummy training in swarm
         continue-on-error: false

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 An open-source platform advancing medical AI via privacy-preserving swarm learning, based on NVFlare and developed with
 the ODELIA consortium.
 
-[![PR Tests](https://github.com/KatherLab/MediSwarm/actions/workflows/pr-test.yaml/badge.svg)](https://github.com/KatherLab/MediSwarm/actions/workflows/pr-test.yaml)
-[![Build](https://github.com/KatherLab/MediSwarm/actions/workflows/update-apt-versions.yml/badge.svg)](https://github.com/KatherLab/MediSwarm/actions/workflows/update-apt-versions.yml)
-[![Deploy Test](https://github.com/KatherLab/MediSwarm/actions/workflows/odelia-deploy-test.yml/badge.svg)](https://github.com/KatherLab/MediSwarm/actions/workflows/odelia-deploy-test.yml)
-[![STAMP Deploy Test](https://github.com/KatherLab/MediSwarm/actions/workflows/stamp-deploy-test.yml/badge.svg)](https://github.com/KatherLab/MediSwarm/actions/workflows/stamp-deploy-test.yml)
+[![PR Tests](https://github.com/KatherLab/MediSwarm/actions/workflows/pr-test.yaml/badge.svg?branch=main)](https://github.com/KatherLab/MediSwarm/actions/workflows/pr-test.yaml?query=branch%3Amain)
+[![Build](https://github.com/KatherLab/MediSwarm/actions/workflows/update-apt-versions.yml/badge.svg?branch=main)](https://github.com/KatherLab/MediSwarm/actions/workflows/update-apt-versions.yml?query=branch%3Amain)
+[![Deploy Test](https://github.com/KatherLab/MediSwarm/actions/workflows/odelia-deploy-test.yml/badge.svg?branch=main)](https://github.com/KatherLab/MediSwarm/actions/workflows/odelia-deploy-test.yml?query=branch%3Amain)
+[![STAMP Deploy Test](https://github.com/KatherLab/MediSwarm/actions/workflows/stamp-deploy-test.yml/badge.svg?branch=main)](https://github.com/KatherLab/MediSwarm/actions/workflows/stamp-deploy-test.yml?query=branch%3Amain)
 
 > **Current release: [v1.5.0](https://github.com/KatherLab/MediSwarm/releases/tag/v1.5.0)** (swarm-robustness).
 

--- a/scripts/build/_cacheAndCopyPretrainedModelWeights.sh
+++ b/scripts/build/_cacheAndCopyPretrainedModelWeights.sh
@@ -127,8 +127,30 @@ verify_files () {
 
 
 copy_files() {
-    # Copy MST pre-trained weights
+    # Copy MST pre-trained weights.
+    #
+    # #408: the torch.hub cache holds the checkpoint (~85 MB, required) *and* a full
+    # clone of the dinov2 repo. The clone cannot simply be dropped -- models/mst.py
+    # calls torch.hub.load('facebookresearch/dinov2', ...), which imports hubconf.py
+    # and the dinov2 package from it. But its docs/ (1.8 MB of PNGs), notebooks/
+    # (1.3 MB of .ipynb) and .github/ are documentation and media that are never
+    # imported, and they end up in a Docker image layer. Prune only those.
     cp -r "$CACHE_DIR/torch_home_cache" "$TARGET_DIR/torch_home_cache"
+    _dinov2_dir="$TARGET_DIR/torch_home_cache/hub/facebookresearch_dinov2_main"
+    if [[ -d "$_dinov2_dir" ]]; then
+        rm -rf "$_dinov2_dir/docs" "$_dinov2_dir/notebooks" "$_dinov2_dir/.github"
+        # Fail loudly rather than shipping an image whose backbone cannot load: a
+        # missing hub artifact only surfaces at training time, not in CI.
+        for _required in \
+            "$TARGET_DIR/torch_home_cache/hub/checkpoints/dinov2_vits14_pretrain.pth" \
+            "$_dinov2_dir/hubconf.py" \
+            "$_dinov2_dir/dinov2" ; do
+            if [[ ! -e "$_required" ]]; then
+                echo "ERROR: required torch.hub artifact missing after prune: $_required" >&2
+                exit 1
+            fi
+        done
+    fi
     chmod a+rX "$TARGET_DIR/torch_home_cache" -R
 
     # Copy ResNet18 pre-trained weights


### PR DESCRIPTION
Three small, self-contained issues. Each was verified by measurement rather than assumption.

## #408 — copy only what the image needs
Measured first: the torch.hub cache is **89 MB**, of which **85 MB is the dinov2 checkpoint** (required) and 4.6 MB is a clone of the dinov2 repo. The clone **cannot** simply be dropped — `models/mst.py:34` calls `torch.hub.load('facebookresearch/dinov2', ...)`, which imports `hubconf.py` and the `dinov2` package from it. What *is* dead weight: `docs/` (1.8 MB of PNGs), `notebooks/` (1.3 MB of `.ipynb`) and `.github/`.

Pruned exactly those — **measured 89M → 86M**. Because a missing hub artifact would only surface at training time and never in CI, the copy now asserts the checkpoint, `hubconf.py` and the `dinov2` package survive, and fails the build loudly otherwise. Verified against the real cache: nothing required is removed and `hubconf.py` references nothing pruned.

*Honest scope note:* the issue title suggests a large win; the ceiling here is ~3 MB, because the payload really is the checkpoint.

## #352 — actually run the all-models preflight
`run_all_models_preflight_check()` already existed (`runIntegrationTests.sh:988`) and was dispatchable — but was wired into **no workflow**. PRs only ever exercised the default model, so a break in any of the other five productive models stayed invisible until a deploy test or a real run hit it.

Now runs on the weekly schedule and on manual dispatch — deliberately **not** per-PR, since it preflights all six models on the one shared GPU.

## #390 — badge hygiene
Badges now track `main` (`?branch=main`) instead of whatever ran last, and their links filter to main too. `pr-test` gains `workflow_dispatch` so a maintainer can refresh a stale badge after an infrastructure fix without pushing an empty commit.

The two deploy-test badges are **deliberately left in place**. They are red because the deploy test genuinely cannot publish its image yet (see the companion Docker Hub auth PR) — hiding a real failure would be worse than showing it. They should go green once that lands and a deploy run succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
