### PR TITLE
fix(ci): keep the ODELIA deploy test off dl3 (DECADE production host)

### DIFF
--- a/.github/workflows/odelia-deploy-test.yml
+++ b/.github/workflows/odelia-deploy-test.yml
@@ -16,7 +16,7 @@ on:
       conf_source:
         description: "Deploy-site credential/config file on the runner (default: ~/mediswarm_deploy_conf/...)"
         required: false
-        # Empty -> the job falls back to $HOME/mediswarm_deploy_conf/deploy_sites_4node_test.conf
+        # Empty -> the job falls back to $HOME/mediswarm_deploy_conf/deploy_sites_odelia_ci_2node.conf
         # on the runner. A literal $HOME here would NOT be expanded by YAML.
         default: ""
         type: string
@@ -98,7 +98,7 @@ jobs:
 
           project_file="${INPUT_PROJECT_FILE:-application/provision/project_deploy_test_4site.yml}"
           num_rounds="${INPUT_NUM_ROUNDS:-1}"
-          conf_source="${INPUT_CONF_SOURCE:-$HOME/mediswarm_deploy_conf/deploy_sites_4node_test.conf}"
+          conf_source="${INPUT_CONF_SOURCE:-$HOME/mediswarm_deploy_conf/deploy_sites_odelia_ci_2node.conf}"
           run_all="${INPUT_RUN_ALL:-false}"
           model="${INPUT_MODEL:-1DivideAndConquer}"
           job="${INPUT_JOB:-challenge_1DivideAndConquer}"


### PR DESCRIPTION
Found by running the ODELIA deploy test for the first time on the ci runners.

## What happened
The ODELIA deploy test defaults to the **4-site** conf, whose `CLIENT_SITES` include `DL3A`/`DL3B` — both on **dl3, which runs the DECADE production FL server**.

`fix_remote_dns()` rewrites `/etc/hosts` on *every* client host. dl3's own hostname **is** `dl3.tud.de`, which is also the ODELIA server's provisioned FQDN — so the test tried to repoint `dl3.tud.de` away from dl3, **on dl3**, which would break the DECADE server's self-resolution. It also deploys kits and runs containers on a production box.

From run `30529577286`:
```
[INFO]   100.64.4.103 maps dl3.tud.de → 100.64.4.103 (wrong, updating to 100.64.4.100)
##[error]Process completed with exit code 1.
```

**No damage occurred** — the rewrite failed because the runner has no passwordless sudo on dl3. I verified afterwards that dl3's `/etc/hosts` still maps `dl3.tud.de → 100.64.4.103` and `stamp_swarm_server_flserver_7e56dd4` is still up with its ports listening. But that was luck, not design.

## Fix
Default the workflow to a **dl0 + dl2** conf (`deploy_sites_odelia_ci_2node.conf`, staged 0600 on both runners), matching what the STAMP deploy test already does. The 4-site conf remains available via the `conf_source` input for deliberate runs.

This follows the stated host split: **cosmos** = ODELIA server/admin + development; **dl0/dl2** = CI and validation; **dl3** = DECADE production.

## Known issue left open
The ODELIA server's provisioned FQDN is `dl3.tud.de` — the same name as a real, different machine. That collision is what makes this failure mode possible at all. Renaming the provisioned server would fix it properly, but needs a kit rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)