### PR TITLE
ODELIA docker build: overwrite master_template.yml only after NVFlare installation 

### DIFF
--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -286,9 +286,9 @@ RUN chmod a+rwX /huggingface_home -R
 # install ODELIA fork of NVFlare from local source
 WORKDIR /workspace/
 COPY ./MediSwarm/docker_config/NVFlare /workspace/nvflare
-## Override with MediSwarm master_template.yml (contains version placeholders injected by build script)
-COPY ./MediSwarm/docker_config/master_template.yml /workspace/nvflare/nvflare/lighter/templates/
 RUN python3 -m pip install --no-cache-dir /workspace/nvflare && rm -rf /workspace/nvflare
+## Override with MediSwarm master_template.yml (contains version placeholders injected by build script)
+COPY ./MediSwarm/docker_config/master_template.yml /opt/conda/lib/python3.10/site-packages/nvflare/lighter/templates/master_template.yml
 
 # ---------------------------------------------------------------------------
 # Stage 5: application code (changes every commit)

--- a/docker_config/Dockerfile_ODELIA
+++ b/docker_config/Dockerfile_ODELIA
@@ -288,7 +288,8 @@ WORKDIR /workspace/
 COPY ./MediSwarm/docker_config/NVFlare /workspace/nvflare
 RUN python3 -m pip install --no-cache-dir /workspace/nvflare && rm -rf /workspace/nvflare
 ## Override with MediSwarm master_template.yml (contains version placeholders injected by build script)
-COPY ./MediSwarm/docker_config/master_template.yml /opt/conda/lib/python3.10/site-packages/nvflare/lighter/templates/master_template.yml
+COPY ./MediSwarm/docker_config/master_template.yml /tmp/master_template.yml
+RUN mv /tmp/master_template.yml $(python3 -c "import nvflare.lighter,os;print(os.path.dirname(nvflare.lighter.__file__))")/templates/master_template.yml
 
 # ---------------------------------------------------------------------------
 # Stage 5: application code (changes every commit)


### PR DESCRIPTION
When building the ODELIA Docker image, improve docker build cache usage by copying our custom master_template.yml to the installed NVFlare directory so that we can re-use the cached result of installing the NVFlare python package.
(pulled out from https://github.com/KatherLab/MediSwarm/pull/391)