### PR TITLE
fix(deploy-test): clear root-owned stamp_eval_data before checkout

### DIFF
--- a/.github/workflows/stamp-deploy-test.yml
+++ b/.github/workflows/stamp-deploy-test.yml
@@ -66,9 +66,16 @@ jobs:
     steps:
       - name: Clean root-owned files from previous runs
         run: |
-          # NVFlare server container creates root-owned workspace files that
-          # block actions/checkout@v4's git clean. Remove them before checkout.
-          sudo rm -rf "$GITHUB_WORKSPACE/workspace" 2>/dev/null || true
+          # Containers in this workflow run as root and leave root-owned files in
+          # the workspace, which block actions/checkout@v4's git clean on the NEXT
+          # run ("failed to remove ...: Permission denied" -> checkout fails).
+          #   workspace/       — NVFlare server container
+          #   stamp_eval_data/ — the synthetic-dataset container in "Prepare local
+          #                      evaluation data"; this one was missing, so a run
+          #                      that reached the eval step wedged every later run.
+          sudo rm -rf "$GITHUB_WORKSPACE/workspace" \
+                      "$GITHUB_WORKSPACE/stamp_eval_data" \
+                      "$GITHUB_WORKSPACE/deploy_test_stamp" 2>/dev/null || true
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Found while validating the Docker Hub auth fix (#507) with a real deploy run.

## Symptom
The run died at **`actions/checkout@v4`**, before any deploy logic — which makes it look like an infrastructure/git problem unrelated to the deploy test:
```
warning: failed to remove stamp_eval_data/client_A/features/P_004.h5: Permission denied
```

## Cause
The **previous** run's "Prepare local evaluation data" step generates the synthetic dataset with `docker run -v "$eval_root":/data …`. That container runs as **root**, so `$GITHUB_WORKSPACE/stamp_eval_data` is left root-owned. The pre-checkout cleanup only removed `workspace/`, so `git clean` couldn't remove `stamp_eval_data/` and checkout failed.

This is self-perpetuating: once a run reaches the eval step, **every later run wedges at checkout** until someone manually `sudo rm -rf`s the directory. It also explains why the failure appears unrelated to whatever the run was meant to test.

## Fix
Remove `stamp_eval_data/` (and `deploy_test_stamp/`) alongside `workspace/` in the existing pre-checkout cleanup step.

Also cleared the stale root-owned directories on dl0 and dl2 by hand so the next run isn't blocked by the existing mess.

`odelia-deploy-test.yml` was checked and does **not** have this gap — it creates no equivalent workspace-local root-owned directory (its cleanup already covers `workspace/` and `deploy_test/`).

## Progress context
With #507 merged, the push step now **succeeds** — all 8 previous deploy runs died there with `denied: requested access to the resource is denied`. This is the next layer of the same validation effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
