### PR TITLE
ODELIA: Workaround for local data directory under /data

### DIFF
--- a/docker_config/master_template.yml
+++ b/docker_config/master_template.yml
@@ -840,7 +840,7 @@ docker_cln_sh: |
       # its own host path makes any link that stays WITHIN the tree resolve. Targets
       # outside $MY_DATA_DIR still need an explicit extra mount, e.g. via
       # MEDISWARM_DOCKER_OPTIONS="-v /abs/target:/abs/target:ro" in startup/image.conf.
-      if [ "$MY_DATA_DIR" != "/data" ]; then
+      if ! [[ "$MY_DATA_DIR" =~ "/data" ]]; then
           DOCKER_MOUNTS+=" -v $MY_DATA_DIR:$MY_DATA_DIR:ro"
       fi
   fi


### PR DESCRIPTION
This PR does not double-mount the local data directory if located inside /data, which caused a mount failure so far.
(commit pulled out from #391)