### PR TITLE
Make strict ODELIA swarm runs reliable and exact-client by default

### DIFF
--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_client.conf
@@ -15,8 +15,12 @@
         args {
           launcher_id = "launcher"
           pipe_id = "pipe"
-          # time to wait for final result transfer from subprocess (30 min — large models over VPN)
-          last_result_transfer_timeout = 1800
+          # Let the client job wait for the subprocess result transfer for the
+          # full long-run budget.
+          last_result_transfer_timeout = 86400
+          # Keep producer-side tensor refs alive through a sequential multi-site
+          # submission queue, until the permitted peer fetches them.
+          download_complete_timeout = 86400
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
           # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
@@ -44,8 +48,18 @@
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
           learn_task_ack_timeout = 86400
+          # Retry a missing/TIMEOUT learn-task acknowledgment every hour, while
+          # retaining ACKs from other sites and respecting learn_task_timeout.
+          learn_task_scatter_attempt_timeout = 3600
+          learn_task_scatter_retry_interval = 5
           # time for final result acknowledgment (24 h - ride out transient VPN stalls)
           final_result_ack_timeout = 86400
+
+          # Permission is a small idempotent control request. Allow relayed replies
+          # time to arrive and retry a missing reply without reserving another slot.
+          request_to_submit_result_msg_timeout = 60
+          request_to_submit_result_interval = 5
+          max_concurrent_submissions = 1
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/_shared/custom/fault_tolerant_ccwf.py
+++ b/application/jobs/_shared/custom/fault_tolerant_ccwf.py
@@ -14,26 +14,26 @@ configs) that let a run survive one (or a few) such failures:
   instead of ``system_panic``. (Silent/dropped clients and the configure /
   end-workflow counts are already tolerated by stock NVFlare when ``min_clients>0``.)
 * ``FaultTolerantSwarmClientController`` + ``FaultTolerantGatherer`` -- the
-  rotating aggregator tolerates a peer that submits a bad result: it is logged,
-  not counted toward ``min_responses_required``, and acknowledged so the failure
-  does not cascade. The gather completes once ``min_responses_required`` *good*
-  results arrive (or ``learn_task_timeout`` fires).
+  rotating aggregator can tolerate a peer that submits a bad result when the
+  configured minimum is lower than the trainer count. When every response is
+  required, bad/rejected results and gather timeout instead fail the round and
+  partial aggregation is prohibited.
 
-REQUIRES (set in the job configs): ``min_clients`` (server) and
-``min_responses_required`` (client) BOTH < the number of participating clients,
-so there is headroom to drop a failing node. ``min_clients = 0`` (stock default)
-means "all required" and disables tolerance.
+Tolerance requires ``min_clients`` (server) and ``min_responses_required``
+(client) to be lower than the number of participating clients. Setting both to
+the full named client count selects strict all-site behavior instead.
 
-NOTE: this changes wait-for-all semantics from #345 into "wait for at least
-min_responses". It touches NVFlare-internal control flow and MUST be validated
-with an induced single-node drop on a real multi-node run before production use.
-A fully *re-synced* rejoin of a desynced node (vs. pruning it) is a follow-up;
-here a desynced node is pruned and the run continues with the rest.
+In tolerant mode this changes wait-for-all semantics from #345 into "wait for
+at least min_responses". In strict mode the controller retains every named
+client and retries only unacknowledged learn-task deliveries; duplicate delivery
+of an already accepted round is idempotent.
 """
 
+import threading
 import time
 from datetime import datetime
 
+from nvflare.apis.fl_constant import ReservedKey, ReservedTopic
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import ReturnCode, make_reply
 from nvflare.app_common.app_constant import AppConstants
@@ -51,11 +51,206 @@ def is_non_tolerable_client_error(error) -> bool:
     return bool(error and WARM_START_REQUIRED_MISSING in str(error))
 
 
+class _PermissionReplyRetryEngine:
+    """Turn a missing submission-permission reply into a retryable response.
+
+    ``SwarmClientController.do_learn_task`` already retries
+    ``SERVICE_UNAVAILABLE`` replies, but treats a missing reply as a fatal client
+    error. A control-message reply can arrive after the short request timeout on
+    a relayed connection. Retrying is safe because ``Gatherer`` remembers a
+    granted slot: another request from the same client returns ``OK`` without
+    reserving a second slot.
+
+    The adapter is installed on a cloned ``FLContext`` for one learning task, so
+    it does not monkey-patch the shared engine. All non-permission engine calls
+    and all explicit replies (including ``MODEL_UNRECOGNIZED``) are unchanged.
+    """
+
+    def __init__(self, engine, controller):
+        self._engine = engine
+        self._controller = controller
+        self._missing_reply_count = 0
+
+    def __getattr__(self, name):
+        return getattr(self._engine, name)
+
+    def send_aux_request(self, *args, **kwargs):
+        responses = self._engine.send_aux_request(*args, **kwargs)
+
+        if kwargs.get("topic") != self._controller.request_to_submit_learn_result_task_name:
+            return responses
+        if not isinstance(responses, dict):
+            # Preserve the stock failure path for malformed engine responses.
+            return responses
+
+        targets = kwargs.get("targets")
+        if not isinstance(targets, (list, tuple)) or len(targets) != 1:
+            return responses
+
+        target = targets[0]
+        # Shareable is dict-like and an explicit header-only reply can be
+        # falsey. Presence, not truthiness, distinguishes it from a miss.
+        if target in responses and responses[target] is not None:
+            return responses
+
+        self._missing_reply_count += 1
+        # Log the first miss and then periodically; a long relay outage should
+        # remain visible without producing a warning every retry interval.
+        if self._missing_reply_count == 1 or self._missing_reply_count % 10 == 0:
+            self._controller.log_warning(
+                kwargs.get("fl_ctx"),
+                f"missing submission-permission reply from {target}; treating it as transient and retrying "
+                f"(miss {self._missing_reply_count})",
+            )
+
+        retryable = dict(responses)
+        retryable[target] = make_reply(ReturnCode.SERVICE_UNAVAILABLE)
+        return retryable
+
+
+class _LearnScatterRetryEngine:
+    """Retry a learn-task scatter without resending to acknowledged clients.
+
+    ``TaskController.broadcast_and_wait`` converts every explicit non-OK reply
+    into a generic ``ERROR``. This context-local adapter runs immediately below
+    that controller, where the raw responses are still available. Only a
+    missing response, ``None``, or an explicit ``TIMEOUT`` is retryable. Every
+    other explicit response is retained as terminal, and a client that replied
+    ``OK`` is never sent the same task again.
+    """
+
+    def __init__(self, engine, controller, deadline: float, attempt_timeout: float, retry_interval: float):
+        self._engine = engine
+        self._controller = controller
+        self._deadline = deadline
+        self._attempt_timeout = attempt_timeout
+        self._retry_interval = retry_interval
+        self._active = True
+
+    def __getattr__(self, name):
+        return getattr(self._engine, name)
+
+    def deactivate(self):
+        # The cloned FLContext can be retained by the locally queued learn task.
+        # Once scatter returns, make this adapter a transparent pass-through so
+        # a later round cannot inherit the old round's deadline.
+        self._active = False
+
+    @staticmethod
+    def _return_code(reply):
+        if reply is None:
+            return None
+        getter = getattr(reply, "get_return_code", None)
+        if callable(getter):
+            return getter(ReturnCode.OK)
+        if isinstance(reply, dict):
+            # This fallback also keeps the adapter straightforward to unit test.
+            return reply.get("return_code", reply.get(ReservedKey.RC, ReturnCode.OK))
+        return ReturnCode.OK
+
+    def _is_learn_scatter(self, kwargs) -> bool:
+        if not self._active or kwargs.get("topic") != ReservedTopic.DO_TASK:
+            return False
+        request = kwargs.get("request")
+        get_header = getattr(request, "get_header", None)
+        return callable(get_header) and get_header(ReservedKey.TASK_NAME) == self._controller.do_learn_task_name
+
+    def _is_aborted(self, fl_ctx) -> bool:
+        if getattr(self._controller, "asked_to_stop", False):
+            return True
+        get_abort_signal = getattr(fl_ctx, "get_run_abort_signal", None)
+        if not callable(get_abort_signal):
+            return False
+        abort_signal = get_abort_signal()
+        return bool(abort_signal and getattr(abort_signal, "triggered", False))
+
+    def _wait_before_retry(self, fl_ctx):
+        wait_until = min(self._deadline, time.time() + self._retry_interval)
+        while not self._is_aborted(fl_ctx):
+            remaining = wait_until - time.time()
+            if remaining <= 0:
+                return
+            time.sleep(min(0.2, remaining))
+
+    def send_aux_request(self, *args, **kwargs):
+        # TaskController uses keyword arguments for DO_TASK. Preserve unfamiliar
+        # call shapes exactly rather than guessing argument positions.
+        if not self._is_learn_scatter(kwargs):
+            return self._engine.send_aux_request(*args, **kwargs)
+
+        targets = kwargs.get("targets")
+        if not isinstance(targets, (list, tuple)) or not targets:
+            return self._engine.send_aux_request(*args, **kwargs)
+
+        pending = list(targets)
+        terminal_responses = {}
+        last_timeout_responses = {}
+        attempt = 0
+        fl_ctx = kwargs.get("fl_ctx")
+        request = kwargs.get("request")
+        current_round = request.get_header(AppConstants.CURRENT_ROUND)
+
+        while pending and not self._is_aborted(fl_ctx):
+            remaining = self._deadline - time.time()
+            if remaining <= 0:
+                break
+
+            attempt += 1
+            attempt_kwargs = dict(kwargs)
+            attempt_kwargs["targets"] = list(pending)
+            attempt_kwargs["timeout"] = min(self._attempt_timeout, remaining)
+            responses = self._engine.send_aux_request(*args, **attempt_kwargs)
+            if not isinstance(responses, dict):
+                # Let the stock controller handle a malformed engine response.
+                return responses
+
+            retry_targets = []
+            for target in pending:
+                if target not in responses or responses[target] is None:
+                    retry_targets.append(target)
+                    continue
+
+                reply = responses[target]
+                rc = self._return_code(reply)
+                if rc == ReturnCode.TIMEOUT:
+                    last_timeout_responses[target] = reply
+                    retry_targets.append(target)
+                else:
+                    # OK and every explicit non-timeout error are terminal.
+                    terminal_responses[target] = reply
+
+            pending = retry_targets
+            if not pending:
+                break
+
+            self._controller.log_warning(
+                fl_ctx,
+                f"learn-task scatter for round {current_round} attempt {attempt} did not acknowledge "
+                f"{pending}; retrying only those clients",
+            )
+            if time.time() >= self._deadline:
+                break
+            self._wait_before_retry(fl_ctx)
+
+        # Missing/None responses remain absent so the stock caller takes its
+        # existing missing-reply failure path. Preserve a raw TIMEOUT when one
+        # was received, and preserve every success/terminal error verbatim.
+        final_responses = dict(terminal_responses)
+        for target in pending:
+            timeout_reply = last_timeout_responses.get(target)
+            if timeout_reply is not None:
+                final_responses[target] = timeout_reply
+        return final_responses
+
+
 class FaultTolerantGatherer(Gatherer):
     """Gatherer that tolerates a peer submitting a bad result instead of failing
     the whole gather. Faithful copy of ``Gatherer._do_gather`` with the return-code
     check moved above the response counting so a bad result is neither counted nor
     fatal."""
+
+    def _all_responses_required(self) -> bool:
+        return self.min_responses_required >= len(self.trainer_statuses)
 
     def _do_gather(self, client_name: str, result, fl_ctx: FLContext):
         result_round = result.get_header(AppConstants.CURRENT_ROUND)
@@ -90,6 +285,14 @@ class FaultTolerantGatherer(Gatherer):
         # a bad result never sets reply_time.
         rc = result.get_return_code(ReturnCode.OK)
         if rc != ReturnCode.OK:
+            if self._all_responses_required():
+                self.log_error(
+                    fl_ctx,
+                    f"Strict gather: bad result from required client {client_name} for round {result_round}: {rc}",
+                )
+                self.executor.update_status(action="gather", error=rc)
+                return make_reply(rc)
+
             self.log_warning(
                 fl_ctx,
                 f"FaultTolerant: tolerating bad result from {client_name} for round {result_round}: "
@@ -97,7 +300,15 @@ class FaultTolerantGatherer(Gatherer):
             )
             return make_reply(ReturnCode.OK)
 
-        if result_round == self.for_round:
+        strict = self._all_responses_required()
+
+        # Stock Gatherer counts a response before aggregator.accept() returns.
+        # Keep that behavior in tolerant mode, where the minimum-response wait
+        # is intentionally based on arrivals. In strict mode, marking the final
+        # response here lets the monitor begin aggregation while the final
+        # accept is still in progress. Count strict responses only after the
+        # aggregator has accepted them below.
+        if result_round == self.for_round and not strict:
             now = time.time()
             ts.reply_time = now
             if not self.min_resps_received_time:
@@ -120,26 +331,182 @@ class FaultTolerantGatherer(Gatherer):
 
         fl_ctx.set_prop(AppConstants.AGGREGATION_ACCEPTED, accepted, private=True, sticky=False)
         self.fire_event(AppEventType.AFTER_CONTRIBUTION_ACCEPT, fl_ctx)
+
+        if strict and result_round == self.for_round and not accepted:
+            # Preserve the stock BEFORE/AFTER event pair, but do not count a
+            # rejected contribution as a valid strict response. Fail the run
+            # instead of aggregating fewer than all required clients.
+            self.executor.update_status(action="gather", error=ReturnCode.EXECUTION_EXCEPTION)
+            return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+
+        if strict and result_round == self.for_round:
+            # reply_time is the commit marker proving this contribution is
+            # already present in the aggregator and all accept hooks completed.
+            # is_done() may run concurrently, so this must be the final state
+            # change before returning success.
+            now = time.time()
+            ts.reply_time = now
+            if not self.min_resps_received_time:
+                num_resps_received = sum(1 for status in self.trainer_statuses.values() if status.reply_time)
+                if num_resps_received >= self.min_responses_required:
+                    self.min_resps_received_time = now
         return make_reply(ReturnCode.OK)
+
+    def is_done(self):
+        if not self._all_responses_required():
+            return super().is_done()
+
+        missing = [name for name, status in self.trainer_statuses.items() if not status.reply_time]
+        if not missing:
+            return True
+
+        if self.timeout and time.time() - self.start_time > self.timeout:
+            # Never let _monitor_gather call aggregate() with a partial strict
+            # round. Report the timeout once, then wait for the job abort path.
+            if not getattr(self, "_strict_timeout_reported", False):
+                self._strict_timeout_reported = True
+                self.log_error(
+                    self.fl_ctx,
+                    f"strict gather for round {self.for_round} timed out waiting for required clients {missing}",
+                )
+                self.executor.update_status(action="gather_timeout", error=ReturnCode.TIMEOUT)
+            return False
+
+        return False
 
 
 class FaultTolerantSwarmClientController(SwarmClientController):
     """SwarmClientController that uses FaultTolerantGatherer for aggregation."""
 
-    def __init__(self, *args, broadcast_last_result: bool = True, **kwargs):
+    def __init__(
+        self,
+        *args,
+        broadcast_last_result: bool = True,
+        learn_task_scatter_attempt_timeout=None,
+        learn_task_scatter_retry_interval: float = 5.0,
+        **kwargs,
+    ):
+        if learn_task_scatter_attempt_timeout is not None and learn_task_scatter_attempt_timeout <= 0:
+            raise ValueError("learn_task_scatter_attempt_timeout must be positive")
+        if learn_task_scatter_retry_interval <= 0:
+            raise ValueError("learn_task_scatter_retry_interval must be positive")
+
         super().__init__(*args, **kwargs)
         self.broadcast_last_result = broadcast_last_result
+        # Defaulting the per-attempt timeout to the stock ACK timeout preserves
+        # existing jobs. A shorter explicit value permits retries while the
+        # overall scatter remains bounded by learn_task_timeout.
+        self.learn_task_scatter_attempt_timeout = (
+            learn_task_scatter_attempt_timeout
+            if learn_task_scatter_attempt_timeout is not None
+            else self.learn_task_ack_timeout
+        )
+        self.learn_task_scatter_retry_interval = learn_task_scatter_retry_interval
+        self._learn_request_dedupe_lock = threading.Lock()
+        self._last_accepted_learn_round = None
 
     def start_run(self, fl_ctx: FLContext):
         # do_learn_task() instantiates the module-global ``Gatherer``; patch that
         # symbol so the aggregator role uses the fault-tolerant gatherer. (Done
-        # here rather than copying the large do_learn_task method.)
+        # here rather than copying the large do_learn_task method.) NVFlare runs
+        # one workflow controller in each job child process; a future job that
+        # deliberately mixes multiple swarm controller classes in one process
+        # must replace this with an upstream gatherer factory/instance override.
         import nvflare.app_common.ccwf.swarm_client_ctl as _scc
 
         if _scc.Gatherer is not FaultTolerantGatherer:
             _scc.Gatherer = FaultTolerantGatherer
-            self.log_info(fl_ctx, "FaultTolerant: installed FaultTolerantGatherer (tolerates a failed peer in the gather)")
+            self.log_info(fl_ctx, "installed strict/tolerant FaultTolerantGatherer policy")
         super().start_run(fl_ctx)
+
+    def _scatter(self, task_data, for_round: int, fl_ctx: FLContext) -> bool:
+        """Run the stock scatter with raw-response retry below TaskController."""
+        engine = fl_ctx.get_engine()
+        if not engine:
+            return super()._scatter(task_data, for_round, fl_ctx)
+
+        total_timeout = self.learn_task_timeout or self.learn_task_ack_timeout
+        retry_engine = _LearnScatterRetryEngine(
+            engine=engine,
+            controller=self,
+            deadline=time.time() + total_timeout,
+            attempt_timeout=self.learn_task_scatter_attempt_timeout,
+            retry_interval=self.learn_task_scatter_retry_interval,
+        )
+        retry_fl_ctx = fl_ctx.clone()
+        retry_fl_ctx.put(
+            key=ReservedKey.ENGINE,
+            value=retry_engine,
+            private=True,
+            sticky=False,
+        )
+        try:
+            return super()._scatter(task_data, for_round, retry_fl_ctx)
+        finally:
+            retry_engine.deactivate()
+
+    def _try_process_learn_request(self, request, fl_ctx: FLContext):
+        """Accept a round once and acknowledge a duplicate delivery safely."""
+        current_round = request.get_header(AppConstants.CURRENT_ROUND)
+        if current_round is None:
+            return super()._try_process_learn_request(request, fl_ctx)
+
+        peer_ctx = fl_ctx.get_peer_context()
+        assert isinstance(peer_ctx, FLContext)
+        sender = peer_ctx.get_identity_name()
+
+        with self._learn_request_dedupe_lock:
+            last_round = self._last_accepted_learn_round
+            if last_round is not None:
+                if current_round == last_round:
+                    self.log_info(
+                        fl_ctx,
+                        f"duplicate Learn request from {sender} for round {current_round}; already accepted",
+                    )
+                    return make_reply(ReturnCode.OK)
+                if current_round < last_round:
+                    self.log_error(
+                        fl_ctx,
+                        f"stale Learn request from {sender} for round {current_round}; "
+                        f"last accepted round is {last_round}",
+                    )
+                    return make_reply(ReturnCode.MODEL_UNRECOGNIZED)
+
+            self.log_info(fl_ctx, f"Got Learn request from {sender}")
+            if self.learn_task and not self.allow_busy_task:
+                self.log_error(fl_ctx, f"got Learn request from {sender} while I'm still busy!")
+                self.update_status(action="process_learn_request", error=ReturnCode.EXECUTION_EXCEPTION)
+                return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+
+            self.log_info(fl_ctx, f"accepted learn request from {sender}")
+            if not self.set_learn_task(task_data=request, fl_ctx=fl_ctx):
+                self.log_error(fl_ctx, f"failed to queue Learn request from {sender} for round {current_round}")
+                self.update_status(action="process_learn_request", error=ReturnCode.EXECUTION_EXCEPTION)
+                return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+
+            self._last_accepted_learn_round = current_round
+            return make_reply(ReturnCode.OK)
+
+    def do_learn_task(self, name, task_data, fl_ctx: FLContext, abort_signal):
+        """Run the stock learning task with retryable missing permission replies.
+
+        The stock controller owns the permission loop. Supplying a context-local
+        engine adapter keeps that implementation (including abort, max-wait, and
+        explicit return-code handling) intact while changing only the missing-
+        reply branch into its existing ``SERVICE_UNAVAILABLE`` retry branch.
+        """
+        engine = fl_ctx.get_engine()
+        if not engine:
+            return super().do_learn_task(name, task_data, fl_ctx, abort_signal)
+
+        retry_fl_ctx = fl_ctx.clone()
+        retry_fl_ctx.put(
+            key=ReservedKey.ENGINE,
+            value=_PermissionReplyRetryEngine(engine, self),
+            private=True,
+            sticky=False,
+        )
+        return super().do_learn_task(name, task_data, retry_fl_ctx, abort_signal)
 
     def _distribute_final_results(self, aggr_result, fl_ctx: FLContext):
         """Optionally skip duplicate LAST-result broadcast for validation jobs.

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_client.conf
@@ -15,8 +15,12 @@
         args {
           launcher_id = "launcher"
           pipe_id = "pipe"
-          # time to wait for final result transfer from subprocess (30 min — large models over VPN)
-          last_result_transfer_timeout = 1800
+          # Let the client job wait for the subprocess result transfer for the
+          # full long-run budget.
+          last_result_transfer_timeout = 86400
+          # Keep producer-side tensor refs alive through a sequential multi-site
+          # submission queue, until the permitted peer fetches them.
+          download_complete_timeout = 86400
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
           # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
@@ -44,8 +48,18 @@
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
           learn_task_ack_timeout = 86400
+          # Retry a missing/TIMEOUT learn-task acknowledgment every hour, while
+          # retaining ACKs from other sites and respecting learn_task_timeout.
+          learn_task_scatter_attempt_timeout = 3600
+          learn_task_scatter_retry_interval = 5
           # time for final result acknowledgment (24 h - ride out transient VPN stalls)
           final_result_ack_timeout = 86400
+
+          # Permission is a small idempotent control request. Allow relayed replies
+          # time to arrive and retry a missing reply without reserving another slot.
+          request_to_submit_result_msg_timeout = 60
+          request_to_submit_result_interval = 5
+          max_concurrent_submissions = 1
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_client.conf
@@ -15,8 +15,12 @@
         args {
           launcher_id = "launcher"
           pipe_id = "pipe"
-          # time to wait for final result transfer from subprocess (30 min — large models over VPN)
-          last_result_transfer_timeout = 1800
+          # Let the client job wait for the subprocess result transfer for the
+          # full long-run budget.
+          last_result_transfer_timeout = 86400
+          # Keep producer-side tensor refs alive through a sequential multi-site
+          # submission queue, until the permitted peer fetches them.
+          download_complete_timeout = 86400
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
           # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
@@ -44,8 +48,18 @@
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
           learn_task_ack_timeout = 86400
+          # Retry a missing/TIMEOUT learn-task acknowledgment every hour, while
+          # retaining ACKs from other sites and respecting learn_task_timeout.
+          learn_task_scatter_attempt_timeout = 3600
+          learn_task_scatter_retry_interval = 5
           # time for final result acknowledgment (24 h - ride out transient VPN stalls)
           final_result_ack_timeout = 86400
+
+          # Permission is a small idempotent control request. Allow relayed replies
+          # time to arrive and retry a missing reply without reserving another slot.
+          request_to_submit_result_msg_timeout = 60
+          request_to_submit_result_interval = 5
+          max_concurrent_submissions = 1
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_client.conf
@@ -15,8 +15,12 @@
         args {
           launcher_id = "launcher"
           pipe_id = "pipe"
-          # time to wait for final result transfer from subprocess (30 min — large models over VPN)
-          last_result_transfer_timeout = 1800
+          # Let the client job wait for the subprocess result transfer for the
+          # full long-run budget.
+          last_result_transfer_timeout = 86400
+          # Keep producer-side tensor refs alive through a sequential multi-site
+          # submission queue, until the permitted peer fetches them.
+          download_complete_timeout = 86400
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
           # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
@@ -44,8 +48,18 @@
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
           learn_task_ack_timeout = 86400
+          # Retry a missing/TIMEOUT learn-task acknowledgment every hour, while
+          # retaining ACKs from other sites and respecting learn_task_timeout.
+          learn_task_scatter_attempt_timeout = 3600
+          learn_task_scatter_retry_interval = 5
           # time for final result acknowledgment (24 h - ride out transient VPN stalls)
           final_result_ack_timeout = 86400
+
+          # Permission is a small idempotent control request. Allow relayed replies
+          # time to arrive and retry a missing reply without reserving another slot.
+          request_to_submit_result_msg_timeout = 60
+          request_to_submit_result_interval = 5
+          max_concurrent_submissions = 1
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_client.conf
@@ -15,8 +15,12 @@
         args {
           launcher_id = "launcher"
           pipe_id = "pipe"
-          # time to wait for final result transfer from subprocess (30 min — large models over VPN)
-          last_result_transfer_timeout = 1800
+          # Let the client job wait for the subprocess result transfer for the
+          # full long-run budget.
+          last_result_transfer_timeout = 86400
+          # Keep producer-side tensor refs alive through a sequential multi-site
+          # submission queue, until the permitted peer fetches them.
+          download_complete_timeout = 86400
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
           # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
@@ -44,8 +48,18 @@
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
           learn_task_ack_timeout = 86400
+          # Retry a missing/TIMEOUT learn-task acknowledgment every hour, while
+          # retaining ACKs from other sites and respecting learn_task_timeout.
+          learn_task_scatter_attempt_timeout = 3600
+          learn_task_scatter_retry_interval = 5
           # time for final result acknowledgment (24 h - ride out transient VPN stalls)
           final_result_ack_timeout = 86400
+
+          # Permission is a small idempotent control request. Allow relayed replies
+          # time to arrive and retry a missing reply without reserving another slot.
+          request_to_submit_result_msg_timeout = 60
+          request_to_submit_result_interval = 5
+          max_concurrent_submissions = 1
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_client.conf
@@ -15,8 +15,12 @@
         args {
           launcher_id = "launcher"
           pipe_id = "pipe"
-          # time to wait for final result transfer from subprocess (30 min — large models over VPN)
-          last_result_transfer_timeout = 1800
+          # Let the client job wait for the subprocess result transfer for the
+          # full long-run budget.
+          last_result_transfer_timeout = 86400
+          # Keep producer-side tensor refs alive through a sequential multi-site
+          # submission queue, until the permitted peer fetches them.
+          download_complete_timeout = 86400
           # time to wait for subprocess to call flare.init() (10 min)
           external_pre_init_timeout = 600
           # time to wait for peer to read sent message (24 h - ride out transient VPN stalls; see #346)
@@ -44,8 +48,18 @@
           learn_task_abort_timeout = 300
           # time for task acknowledgment incl. model weight streaming (24 h - ride out transient VPN stalls)
           learn_task_ack_timeout = 86400
+          # Retry a missing/TIMEOUT learn-task acknowledgment every hour, while
+          # retaining ACKs from other sites and respecting learn_task_timeout.
+          learn_task_scatter_attempt_timeout = 3600
+          learn_task_scatter_retry_interval = 5
           # time for final result acknowledgment (24 h - ride out transient VPN stalls)
           final_result_ack_timeout = 86400
+
+          # Permission is a small idempotent control request. Allow relayed replies
+          # time to arrive and retry a missing reply without reserving another slot.
+          request_to_submit_result_msg_timeout = 60
+          request_to_submit_result_interval = 5
+          max_concurrent_submissions = 1
 
           # ids must map to corresponding components
           persistor_id = "persistor"

--- a/assets/readme/README.operator.md
+++ b/assets/readme/README.operator.md
@@ -92,7 +92,11 @@ passwords somewhere, they are only displayed once (or you can download them agai
 ### Fresh vs Continue ODELIA Jobs
 
 Admin startup kits include `prepare_odelia_job.sh`, which copies an in-image job into the admin kit's mounted
-`local/mediswarm_jobs` folder and patches only that copied job.
+`local/mediswarm_jobs` folder and patches only that copied job. With no custom `--min-*` options, the helper
+defaults to the current exact eight-site ODELIA production roster (CAM, VHIO, USZ, RUMC, MHA, RSH, UMCU,
+and UKA), and synchronizes mandatory/participating clients plus every quorum value. A production run therefore
+cannot silently fall back to a 7-of-8 policy. Use `--strict-clients CLIENT_1,CLIENT_2,...` for a different exact
+roster. Supplying `--min-clients`, `--configure-min-clients`, or `--min-responses` opts into a custom test policy.
 
 Fresh start:
 ```bash
@@ -119,8 +123,8 @@ submit_job /fl_admin/local/mediswarm_jobs/ODELIA_ternary_classification_continue
 `continue` is strict: each client must have `/scratch/mediswarm_latest_global.pt` available through the same
 `--scratch_dir` used by the previous run. If any client is missing that checkpoint, the job aborts with
 `WARM_START_REQUIRED_MISSING` instead of silently starting fresh. `fresh` ignores old local checkpoints without
-deleting them. Direct `submit_job MediSwarm/application/jobs/...` remains supported and keeps automatic warm-start
-behavior.
+deleting them. Direct `submit_job MediSwarm/application/jobs/...` remains supported for generic/test workflows and
+keeps automatic warm-start behavior, but it bypasses the helper's exact-client production guard.
 
 The direct-submit "automatic warm-start" is `warm_start_mode = "auto"` (the shipped default in the challenge job
 configs): the first run of a chain finds no mirror and initializes fresh, and every later run warm-starts from

--- a/kit_admin_tools/prepare_odelia_job.sh
+++ b/kit_admin_tools/prepare_odelia_job.sh
@@ -4,15 +4,22 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  ./prepare_odelia_job.sh --job JOB_NAME --warm-start fresh|continue [--num-rounds N] [--min-clients N] [--configure-min-clients N] [--min-responses N] [--broadcast-last-result true|false] [--fold N]
+  ./prepare_odelia_job.sh --job JOB_NAME --warm-start fresh|continue [--num-rounds N] [--min-clients N] [--configure-min-clients N] [--min-responses N] [--strict-clients CLIENT_1,CLIENT_2,...] [--broadcast-last-result true|false] [--fold N]
+
+Client policy:
+  With no --min-* override, the current exact eight-site ODELIA production roster
+  is required automatically. Use --strict-clients to supply another exact roster.
+  Supplying any --min-* option opts into an explicit non-default/test policy.
 
 Examples:
   ./prepare_odelia_job.sh --job ODELIA_ternary_classification --warm-start fresh
   ./prepare_odelia_job.sh --job ODELIA_ternary_classification --warm-start continue
+  ./prepare_odelia_job.sh --job challenge_1DivideAndConquer --warm-start continue --strict-clients CAM_1,MHA_1,RSH_1,RUMC_1,UKA_1,UMCU_1,USZ_1,VHIO_1
 EOF
 }
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+DEFAULT_STRICT_CLIENTS="CAM_1,VHIO_1,USZ_1,RUMC_1,MHA_1,RSH_1,UMCU_1,UKA_1"
 JOB_NAME=""
 WARM_START=""
 FOLD=""
@@ -21,6 +28,10 @@ NUM_ROUNDS=""
 MIN_CLIENTS=""
 CONFIGURE_MIN_CLIENTS=""
 MIN_RESPONSES=""
+STRICT_CLIENTS="$DEFAULT_STRICT_CLIENTS"
+STRICT_CLIENTS_SET=true
+STRICT_CLIENTS_EXPLICIT=false
+CUSTOM_CLIENT_COUNTS_SET=false
 BROADCAST_LAST_RESULT=""
 
 while [ "$#" -gt 0 ]; do
@@ -71,6 +82,7 @@ while [ "$#" -gt 0 ]; do
         exit 2
       fi
       MIN_CLIENTS="${2:-}"
+      CUSTOM_CLIENT_COUNTS_SET=true
       shift 2
       ;;
     --configure-min-clients)
@@ -79,6 +91,7 @@ while [ "$#" -gt 0 ]; do
         exit 2
       fi
       CONFIGURE_MIN_CLIENTS="${2:-}"
+      CUSTOM_CLIENT_COUNTS_SET=true
       shift 2
       ;;
     --min-responses)
@@ -87,6 +100,17 @@ while [ "$#" -gt 0 ]; do
         exit 2
       fi
       MIN_RESPONSES="${2:-}"
+      CUSTOM_CLIENT_COUNTS_SET=true
+      shift 2
+      ;;
+    --strict-clients)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --strict-clients" >&2
+        exit 2
+      fi
+      STRICT_CLIENTS="${2:-}"
+      STRICT_CLIENTS_SET=true
+      STRICT_CLIENTS_EXPLICIT=true
       shift 2
       ;;
     --broadcast-last-result)
@@ -108,6 +132,13 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+# Bare production preparation is strict by default. Existing validation tools
+# that deliberately provide custom quorum values keep their explicit policy.
+if [ "$STRICT_CLIENTS_EXPLICIT" != true ] && [ "$CUSTOM_CLIENT_COUNTS_SET" = true ]; then
+  STRICT_CLIENTS=""
+  STRICT_CLIENTS_SET=false
+fi
 
 if [ -z "$JOB_NAME" ] || [ -z "$WARM_START" ]; then
   usage >&2
@@ -145,6 +176,18 @@ if [ ! -f "$DOCKER_SH" ]; then
   exit 1
 fi
 
+# Keep the helper and patcher version together. Provisioned admin kits place
+# the patcher next to this script; a repository checkout uses the source copy.
+PATCHER_HOST="$DIR/patch_warm_start_job.py"
+if [ ! -f "$PATCHER_HOST" ]; then
+  PATCHER_HOST="$DIR/../scripts/admin/patch_warm_start_job.py"
+fi
+if [ ! -f "$PATCHER_HOST" ]; then
+  echo "Missing job patcher next to the helper or in scripts/admin: $PATCHER_HOST" >&2
+  exit 1
+fi
+PATCHER_HOST="$(cd "$(dirname "$PATCHER_HOST")" && pwd -P)/$(basename "$PATCHER_HOST")"
+
 DOCKER_IMAGE="$(awk -F= '/^[[:space:]]*DOCKER_IMAGE=/{print $2; exit}' "$DOCKER_SH" | tr -d '[:space:]' | tr -d '"')"
 if [ -z "$DOCKER_IMAGE" ]; then
   echo "Could not read DOCKER_IMAGE from $DOCKER_SH" >&2
@@ -164,8 +207,14 @@ if [ -n "$FOLD" ]; then
   DEST_NAME="${DEST_NAME}_fold${FOLD}"
 fi
 DEST_HOST="$OUTPUT_ROOT/$DEST_NAME"
+TEMP_NAME=".${DEST_NAME}.prepare.$$"
+TEMP_HOST="$OUTPUT_ROOT/$TEMP_NAME"
+if [ -e "$TEMP_HOST" ]; then
+  echo "Refusing to overwrite unexpected staging path: $TEMP_HOST" >&2
+  exit 1
+fi
 JOB_SRC="/MediSwarm/application/jobs/$JOB_NAME"
-PATCH_ARGS=(--job-dir "/job_out/$DEST_NAME" --mode "$CONFIG_MODE")
+PATCH_ARGS=(--job-dir "/job_out/$TEMP_NAME" --mode "$CONFIG_MODE")
 if [ -n "$FOLD" ]; then
   PATCH_ARGS+=(--fold "$FOLD")
 fi
@@ -181,19 +230,51 @@ fi
 if [ -n "$MIN_RESPONSES" ]; then
   PATCH_ARGS+=(--min-responses "$MIN_RESPONSES")
 fi
+if [ "$STRICT_CLIENTS_SET" = true ]; then
+  PATCH_ARGS+=(--strict-clients "$STRICT_CLIENTS")
+fi
 if [ -n "$BROADCAST_LAST_RESULT" ]; then
   PATCH_ARGS+=(--broadcast-last-result "$BROADCAST_LAST_RESULT")
 fi
 
 printf -v PATCH_ARGS_QUOTED ' %q' "${PATCH_ARGS[@]}"
 
-rm -rf "$DEST_HOST"
+cleanup_staging() {
+  if [ -e "$TEMP_HOST" ]; then
+    rm -rf -- "$TEMP_HOST"
+  fi
+}
+trap cleanup_staging EXIT
 
 docker run --rm \
   -u "$(id -u):$(id -g)" \
   -v "$OUTPUT_ROOT":/job_out \
+  -v "$PATCHER_HOST":/mediswarm_tools/patch_warm_start_job.py:ro \
   "$DOCKER_IMAGE" \
-  bash -lc "set -euo pipefail; test -d '$JOB_SRC'; cp -R '$JOB_SRC' '/job_out/$DEST_NAME'; python3 /MediSwarm/scripts/admin/patch_warm_start_job.py$PATCH_ARGS_QUOTED"
+  bash -lc "set -euo pipefail; test -d '$JOB_SRC'; cp -R '$JOB_SRC' '/job_out/$TEMP_NAME'; python3 /mediswarm_tools/patch_warm_start_job.py$PATCH_ARGS_QUOTED"
+
+# Preserve any previously prepared job until the new copy has passed every
+# patch/validation step. If the final rename fails, restore the old copy.
+BACKUP_HOST=""
+if [ -e "$DEST_HOST" ]; then
+  BACKUP_HOST="${DEST_HOST}.previous.$$"
+  if [ -e "$BACKUP_HOST" ]; then
+    echo "Refusing to overwrite unexpected backup path: $BACKUP_HOST" >&2
+    exit 1
+  fi
+  mv -- "$DEST_HOST" "$BACKUP_HOST"
+fi
+if mv -- "$TEMP_HOST" "$DEST_HOST"; then
+  trap - EXIT
+  if [ -n "$BACKUP_HOST" ]; then
+    rm -rf -- "$BACKUP_HOST"
+  fi
+else
+  if [ -n "$BACKUP_HOST" ] && [ -e "$BACKUP_HOST" ]; then
+    mv -- "$BACKUP_HOST" "$DEST_HOST"
+  fi
+  exit 1
+fi
 
 echo
 echo "Prepared job: $DEST_HOST"
@@ -209,6 +290,13 @@ if [ -n "$CONFIGURE_MIN_CLIENTS" ]; then
 fi
 if [ -n "$MIN_RESPONSES" ]; then
   echo "Client config min_responses_required: $MIN_RESPONSES"
+fi
+if [ "$STRICT_CLIENTS_SET" = true ]; then
+  if [ "$STRICT_CLIENTS_EXPLICIT" = true ]; then
+    echo "Strict required clients: $STRICT_CLIENTS"
+  else
+    echo "Strict required clients (default ODELIA production profile): $STRICT_CLIENTS"
+  fi
 fi
 if [ -n "$BROADCAST_LAST_RESULT" ]; then
   echo "Client config broadcast_last_result: $BROADCAST_LAST_RESULT"

--- a/scripts/admin/patch_warm_start_job.py
+++ b/scripts/admin/patch_warm_start_job.py
@@ -2,11 +2,13 @@
 """Patch an NVFlare job copy for admin-controlled warm-start tests."""
 
 import argparse
+import json
 import re
 from pathlib import Path
 
 CONFIG_RELATIVE_PATH = Path("app/config/config_fed_client.conf")
 SERVER_CONFIG_RELATIVE_PATH = Path("app/config/config_fed_server.conf")
+META_CONFIG_RELATIVE_PATH = Path("meta.conf")
 PERSISTOR_PATH = 'path = "warm_continue.WarmStartablePTFileModelPersistor"'
 
 # The SubprocessLauncher strips leading KEY=VALUE tokens off `script` into the
@@ -54,6 +56,54 @@ def _positive_int_or_none(value, name: str):
     if value <= 0:
         raise ValueError(f"{name} must be a positive integer")
     return value
+
+
+def parse_strict_clients(value):
+    """Parse an exact, ordered CSV client set and reject ambiguous input."""
+    if value is None:
+        return None
+
+    raw_clients = value.split(",") if isinstance(value, str) else list(value)
+    clients = [str(client).strip() for client in raw_clients]
+    if not clients or any(not client for client in clients):
+        raise ValueError("strict_clients must be a comma-separated list of non-empty client names")
+
+    seen = set()
+    duplicates = []
+    for client in clients:
+        if client in seen and client not in duplicates:
+            duplicates.append(client)
+        seen.add(client)
+    if duplicates:
+        raise ValueError(f"strict_clients contains duplicate client name(s): {', '.join(duplicates)}")
+    return tuple(clients)
+
+
+def _resolve_strict_counts(
+    strict_clients,
+    min_clients=None,
+    configure_min_clients=None,
+    min_responses_required=None,
+):
+    clients = parse_strict_clients(strict_clients)
+    if clients is None:
+        return clients, min_clients, configure_min_clients, min_responses_required
+
+    client_count = len(clients)
+    explicit_counts = {
+        "min_clients": min_clients,
+        "configure_min_clients": configure_min_clients,
+        "min_responses_required": min_responses_required,
+    }
+    for name, value in explicit_counts.items():
+        value = _positive_int_or_none(value, name)
+        if value is not None and value != client_count:
+            raise ValueError(
+                f"{name}={value} conflicts with strict_clients count {client_count}; "
+                "strict mode requires the exact same count everywhere"
+            )
+
+    return clients, client_count, client_count, client_count
 
 
 def patch_launcher_env(config_text: str, key: str, value) -> str:
@@ -127,6 +177,37 @@ def upsert_numeric_assignment(config_text: str, key: str, value: int, after_key:
     line_end = match.group(0)
     eol = "\r\n" if line_end.endswith("\r\n") else "\n"
     insert = f"{match.group(1)}{key} = {value}{eol}"
+    return config_text[: match.end()] + insert + config_text[match.end() :]
+
+
+def upsert_string_list_assignment(config_text: str, key: str, values, after_key: str) -> str:
+    """Replace a HOCON string list, or insert it immediately after ``after_key``."""
+    values = parse_strict_clients(values)
+    if values is None:
+        raise ValueError(f"{key} requires at least one client")
+    rendered = "[" + ", ".join(json.dumps(value) for value in values) + "]"
+    pattern = re.compile(
+        rf"^(\s*{re.escape(key)}\s*=\s*)\[[^\]]*\]([^\S\r\n]*(?:#.*)?(?:\r?\n|$))",
+        re.MULTILINE,
+    )
+
+    def replace(match):
+        return f"{match.group(1)}{rendered}{match.group(2)}"
+
+    patched, count = pattern.subn(replace, config_text, count=1)
+    if count == 1:
+        return patched
+
+    after_pattern = re.compile(
+        rf"^(\s*){re.escape(after_key)}\s*=\s*[^\r\n]*(?:\r?\n|$)",
+        re.MULTILINE,
+    )
+    match = after_pattern.search(config_text)
+    if not match:
+        raise ValueError(f"Config does not contain assignment for {after_key}")
+
+    eol = "\r\n" if match.group(0).endswith("\r\n") else "\n"
+    insert = f"{match.group(1)}{key} = {rendered}{eol}"
     return config_text[: match.end()] + insert + config_text[match.end() :]
 
 
@@ -231,7 +312,13 @@ def patch_config_text(
     return patched
 
 
-def patch_server_config_text(config_text: str, num_rounds=None, min_clients=None, configure_min_clients=None) -> str:
+def patch_server_config_text(
+    config_text: str,
+    num_rounds=None,
+    min_clients=None,
+    configure_min_clients=None,
+    participating_clients=None,
+) -> str:
     patched = config_text
     num_rounds = _positive_int_or_none(num_rounds, "num_rounds")
     min_clients = _positive_int_or_none(min_clients, "min_clients")
@@ -247,7 +334,27 @@ def patch_server_config_text(config_text: str, num_rounds=None, min_clients=None
             configure_min_clients,
             after_key="min_clients",
         )
+    if participating_clients is not None:
+        patched = upsert_string_list_assignment(
+            patched,
+            "participating_clients",
+            participating_clients,
+            after_key="configure_min_clients",
+        )
     return patched
+
+
+def patch_meta_config_text(config_text: str, strict_clients) -> str:
+    clients = parse_strict_clients(strict_clients)
+    if clients is None:
+        return config_text
+    patched = patch_numeric_assignment(config_text, "min_clients", len(clients))
+    return upsert_string_list_assignment(
+        patched,
+        "mandatory_clients",
+        clients,
+        after_key="min_clients",
+    )
 
 
 def patch_job_dir(
@@ -259,35 +366,58 @@ def patch_job_dir(
     min_responses_required=None,
     broadcast_last_result=None,
     fold=None,
+    strict_clients=None,
 ) -> Path:
+    strict_clients, min_clients, configure_min_clients, min_responses_required = _resolve_strict_counts(
+        strict_clients,
+        min_clients=min_clients,
+        configure_min_clients=configure_min_clients,
+        min_responses_required=min_responses_required,
+    )
+
     config_path = job_dir / CONFIG_RELATIVE_PATH
     if not config_path.is_file():
         raise FileNotFoundError(f"Missing job config: {config_path}")
 
     config_text = config_path.read_text()
-    config_path.write_text(
-        patch_config_text(
-            config_text,
-            mode,
-            min_responses_required=min_responses_required,
-            broadcast_last_result=broadcast_last_result,
-            fold=fold,
-        )
+    patched_config_text = patch_config_text(
+        config_text,
+        mode,
+        min_responses_required=min_responses_required,
+        broadcast_last_result=broadcast_last_result,
+        fold=fold,
     )
 
-    if num_rounds is not None or min_clients is not None or configure_min_clients is not None:
+    server_config_path = None
+    patched_server_config_text = None
+    if num_rounds is not None or min_clients is not None or configure_min_clients is not None or strict_clients is not None:
         server_config_path = job_dir / SERVER_CONFIG_RELATIVE_PATH
         if not server_config_path.is_file():
             raise FileNotFoundError(f"Missing job server config: {server_config_path}")
         server_config_text = server_config_path.read_text()
-        server_config_path.write_text(
-            patch_server_config_text(
-                server_config_text,
-                num_rounds=num_rounds,
-                min_clients=min_clients,
-                configure_min_clients=configure_min_clients,
-            )
+        patched_server_config_text = patch_server_config_text(
+            server_config_text,
+            num_rounds=num_rounds,
+            min_clients=min_clients,
+            configure_min_clients=configure_min_clients,
+            participating_clients=strict_clients,
         )
+
+    meta_config_path = None
+    patched_meta_config_text = None
+    if strict_clients is not None:
+        meta_config_path = job_dir / META_CONFIG_RELATIVE_PATH
+        if not meta_config_path.is_file():
+            raise FileNotFoundError(f"Missing job metadata config: {meta_config_path}")
+        patched_meta_config_text = patch_meta_config_text(meta_config_path.read_text(), strict_clients)
+
+    # Compute every requested edit before writing any file, so invalid strict
+    # profiles cannot leave a partially configured job directory behind.
+    config_path.write_text(patched_config_text)
+    if server_config_path is not None:
+        server_config_path.write_text(patched_server_config_text)
+    if meta_config_path is not None:
+        meta_config_path.write_text(patched_meta_config_text)
 
     return config_path
 
@@ -313,6 +443,15 @@ def main() -> int:
         help="Patch app/config/config_fed_client.conf min_responses_required",
     )
     parser.add_argument(
+        "--strict-clients",
+        type=parse_strict_clients,
+        metavar="CLIENT_1,CLIENT_2,...",
+        help=(
+            "Require exactly this CSV client set. Consistently patches meta mandatory_clients/min_clients, "
+            "server participating_clients/min_clients/configure_min_clients, and client min_responses_required"
+        ),
+    )
+    parser.add_argument(
         "--broadcast-last-result",
         choices=("true", "false"),
         help="Patch app/config/config_fed_client.conf broadcast_last_result",
@@ -335,6 +474,7 @@ def main() -> int:
         min_responses_required=args.min_responses,
         broadcast_last_result=args.broadcast_last_result,
         fold=args.fold,
+        strict_clients=args.strict_clients,
     )
     print(f'Patched {config_path}: warm_start_mode = "{internal_mode}"')
     if args.num_rounds is not None:
@@ -348,6 +488,9 @@ def main() -> int:
         )
     if args.min_responses is not None:
         print(f"Patched {config_path}: min_responses_required = {args.min_responses}")
+    if args.strict_clients is not None:
+        client_list = ", ".join(args.strict_clients)
+        print(f"Patched strict client set ({len(args.strict_clients)}): {client_list}")
     if args.broadcast_last_result is not None:
         print(f"Patched {config_path}: broadcast_last_result = {args.broadcast_last_result}")
     if args.fold is not None:

--- a/scripts/build/_injectLiveSyncIntoStartupKits.sh
+++ b/scripts/build/_injectLiveSyncIntoStartupKits.sh
@@ -37,6 +37,7 @@ HELPER_SOURCE_DIR="kit_live_sync"
 SYNC_CONF_SOURCE="$HELPER_SOURCE_DIR/sync.conf"
 SYNC_CONF_EXAMPLE_SOURCE="$HELPER_SOURCE_DIR/sync.conf.example"
 ADMIN_HELPER_SOURCE="kit_admin_tools/prepare_odelia_job.sh"
+ADMIN_PATCHER_SOURCE="scripts/admin/patch_warm_start_job.py"
 
 if [ ! -d "$HELPER_SOURCE_DIR" ]; then
   echo "Missing helper directory: $HELPER_SOURCE_DIR"
@@ -50,6 +51,11 @@ fi
 
 if [ ! -f "$ADMIN_HELPER_SOURCE" ]; then
   echo "Missing admin helper: $ADMIN_HELPER_SOURCE"
+  exit 1
+fi
+
+if [ ! -f "$ADMIN_PATCHER_SOURCE" ]; then
+  echo "Missing admin job patcher: $ADMIN_PATCHER_SOURCE"
   exit 1
 fi
 
@@ -111,8 +117,9 @@ IMAGECONF
 
   if [ -f "$STARTUP_DIR/fl_admin.sh" ]; then
     cp "$ADMIN_HELPER_SOURCE" "$STARTUP_DIR/prepare_odelia_job.sh"
+    cp "$ADMIN_PATCHER_SOURCE" "$STARTUP_DIR/patch_warm_start_job.py"
     chmod +x "$STARTUP_DIR/prepare_odelia_job.sh"
-    echo "Injected admin warm-start job helper into $STARTUP_DIR"
+    echo "Injected admin warm-start job helper and matching patcher into $STARTUP_DIR"
   fi
 
   # Clean up legacy docker_original.sh wrapper if present from a previous build

--- a/tests/unit_tests/test_admin_warm_start_job.py
+++ b/tests/unit_tests/test_admin_warm_start_job.py
@@ -5,6 +5,8 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PATCHER_PATH = REPO_ROOT / "scripts" / "admin" / "patch_warm_start_job.py"
+PREPARE_HELPER_PATH = REPO_ROOT / "kit_admin_tools" / "prepare_odelia_job.sh"
+KIT_INJECTOR_PATH = REPO_ROOT / "scripts" / "build" / "_injectLiveSyncIntoStartupKits.sh"
 
 
 def _import_patcher():
@@ -12,6 +14,30 @@ def _import_patcher():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_prepare_helper_defaults_to_exact_odelia_eight_unless_counts_are_explicit():
+    helper = PREPARE_HELPER_PATH.read_text()
+
+    assert (
+        'DEFAULT_STRICT_CLIENTS="CAM_1,VHIO_1,USZ_1,RUMC_1,MHA_1,RSH_1,UMCU_1,UKA_1"'
+        in helper
+    )
+    assert 'STRICT_CLIENTS="$DEFAULT_STRICT_CLIENTS"' in helper
+    assert 'CUSTOM_CLIENT_COUNTS_SET=true' in helper
+    assert '[ "$STRICT_CLIENTS_EXPLICIT" != true ] && [ "$CUSTOM_CLIENT_COUNTS_SET" = true ]' in helper
+
+
+def test_prepare_helper_stages_before_replacing_and_uses_kit_paired_patcher():
+    helper = PREPARE_HELPER_PATH.read_text()
+    injector = KIT_INJECTOR_PATH.read_text()
+
+    assert 'PATCH_ARGS=(--job-dir "/job_out/$TEMP_NAME"' in helper
+    assert 'mv -- "$TEMP_HOST" "$DEST_HOST"' in helper
+    assert 'rm -rf "$DEST_HOST"' not in helper
+    assert '-v "$PATCHER_HOST":/mediswarm_tools/patch_warm_start_job.py:ro' in helper
+    assert 'python3 /mediswarm_tools/patch_warm_start_job.py' in helper
+    assert 'cp "$ADMIN_PATCHER_SOURCE" "$STARTUP_DIR/patch_warm_start_job.py"' in injector
 
 
 CONFIG_TEMPLATE = """components = [
@@ -42,6 +68,17 @@ SERVER_CONFIG_TEMPLATE = """workflows = [
     }
   }
 ]
+"""
+
+META_CONFIG_TEMPLATE = """name = "challenge_1DivideAndConquer"
+resource_spec {}
+deploy_map {
+  app = [
+    "@ALL"
+  ]
+}
+min_clients = 2
+mandatory_clients = []
 """
 
 
@@ -135,6 +172,46 @@ def test_patch_server_config_replaces_existing_configure_min_clients():
     assert "configure_min_clients = 5" not in patched
 
 
+def test_parse_strict_clients_trims_and_preserves_order():
+    patcher = _import_patcher()
+
+    assert patcher.parse_strict_clients("CAM_1, MHA_1,UKA_1") == ("CAM_1", "MHA_1", "UKA_1")
+
+
+@pytest.mark.parametrize("value", ["", "CAM_1,,UKA_1", "CAM_1,  ,UKA_1"])
+def test_parse_strict_clients_rejects_empty_names(value):
+    patcher = _import_patcher()
+
+    with pytest.raises(ValueError, match="non-empty client names"):
+        patcher.parse_strict_clients(value)
+
+
+def test_parse_strict_clients_rejects_duplicate_names():
+    patcher = _import_patcher()
+
+    with pytest.raises(ValueError, match=r"duplicate client name\(s\): CAM_1"):
+        patcher.parse_strict_clients("CAM_1,MHA_1,CAM_1")
+
+
+def test_strict_profile_patches_all_client_membership_and_count_fields():
+    patcher = _import_patcher()
+    clients = ("CAM_1", "MHA_1", "UKA_1")
+
+    patched_server = patcher.patch_server_config_text(
+        SERVER_CONFIG_TEMPLATE,
+        min_clients=len(clients),
+        configure_min_clients=len(clients),
+        participating_clients=clients,
+    )
+    patched_meta = patcher.patch_meta_config_text(META_CONFIG_TEMPLATE, clients)
+
+    assert "min_clients = 3  # tolerate drops" in patched_server
+    assert "configure_min_clients = 3" in patched_server
+    assert 'participating_clients = ["CAM_1", "MHA_1", "UKA_1"]' in patched_server
+    assert "min_clients = 3" in patched_meta
+    assert 'mandatory_clients = ["CAM_1", "MHA_1", "UKA_1"]' in patched_meta
+
+
 def test_patch_numeric_assignment_rejects_missing_key():
     patcher = _import_patcher()
 
@@ -178,6 +255,86 @@ def test_patch_job_dir_smoke_prepares_admin_local_continue_job(tmp_path):
     assert "num_rounds = 2" in patched_server
     assert "min_clients = 2" in patched_server
     assert "configure_min_clients = 3" in patched_server
+
+
+def test_patch_job_dir_strict_clients_sets_one_consistent_exact_profile(tmp_path):
+    patcher = _import_patcher()
+    job_dir = tmp_path / "strict_job"
+    config_dir = job_dir / "app" / "config"
+    config_dir.mkdir(parents=True)
+    client_path = config_dir / "config_fed_client.conf"
+    server_path = config_dir / "config_fed_server.conf"
+    meta_path = job_dir / "meta.conf"
+    client_path.write_text(CONFIG_TEMPLATE)
+    server_path.write_text(SERVER_CONFIG_TEMPLATE)
+    meta_path.write_text(META_CONFIG_TEMPLATE)
+
+    patcher.patch_job_dir(
+        job_dir,
+        "continue",
+        strict_clients="CAM_1,MHA_1,UKA_1",
+    )
+
+    assert "min_responses_required = 3" in client_path.read_text()
+    assert "min_clients = 3  # tolerate drops" in server_path.read_text()
+    assert "configure_min_clients = 3" in server_path.read_text()
+    assert 'participating_clients = ["CAM_1", "MHA_1", "UKA_1"]' in server_path.read_text()
+    assert "min_clients = 3" in meta_path.read_text()
+    assert 'mandatory_clients = ["CAM_1", "MHA_1", "UKA_1"]' in meta_path.read_text()
+
+
+@pytest.mark.parametrize(
+    ("argument", "value", "error_name"),
+    [
+        ("min_clients", 2, "min_clients"),
+        ("configure_min_clients", 2, "configure_min_clients"),
+        ("min_responses_required", 2, "min_responses_required"),
+    ],
+)
+def test_patch_job_dir_rejects_counts_that_conflict_with_strict_clients_without_writing(
+    tmp_path, argument, value, error_name
+):
+    patcher = _import_patcher()
+    job_dir = tmp_path / "strict_job"
+    config_dir = job_dir / "app" / "config"
+    config_dir.mkdir(parents=True)
+    client_path = config_dir / "config_fed_client.conf"
+    server_path = config_dir / "config_fed_server.conf"
+    meta_path = job_dir / "meta.conf"
+    originals = {
+        client_path: CONFIG_TEMPLATE,
+        server_path: SERVER_CONFIG_TEMPLATE,
+        meta_path: META_CONFIG_TEMPLATE,
+    }
+    for path, text in originals.items():
+        path.write_text(text)
+
+    with pytest.raises(ValueError, match=rf"{error_name}=2 conflicts with strict_clients count 3"):
+        patcher.patch_job_dir(
+            job_dir,
+            "continue",
+            strict_clients="CAM_1,MHA_1,UKA_1",
+            **{argument: value},
+        )
+
+    assert {path: path.read_text() for path in originals} == originals
+
+
+def test_patch_job_dir_strict_profile_validates_every_file_before_writing(tmp_path):
+    patcher = _import_patcher()
+    job_dir = tmp_path / "strict_job"
+    config_dir = job_dir / "app" / "config"
+    config_dir.mkdir(parents=True)
+    client_path = config_dir / "config_fed_client.conf"
+    server_path = config_dir / "config_fed_server.conf"
+    client_path.write_text(CONFIG_TEMPLATE)
+    server_path.write_text(SERVER_CONFIG_TEMPLATE)
+
+    with pytest.raises(FileNotFoundError, match="Missing job metadata config"):
+        patcher.patch_job_dir(job_dir, "continue", strict_clients="CAM_1,MHA_1,UKA_1")
+
+    assert client_path.read_text() == CONFIG_TEMPLATE
+    assert server_path.read_text() == SERVER_CONFIG_TEMPLATE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_warm_continue.py
+++ b/tests/unit_tests/test_warm_continue.py
@@ -74,11 +74,50 @@ def _install_warm_continue_nvflare_mocks(monkeypatch):
 
 
 def _install_controller_nvflare_mocks(monkeypatch):
+    engine_key = "__engine__"
+
+    class FakeShareable(dict):
+        def __init__(self):
+            super().__init__()
+            self.headers = {}
+
+        def set_header(self, key, value):
+            self.headers[key] = value
+
+        def get_header(self, key, default=None):
+            return self.headers.get(key, default)
+
+        def get_return_code(self, default=None):
+            return self.get("return_code", default)
+
     class FakeFLContext:
-        def __init__(self, identity=None, props=None, peer_context=None):
+        def __init__(self, identity=None, props=None, peer_context=None, engine=None, run_abort_signal=None):
             self.identity = identity
             self.props = props or {}
             self.peer_context = peer_context
+            self.engine = engine
+            self.run_abort_signal = run_abort_signal
+
+        def clone(self):
+            return FakeFLContext(
+                identity=self.identity,
+                props=dict(self.props),
+                peer_context=self.peer_context,
+                engine=self.engine,
+                run_abort_signal=self.run_abort_signal,
+            )
+
+        def put(self, key, value, private, sticky):
+            if key == engine_key:
+                self.engine = value
+            else:
+                self.props[key] = value
+
+        def get_engine(self):
+            return self.engine
+
+        def get_run_abort_signal(self):
+            return self.run_abort_signal
 
         def get_peer_context(self):
             return self.peer_context
@@ -89,8 +128,8 @@ def _install_controller_nvflare_mocks(monkeypatch):
         def get_prop(self, key):
             return self.props.get(key)
 
-        def set_prop(self, *args, **kwargs):
-            return None
+        def set_prop(self, key, value, private, sticky):
+            self.props[key] = value
 
     class FakeClientStatus:
         def __init__(self):
@@ -100,10 +139,28 @@ def _install_controller_nvflare_mocks(monkeypatch):
             self.last_progress_time = None
 
     class FakeGatherer:
-        pass
+        def is_done(self):
+            return "base-is-done"
 
     class FakeSwarmClientController:
-        pass
+        def __init__(self, *args, learn_task_ack_timeout=30, learn_task_timeout=None, **kwargs):
+            self.learn_task_ack_timeout = learn_task_ack_timeout
+            self.learn_task_timeout = learn_task_timeout
+            self.do_learn_task_name = "swarm_learn"
+            self.learn_task = None
+            self.allow_busy_task = True
+            self.asked_to_stop = False
+
+        def do_learn_task(self, name, task_data, fl_ctx, abort_signal):
+            self.base_seen_fl_ctx = fl_ctx
+            return fl_ctx.get_engine()
+
+        def start_run(self, fl_ctx):
+            self.base_start_run_fl_ctx = fl_ctx
+
+        def _scatter(self, task_data, for_round, fl_ctx):
+            self.base_seen_fl_ctx = fl_ctx
+            return fl_ctx.get_engine()
 
     class FakeSwarmServerController:
         pass
@@ -120,6 +177,7 @@ def _install_controller_nvflare_mocks(monkeypatch):
     modules = {
         "nvflare": types.ModuleType("nvflare"),
         "nvflare.apis": types.ModuleType("nvflare.apis"),
+        "nvflare.apis.fl_constant": types.ModuleType("nvflare.apis.fl_constant"),
         "nvflare.apis.fl_context": types.ModuleType("nvflare.apis.fl_context"),
         "nvflare.apis.shareable": types.ModuleType("nvflare.apis.shareable"),
         "nvflare.app_common": types.ModuleType("nvflare.app_common"),
@@ -133,13 +191,32 @@ def _install_controller_nvflare_mocks(monkeypatch):
         "nvflare.security": types.ModuleType("nvflare.security"),
         "nvflare.security.logging": types.ModuleType("nvflare.security.logging"),
     }
+    modules["nvflare.apis.fl_constant"].ReservedKey = SimpleNamespace(
+        ENGINE=engine_key,
+        RC="__rc__",
+        TASK_NAME="__task_name__",
+    )
+    modules["nvflare.apis.fl_constant"].ReservedTopic = SimpleNamespace(DO_TASK="__do_task__")
     modules["nvflare.apis.fl_context"].FLContext = FakeFLContext
-    modules["nvflare.apis.shareable"].ReturnCode = SimpleNamespace(OK="OK", EXECUTION_EXCEPTION="EXECUTION_EXCEPTION")
-    modules["nvflare.apis.shareable"].make_reply = lambda rc: {"return_code": rc}
+    modules["nvflare.apis.shareable"].ReturnCode = SimpleNamespace(
+        OK="OK",
+        ERROR="ERROR",
+        EXECUTION_EXCEPTION="EXECUTION_EXCEPTION",
+        MODEL_UNRECOGNIZED="MODEL_UNRECOGNIZED",
+        SERVICE_UNAVAILABLE="SERVICE_UNAVAILABLE",
+        TIMEOUT="TIMEOUT",
+    )
+    def make_reply(rc):
+        reply = FakeShareable()
+        reply["return_code"] = rc
+        return reply
+
+    modules["nvflare.apis.shareable"].make_reply = make_reply
     modules["nvflare.app_common.app_constant"].AppConstants = SimpleNamespace(
         CURRENT_ROUND="current_round",
         TRAINING_RESULT="training_result",
         AGGREGATION_ACCEPTED="aggregation_accepted",
+        NUM_ROUNDS="num_rounds",
     )
     modules["nvflare.app_common.app_event_type"].AppEventType = SimpleNamespace(
         BEFORE_CONTRIBUTION_ACCEPT="before_contribution_accept",
@@ -345,3 +422,477 @@ def test_transient_error_is_still_pruned_when_min_clients_remain(fault_tolerant_
     assert controller.asked_to_stop is False
     assert "site1" not in controller.client_statuses
     assert panics == []
+
+
+class _SequenceEngine:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+        self.forwarded_attribute = "forwarded"
+
+    def send_aux_request(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.responses.pop(0)
+
+
+def _make_permission_retry_adapter(module, responses):
+    warnings = []
+    controller = SimpleNamespace(
+        request_to_submit_learn_result_task_name="request_submit",
+        log_warning=lambda fl_ctx, message: warnings.append((fl_ctx, message)),
+    )
+    engine = _SequenceEngine(responses)
+    return module._PermissionReplyRetryEngine(engine, controller), engine, warnings
+
+
+def test_missing_permission_reply_becomes_retryable_service_unavailable(fault_tolerant_ccwf):
+    module, _ = fault_tolerant_ccwf
+    adapter, engine, warnings = _make_permission_retry_adapter(
+        module,
+        responses=[
+            {},
+            {"MHA_1": module.make_reply(module.ReturnCode.OK)},
+        ],
+    )
+
+    first = adapter.send_aux_request(
+        targets=["MHA_1"],
+        topic="request_submit",
+        request={},
+        timeout=60,
+        fl_ctx="ctx",
+        secure=False,
+    )
+    second = adapter.send_aux_request(
+        targets=["MHA_1"],
+        topic="request_submit",
+        request={},
+        timeout=60,
+        fl_ctx="ctx",
+        secure=False,
+    )
+
+    assert first["MHA_1"]["return_code"] == module.ReturnCode.SERVICE_UNAVAILABLE
+    assert second["MHA_1"]["return_code"] == module.ReturnCode.OK
+    assert len(engine.calls) == 2
+    assert len(warnings) == 1
+    assert "treating it as transient and retrying" in warnings[0][1]
+    assert adapter.forwarded_attribute == "forwarded"
+
+
+def test_explicit_permission_rejection_is_not_rewritten(fault_tolerant_ccwf):
+    module, _ = fault_tolerant_ccwf
+    rejected = {"MHA_1": module.make_reply(module.ReturnCode.MODEL_UNRECOGNIZED)}
+    adapter, _, warnings = _make_permission_retry_adapter(module, responses=[rejected])
+
+    actual = adapter.send_aux_request(
+        targets=["MHA_1"],
+        topic="request_submit",
+        request={},
+        timeout=60,
+        fl_ctx="ctx",
+        secure=False,
+    )
+
+    assert actual is rejected
+    assert warnings == []
+
+
+def test_explicit_falsey_permission_rejection_is_not_rewritten(fault_tolerant_ccwf):
+    module, _ = fault_tolerant_ccwf
+
+    class FalseyReply:
+        def __bool__(self):
+            return False
+
+        def get_return_code(self, default=None):
+            return module.ReturnCode.MODEL_UNRECOGNIZED
+
+    explicit_reply = FalseyReply()
+    rejected = {"MHA_1": explicit_reply}
+    adapter, _, warnings = _make_permission_retry_adapter(module, responses=[rejected])
+
+    actual = adapter.send_aux_request(
+        targets=["MHA_1"],
+        topic="request_submit",
+        request={},
+        timeout=60,
+        fl_ctx="ctx",
+        secure=False,
+    )
+
+    assert actual is rejected
+    assert actual["MHA_1"] is explicit_reply
+    assert warnings == []
+
+
+def test_retry_adapter_is_context_local_for_learning_task(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    delegate = _SequenceEngine([])
+    original_fl_ctx = fl_context_cls(engine=delegate)
+    controller = module.FaultTolerantSwarmClientController.__new__(
+        module.FaultTolerantSwarmClientController
+    )
+    controller.request_to_submit_learn_result_task_name = "request_submit"
+    controller.log_warning = lambda *args, **kwargs: None
+
+    seen_engine = controller.do_learn_task(
+        name="train",
+        task_data={},
+        fl_ctx=original_fl_ctx,
+        abort_signal=SimpleNamespace(triggered=False),
+    )
+
+    assert isinstance(seen_engine, module._PermissionReplyRetryEngine)
+    assert seen_engine._engine is delegate
+    assert controller.base_seen_fl_ctx is not original_fl_ctx
+    assert original_fl_ctx.get_engine() is delegate
+
+
+def test_start_run_installs_fault_tolerant_gatherer_used_by_inherited_controller(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    controller = module.FaultTolerantSwarmClientController()
+    controller.log_info = lambda *args: None
+    fl_ctx = fl_context_cls()
+
+    controller.start_run(fl_ctx)
+
+    swarm_module = sys.modules["nvflare.app_common.ccwf.swarm_client_ctl"]
+    assert swarm_module.Gatherer is module.FaultTolerantGatherer
+    assert controller.base_start_run_fl_ctx is fl_ctx
+
+
+def test_learn_scatter_retries_only_missing_none_and_timeout(fault_tolerant_ccwf):
+    module, _ = fault_tolerant_ccwf
+    ok_a = module.make_reply(module.ReturnCode.OK)
+    timeout_b = module.make_reply(module.ReturnCode.TIMEOUT)
+    ok_b = module.make_reply(module.ReturnCode.OK)
+    error_c = module.make_reply(module.ReturnCode.ERROR)
+    engine = _SequenceEngine(
+        [
+            {"A": ok_a, "B": timeout_b, "C": None},
+            {"B": ok_b, "C": error_c},
+        ]
+    )
+    warnings = []
+    controller = SimpleNamespace(
+        do_learn_task_name="swarm_learn",
+        asked_to_stop=False,
+        log_warning=lambda fl_ctx, message: warnings.append(message),
+    )
+    request = module.make_reply(module.ReturnCode.OK)
+    request.set_header(module.ReservedKey.TASK_NAME, "swarm_learn")
+    request.set_header(module.AppConstants.CURRENT_ROUND, 3)
+    adapter = module._LearnScatterRetryEngine(
+        engine=engine,
+        controller=controller,
+        deadline=module.time.time() + 1,
+        attempt_timeout=0.1,
+        retry_interval=0.001,
+    )
+
+    actual = adapter.send_aux_request(
+        targets=["A", "B", "C"],
+        topic=module.ReservedTopic.DO_TASK,
+        request=request,
+        timeout=30,
+        fl_ctx="ctx",
+        secure=False,
+    )
+
+    assert engine.calls[0][1]["targets"] == ["A", "B", "C"]
+    assert engine.calls[1][1]["targets"] == ["B", "C"]
+    assert actual == {"A": ok_a, "B": ok_b, "C": error_c}
+    assert len(warnings) == 1
+    assert "retrying only those clients" in warnings[0]
+
+
+def test_learn_scatter_never_retries_explicit_terminal_errors(fault_tolerant_ccwf):
+    module, _ = fault_tolerant_ccwf
+    execution_error = module.make_reply(module.ReturnCode.EXECUTION_EXCEPTION)
+    engine = _SequenceEngine([{"UKA_1": execution_error}])
+    controller = SimpleNamespace(
+        do_learn_task_name="swarm_learn",
+        asked_to_stop=False,
+        log_warning=lambda *args: None,
+    )
+    request = module.make_reply(module.ReturnCode.OK)
+    request.set_header(module.ReservedKey.TASK_NAME, "swarm_learn")
+    adapter = module._LearnScatterRetryEngine(
+        engine=engine,
+        controller=controller,
+        deadline=module.time.time() + 1,
+        attempt_timeout=0.1,
+        retry_interval=0.001,
+    )
+
+    actual = adapter.send_aux_request(
+        targets=["UKA_1"],
+        topic=module.ReservedTopic.DO_TASK,
+        request=request,
+        timeout=30,
+        fl_ctx="ctx",
+        secure=False,
+    )
+
+    assert actual == {"UKA_1": execution_error}
+    assert len(engine.calls) == 1
+
+
+def test_learn_scatter_stops_retrying_when_run_is_aborted(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    abort_signal = SimpleNamespace(triggered=False)
+
+    class AbortAfterFirstEngine(_SequenceEngine):
+        def send_aux_request(self, *args, **kwargs):
+            response = super().send_aux_request(*args, **kwargs)
+            abort_signal.triggered = True
+            return response
+
+    engine = AbortAfterFirstEngine([{}])
+    controller = SimpleNamespace(
+        do_learn_task_name="swarm_learn",
+        asked_to_stop=False,
+        log_warning=lambda *args: None,
+    )
+    request = module.make_reply(module.ReturnCode.OK)
+    request.set_header(module.ReservedKey.TASK_NAME, "swarm_learn")
+    adapter = module._LearnScatterRetryEngine(
+        engine=engine,
+        controller=controller,
+        deadline=module.time.time() + 86400,
+        attempt_timeout=3600,
+        retry_interval=5,
+    )
+
+    actual = adapter.send_aux_request(
+        targets=["UKA_1"],
+        topic=module.ReservedTopic.DO_TASK,
+        request=request,
+        timeout=86400,
+        fl_ctx=fl_context_cls(run_abort_signal=abort_signal),
+        secure=False,
+    )
+
+    assert actual == {}
+    assert len(engine.calls) == 1
+
+
+def test_scatter_timeout_defaults_to_stock_ack_timeout(fault_tolerant_ccwf):
+    module, _ = fault_tolerant_ccwf
+
+    controller = module.FaultTolerantSwarmClientController(
+        learn_task_ack_timeout=37,
+        learn_task_timeout=90,
+    )
+
+    assert controller.learn_task_scatter_attempt_timeout == 37
+    assert controller.learn_task_scatter_retry_interval == 5.0
+
+
+def _return_code(reply, default=None):
+    return reply.get_return_code(default)
+
+
+def test_duplicate_learn_request_is_acknowledged_without_requeue(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    controller = module.FaultTolerantSwarmClientController()
+    controller.log_info = lambda *args: None
+    controller.log_error = lambda *args: None
+    controller.update_status = lambda **kwargs: None
+    queued = []
+    controller.set_learn_task = lambda task_data, fl_ctx: queued.append(task_data) or True
+    fl_ctx = fl_context_cls(peer_context=fl_context_cls(identity="USZ_1"))
+    request = module.make_reply(module.ReturnCode.OK)
+    request.set_header(module.AppConstants.CURRENT_ROUND, 4)
+
+    first = controller._try_process_learn_request(request, fl_ctx)
+    duplicate = controller._try_process_learn_request(request, fl_ctx)
+
+    assert _return_code(first) == module.ReturnCode.OK
+    assert _return_code(duplicate) == module.ReturnCode.OK
+    assert queued == [request]
+    assert controller._last_accepted_learn_round == 4
+
+
+def test_older_learn_request_is_rejected_without_requeue(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    controller = module.FaultTolerantSwarmClientController()
+    controller.log_info = lambda *args: None
+    controller.log_error = lambda *args: None
+    controller.update_status = lambda **kwargs: None
+    queued = []
+    controller.set_learn_task = lambda task_data, fl_ctx: queued.append(task_data) or True
+    fl_ctx = fl_context_cls(peer_context=fl_context_cls(identity="USZ_1"))
+    current = module.make_reply(module.ReturnCode.OK)
+    current.set_header(module.AppConstants.CURRENT_ROUND, 5)
+    stale = module.make_reply(module.ReturnCode.OK)
+    stale.set_header(module.AppConstants.CURRENT_ROUND, 4)
+
+    controller._try_process_learn_request(current, fl_ctx)
+    rejected = controller._try_process_learn_request(stale, fl_ctx)
+
+    assert _return_code(rejected) == module.ReturnCode.MODEL_UNRECOGNIZED
+    assert queued == [current]
+
+
+def _make_strict_gatherer(module, fl_ctx, accepted=True):
+    updates = []
+    gatherer = module.FaultTolerantGatherer.__new__(module.FaultTolerantGatherer)
+    gatherer.for_round = 2
+    gatherer.min_responses_required = 2
+    gatherer.trainer_statuses = {
+        "A": SimpleNamespace(reply_time=1),
+        "B": SimpleNamespace(reply_time=None),
+    }
+    gatherer.min_resps_received_time = None
+    gatherer.timeout = None
+    gatherer.start_time = module.time.time()
+    gatherer.executor = SimpleNamespace(update_status=lambda **kwargs: updates.append(kwargs))
+    gatherer.aggregator = SimpleNamespace(accept=lambda result, ctx: accepted)
+    gatherer.log_error = lambda *args: None
+    gatherer.log_warning = lambda *args: None
+    gatherer.log_info = lambda *args: None
+    gatherer.fire_event = lambda *args: None
+    gatherer.fl_ctx = fl_ctx
+    return gatherer, updates
+
+
+def test_strict_gather_bad_result_reports_same_error_and_does_not_count(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    gatherer, updates = _make_strict_gatherer(module, fl_context_cls())
+    result = module.make_reply(module.ReturnCode.ERROR)
+    result.set_header(module.AppConstants.CURRENT_ROUND, 2)
+
+    reply = gatherer._do_gather("B", result, gatherer.fl_ctx)
+
+    assert _return_code(reply) == module.ReturnCode.ERROR
+    assert gatherer.trainer_statuses["B"].reply_time is None
+    assert updates == [{"action": "gather", "error": module.ReturnCode.ERROR}]
+
+
+def test_strict_gather_rejected_contribution_is_uncounted(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    gatherer, updates = _make_strict_gatherer(module, fl_context_cls(), accepted=False)
+    events = []
+    gatherer.fire_event = lambda event_type, fl_ctx: events.append(event_type)
+    result = module.make_reply(module.ReturnCode.OK)
+    result.set_header(module.AppConstants.CURRENT_ROUND, 2)
+
+    reply = gatherer._do_gather("B", result, gatherer.fl_ctx)
+
+    assert _return_code(reply) == module.ReturnCode.EXECUTION_EXCEPTION
+    assert gatherer.trainer_statuses["B"].reply_time is None
+    assert gatherer.min_resps_received_time is None
+    assert updates == [{"action": "gather", "error": module.ReturnCode.EXECUTION_EXCEPTION}]
+    assert events == [
+        module.AppEventType.BEFORE_CONTRIBUTION_ACCEPT,
+        module.AppEventType.AFTER_CONTRIBUTION_ACCEPT,
+    ]
+    assert gatherer.fl_ctx.get_prop(module.AppConstants.AGGREGATION_ACCEPTED) is False
+
+
+def test_strict_gather_counts_final_response_only_after_accept_finishes(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    gatherer, updates = _make_strict_gatherer(module, fl_context_cls())
+    accept_started = module.threading.Event()
+    allow_accept_to_finish = module.threading.Event()
+    replies = []
+
+    def accept(result, fl_ctx):
+        accept_started.set()
+        assert allow_accept_to_finish.wait(timeout=1)
+        return True
+
+    gatherer.aggregator = SimpleNamespace(accept=accept)
+    result = module.make_reply(module.ReturnCode.OK)
+    result.set_header(module.AppConstants.CURRENT_ROUND, 2)
+
+    gather_thread = module.threading.Thread(
+        target=lambda: replies.append(gatherer._do_gather("B", result, gatherer.fl_ctx))
+    )
+    gather_thread.start()
+    assert accept_started.wait(timeout=1)
+
+    assert gatherer.is_done() is False
+    assert gatherer.trainer_statuses["B"].reply_time is None
+
+    allow_accept_to_finish.set()
+    gather_thread.join(timeout=1)
+    assert not gather_thread.is_alive()
+    assert [_return_code(reply) for reply in replies] == [module.ReturnCode.OK]
+    assert gatherer.trainer_statuses["B"].reply_time is not None
+    assert gatherer.is_done() is True
+    assert updates == []
+
+
+def test_strict_gather_accept_exception_does_not_count_response(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    gatherer, _ = _make_strict_gatherer(module, fl_context_cls())
+    gatherer.aggregator = SimpleNamespace(accept=lambda result, fl_ctx: (_ for _ in ()).throw(RuntimeError("boom")))
+    result = module.make_reply(module.ReturnCode.OK)
+    result.set_header(module.AppConstants.CURRENT_ROUND, 2)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        gatherer._do_gather("B", result, gatherer.fl_ctx)
+
+    assert gatherer.trainer_statuses["B"].reply_time is None
+    assert gatherer.is_done() is False
+
+
+def test_strict_gather_after_accept_event_exception_does_not_count_response(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    gatherer, _ = _make_strict_gatherer(module, fl_context_cls())
+
+    def fire_event(event_type, fl_ctx):
+        if event_type == module.AppEventType.AFTER_CONTRIBUTION_ACCEPT:
+            raise RuntimeError("after hook failed")
+
+    gatherer.fire_event = fire_event
+    result = module.make_reply(module.ReturnCode.OK)
+    result.set_header(module.AppConstants.CURRENT_ROUND, 2)
+
+    with pytest.raises(RuntimeError, match="after hook failed"):
+        gatherer._do_gather("B", result, gatherer.fl_ctx)
+
+    assert gatherer.trainer_statuses["B"].reply_time is None
+    assert gatherer.is_done() is False
+
+
+def test_strict_gather_timeout_never_finishes_partial_aggregation(fault_tolerant_ccwf):
+    module, fl_context_cls = fault_tolerant_ccwf
+    gatherer, updates = _make_strict_gatherer(module, fl_context_cls())
+    gatherer.start_time = module.time.time() - 10
+    gatherer.timeout = 1
+
+    assert gatherer.is_done() is False
+    assert gatherer.is_done() is False
+    assert updates == [{"action": "gather_timeout", "error": module.ReturnCode.TIMEOUT}]
+
+
+@pytest.mark.parametrize(
+    "job_name",
+    [
+        "challenge_1DivideAndConquer",
+        "challenge_2BCN_AIM",
+        "challenge_3agaldran",
+        "challenge_4abmil",
+        "challenge_5pimed",
+        "ODELIA_ternary_classification",
+    ],
+)
+def test_production_swarm_client_configs_keep_result_refs_and_control_retries_alive(job_name):
+    client_config = (
+        REPO_ROOT / "application" / "jobs" / job_name / "app" / "config" / "config_fed_client.conf"
+    ).read_text()
+
+    assert 'path = "fault_tolerant_ccwf.FaultTolerantSwarmClientController"' in client_config
+    assert "last_result_transfer_timeout = 86400" in client_config
+    assert "download_complete_timeout = 86400" in client_config
+    assert "learn_task_scatter_attempt_timeout = 3600" in client_config
+    assert "learn_task_scatter_retry_interval = 5" in client_config
+    assert "request_to_submit_result_msg_timeout = 60" in client_config
+    assert "request_to_submit_result_interval = 5" in client_config
+    assert "max_concurrent_submissions = 1" in client_config
+    # Reusable templates must not bake in the current ODELIA deployment's site count.
+    assert "min_responses_required = 5" in client_config


### PR DESCRIPTION
## What changed

- Keep producer-side large-model result references alive for the full long-run budget in all six productive ODELIA jobs.
- Retry only missing/raw-timeout learn-task deliveries, retaining acknowledgements already received.
- Make repeated delivery of the same round idempotent and reject stale rounds.
- Treat missing result-submission permission replies as transient while preserving explicit terminal replies.
- In strict mode, reject bad/rejected contributions, prohibit timeout-driven partial aggregation, and count a contribution only after `aggregator.accept()` plus contribution hooks complete.
- Make the admin preparation path exact-client safe:
  - bare production preparation defaults to the current named eight ODELIA sites;
  - one `--strict-clients` value derives mandatory clients, participating clients, and all quorum values;
  - conflicting values fail before job files are written;
  - preparation happens in a temporary sibling and preserves the last valid staged job until validation succeeds;
  - generated admin kits carry the matching patcher with the helper.
- Keep reusable source-job quorum values generic for two-client and other validation workflows; supplying explicit `--min-*` values opts into that custom/test policy.

## Why

Two independent production defects were reproduced.

1. In strict job `6e1d08b9`, CAM's result reference had the default 1,800-second lifetime. It expired before MHA received serialized-submission permission at 1,881.55 seconds, so the first fetch returned `no ref found` and the round desynchronized. The producer TTL is controlled by `download_complete_timeout`, not tensor inactivity timeout.

2. Canary `a8c6a75b` reported eight accepted contributions and `FINISHED:COMPLETED`, but actually logged `aggregating 7 update(s)`. The monitor observed the final trainer's `reply_time` and began aggregation while `aggregator.accept()` was still processing UKA. The strict path now publishes that completion marker only after successful acceptance and event handling.

The production policy is exact all-site participation. Retries preserve all eight; terminal site failure fails loudly. No pruning or partial continuation is introduced by this PR.

## Impact

Future image builds contain the controller and six corrected job configurations. Future generated admin kits contain the strict-default helper and its matching patcher. Existing client identity/certificate kits do not need to be rebuilt merely to run a new image, but the new admin preparation behavior requires the updated helper/patcher (automatically included in newly generated admin kits).

## Validation

- Replacement one-round canary `1e4bface-91f8-460b-bcf0-2e14d60b5d72`: exact eight started/finished, exactly eight accepted, `aggregating 8 update(s)`, final broadcast to all peers, server `ALL_DONE`, no errors.
- Current full job `87c5bbee-6f8b-41cb-bd37-e9625cbecee2`: rounds 0–11 each aggregated exactly eight updates; round 12 remains healthy with all eight connected at the latest audit.
- `378 passed, 7 skipped, 1 deselected` in the complete non-GPU unit suite; only pre-existing metric warnings.
- Focused deterministic tests cover the final-accept race, rejection/event ordering, strict timeout, retry target retention, explicit-reply preservation, abort handling, and duplicate delivery.
- `bash -n` for both modified shell scripts.
- Python compilation and `git diff --check`.
- Exact `jefftud/odelia:1.6.0` constructor/config compatibility, including `download_complete_timeout`.
- End-to-end admin-helper staging smoke against the 1.6.0 image produced exact mandatory/participating client lists and 8/8/8 quorum values.

Closes #513.
Partially addresses #466.