### PR TITLE
fix(deploy-test): cleanup must not rely on sudo; stop creating root-owned files

### DIFF
--- a/.github/workflows/odelia-deploy-test.yml
+++ b/.github/workflows/odelia-deploy-test.yml
@@ -71,7 +71,11 @@ jobs:
         run: |
           # NVFlare server container creates root-owned workspace files that
           # block actions/checkout@v4's git clean.  Remove them before checkout.
-          sudo rm -rf "$GITHUB_WORKSPACE/workspace" "$GITHUB_WORKSPACE/deploy_test" 2>/dev/null || true
+          # `sudo` is NOT usable on these runners (no passwordless sudo): it prompts,
+          # fails silently under `2>/dev/null || true`, and the step reports success
+          # while deleting nothing. Use a disposable root container, as pr-test.yaml does.
+          docker run --rm -v "$GITHUB_WORKSPACE":/ws alpine sh -c \
+            'rm -rf /ws/workspace /ws/deploy_test' || true
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/stamp-deploy-test.yml
+++ b/.github/workflows/stamp-deploy-test.yml
@@ -73,9 +73,16 @@ jobs:
           #   stamp_eval_data/ — the synthetic-dataset container in "Prepare local
           #                      evaluation data"; this one was missing, so a run
           #                      that reached the eval step wedged every later run.
-          sudo rm -rf "$GITHUB_WORKSPACE/workspace" \
-                      "$GITHUB_WORKSPACE/stamp_eval_data" \
-                      "$GITHUB_WORKSPACE/deploy_test_stamp" 2>/dev/null || true
+          # NOTE: `sudo` is NOT usable here. The runner user has no passwordless
+          # sudo, so `sudo rm -rf ... 2>/dev/null || true` prompts, fails silently
+          # and the step reports success while deleting nothing -- which is why the
+          # previous fix appeared to work and the checkout kept failing anyway.
+          # Use a disposable root container instead, as pr-test.yaml already does.
+          docker run --rm -v "$GITHUB_WORKSPACE":/ws alpine sh -c \
+            'rm -rf /ws/workspace /ws/stamp_eval_data /ws/deploy_test_stamp' || true
+          # Belt and braces: hand anything else root-owned back to the runner user.
+          docker run --rm -v "$GITHUB_WORKSPACE":/ws alpine sh -c \
+            'find /ws -mindepth 1 -maxdepth 1 -not -name ".git" -exec chown -R '"$(id -u):$(id -g)"' {} + 2>/dev/null || true' || true
 
       - uses: actions/checkout@v4
         with:
@@ -184,7 +191,11 @@ jobs:
           # The image's WORKDIR is /workspace, but the source lives at /MediSwarm,
           # so the script must be addressed by absolute path (a relative path fails
           # with "can't open file '/workspace/application/...'").
-          docker run --rm -v "$eval_root":/data "$image" \
+          # Run as the invoking user, not root: otherwise every generated file under
+          # stamp_eval_data/ is root-owned and blocks the NEXT run's checkout (git
+          # clean cannot remove them, and the runner has no passwordless sudo).
+          # Same pattern as scripts/ci/runIntegrationTests.sh.
+          docker run --rm -u "$(id -u):$(id -g)" -v "$eval_root":/data "$image" \
             python3 /MediSwarm/application/jobs/STAMP_classification/app/scripts/create_synthetic_dataset/create_synthetic_stamp_dataset.py /data
 
           # Resolve the eval site name from the conf (first client site).


### PR DESCRIPTION
The cleanup added in #508 **never deleted anything** — this fixes it properly.

## Why #508 didn't work
The runner user has **no passwordless sudo**. So:
```
sudo rm -rf "$GITHUB_WORKSPACE/stamp_eval_data" 2>/dev/null || true
```
prompts for a password, fails, has its error swallowed by `2>/dev/null`, and is forgiven by `|| true`. The step reports **success** while removing nothing — and the next checkout still dies on `failed to remove stamp_eval_data/…: Permission denied`. The same silent no-op is in `odelia-deploy-test.yml`.

(Corroborated independently: the deploy script itself failed with `sudo: no password was provided` on the same host.)

## Fix — two layers
1. **Delete without sudo.** Use a disposable root container, the pattern `pr-test.yaml` already uses for exactly this, plus a `chown` sweep for anything else root-owned. Applied to **both** deploy workflows.
2. **Stop creating root-owned files at all.** Run the synthetic-eval-data container with `-u $(id -u):$(id -g)`, so `stamp_eval_data/` belongs to the runner user and never needs privileged deletion. Matches `scripts/ci/runIntegrationTests.sh`, which already does this for every other container.

Layer 2 is the actual cause; layer 1 keeps the workspace recoverable if any other container leaves root-owned files behind.

## How it was found
By dispatching real deploy runs and reading the logs — each fix exposed the next failure. This one is a good example of the "green CI proves nothing about the deploy path" lesson: the cleanup step was green throughout while doing nothing, and the resulting failure looked like an unrelated git/checkout problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
