### PR TITLE
feat(stamp): verify cross-site class order before a run starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ deploy_sites_decade_2node.conf
 # Startup-kit passwords — NEVER commit (workspace/ is ignored too, this is belt-and-braces)
 kit_passwords.txt
 **/kit_passwords.txt
+
+# Staged swarm jobs, hand-edited per run and regenerated each time
+run_staging/

--- a/application/jobs/STAMP_classification/app/custom/main.py
+++ b/application/jobs/STAMP_classification/app/custom/main.py
@@ -91,6 +91,12 @@ def main():
             )
         )
 
+        # Verify the class order BEFORE any training. A cross-site mismatch makes
+        # swarm aggregation average classifier weights that mean different things,
+        # which produces a completed run whose result cannot be trusted. Enforced
+        # only when STAMP_EXPECTED_CATEGORIES is set; otherwise just logged.
+        stamp_training.verify_class_order(env, model)
+
         if TRAINING_MODE == TM_SWARM:
             flare.patch(trainer)
             torch.autograd.set_detect_anomaly(True)

--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -379,6 +379,126 @@ def compute_weighted_epochs(num_train_samples: int, site_name: str = "") -> int:
     return epochs
 
 
+# ---------------------------------------------------------------------------
+# Class-order verification
+# ---------------------------------------------------------------------------
+# Swarm aggregation averages the classifier head position by position. If one
+# site infers the class order ["no", "yes"] and another ["yes", "no"], every
+# round averages weights that mean opposite things: the run completes, the loss
+# looks plausible, and the result is silently meaningless. Nothing in NVFlare or
+# STAMP detects this — the shapes match, only the semantics differ.
+#
+# STAMP infers the order from each site's own clinical table, so it depends on
+# that site's label spelling and on which labels are present. Two real examples:
+# a site that leaves a third label ("not provided", "FAP") in its table gets a
+# 3-class head, and sites that disagree on capitalisation ("Lynch syndrome" vs
+# "Lynch Syndrome") produce different orders. The second cost us a DECADE run,
+# which aborted mid-flight with EXECUTION_EXCEPTION.
+#
+# Opt in per run by setting STAMP_EXPECTED_CATEGORIES to the agreed order, e.g.
+#     STAMP_EXPECTED_CATEGORIES="Lynch syndrome,Sporadic"
+#     STAMP_EXPECTED_CATEGORIES="no,yes"
+# Comparison is case-insensitive and whitespace-insensitive but ORDER-SENSITIVE,
+# because the order is exactly what must agree. When unset, the inferred order is
+# logged and not enforced, so existing runs are unaffected.
+
+ENV_EXPECTED_CATEGORIES = "STAMP_EXPECTED_CATEGORIES"
+
+
+def parse_expected_categories(raw):
+    """Parse a comma-separated class order into a list, or None if unset/blank."""
+    if raw is None:
+        return None
+    parts = [part.strip() for part in str(raw).split(",")]
+    parts = [part for part in parts if part]
+    return parts or None
+
+
+def categories_match(observed, expected):
+    """Order-sensitive, case- and whitespace-insensitive class-order comparison."""
+    if observed is None or expected is None:
+        return False
+    normalize = lambda values: [str(v).strip().casefold() for v in values]  # noqa: E731
+    return normalize(observed) == normalize(expected)
+
+
+def extract_categories(model):
+    """Best-effort read of the class order STAMP inferred, or None if unavailable.
+
+    STAMP exposes it as ``model.categories``; some versions only keep it in
+    ``model.hparams``. Returns stripped strings so comparison is not thrown off by
+    stray whitespace in a clinical table.
+    """
+    categories = getattr(model, "categories", None)
+    if categories is None:
+        hparams = getattr(model, "hparams", None)
+        if hparams is not None:
+            categories = (
+                hparams.get("categories")
+                if hasattr(hparams, "get")
+                else getattr(hparams, "categories", None)
+            )
+    if categories is None:
+        return None
+    try:
+        return [str(value).strip() for value in list(categories)]
+    except TypeError:
+        return None
+
+
+def verify_class_order(env: dict, model, expected_categories=None):
+    """Fail before round 0 if this site's class order is not the agreed one.
+
+    Raises ValueError on a mismatch — deliberately before any training happens,
+    since the alternative is a run that completes and cannot be trusted. Returns
+    the observed class order (or None if it could not be read).
+    """
+    observed = extract_categories(model)
+    if observed is None:
+        logger.warning(
+            "Could not read the inferred class order from the model — skipping "
+            "class-order verification. A cross-site order mismatch would NOT be "
+            "detected for this run."
+        )
+        return None
+
+    # Always worth checking: a stray third label (e.g. 'not provided', 'FAP')
+    # silently widens the head and guarantees a mismatch with the other sites.
+    num_classes = env.get("num_classes")
+    if num_classes is not None and len(observed) != int(num_classes):
+        raise ValueError(
+            f"Class-order check: this site inferred {len(observed)} classes "
+            f"{observed!r} but STAMP_NUM_CLASSES is {num_classes}. Remove any extra "
+            "label (e.g. 'not provided') from the clinical table, or correct "
+            "STAMP_NUM_CLASSES, before starting the run."
+        )
+
+    if expected_categories is None:
+        expected_categories = parse_expected_categories(
+            os.environ.get(ENV_EXPECTED_CATEGORIES)
+        )
+
+    if expected_categories is None:
+        logger.info(
+            "Inferred class order %r (not verified — set %s to the agreed order "
+            "to enforce it across sites)", observed, ENV_EXPECTED_CATEGORIES,
+        )
+        return observed
+
+    if not categories_match(observed, expected_categories):
+        raise ValueError(
+            f"Class-order mismatch: this site inferred {observed!r} but the run "
+            f"expects {list(expected_categories)!r} (compared case-insensitively, "
+            "order matters). Swarm aggregation averages the classifier head by "
+            "position, so continuing would silently combine classes that mean "
+            "different things. Align the labels in the clinical table, or correct "
+            f"{ENV_EXPECTED_CATEGORIES}."
+        )
+
+    logger.info("Class order verified: %r", observed)
+    return observed
+
+
 def _select_precision(task: str, use_gpu: bool) -> str:
     """Pick a Lightning precision that the task's loss can actually backprop.
 

--- a/tests/unit_tests/test_stamp_class_order.py
+++ b/tests/unit_tests/test_stamp_class_order.py
@@ -1,0 +1,156 @@
+"""Unit tests for STAMP cross-site class-order verification.
+
+Swarm aggregation averages the classifier head position by position, so if two
+sites infer different class orders the run completes and is silently meaningless.
+These tests cover the guard that refuses to start such a run.
+
+Regression: a real DECADE Lynch/Sporadic run aborted mid-flight because two sites
+spelled the same label with different capitalisation. Comparison must therefore be
+case-insensitive but still order-sensitive.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("lightning")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP_CUSTOM_DIR = (
+    REPO_ROOT / "application" / "jobs" / "STAMP_classification" / "app" / "custom"
+)
+if str(STAMP_CUSTOM_DIR) not in sys.path:
+    sys.path.insert(0, str(STAMP_CUSTOM_DIR))
+
+import stamp_training as st  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# parse_expected_categories
+# ---------------------------------------------------------------------------
+
+def test_parse_expected_categories_basic():
+    assert st.parse_expected_categories("no,yes") == ["no", "yes"]
+    assert st.parse_expected_categories("Lynch syndrome, Sporadic") == [
+        "Lynch syndrome", "Sporadic"
+    ]
+
+
+def test_parse_expected_categories_unset_or_blank_is_none():
+    assert st.parse_expected_categories(None) is None
+    assert st.parse_expected_categories("") is None
+    assert st.parse_expected_categories("   ") is None
+    assert st.parse_expected_categories(",, ,") is None
+
+
+# ---------------------------------------------------------------------------
+# categories_match
+# ---------------------------------------------------------------------------
+
+def test_categories_match_exact():
+    assert st.categories_match(["no", "yes"], ["no", "yes"])
+
+
+def test_categories_match_is_case_insensitive():
+    # The regression: sites disagreeing only on capitalisation must still match.
+    assert st.categories_match(["Lynch Syndrome", "sporadic"],
+                               ["Lynch syndrome", "Sporadic"])
+
+
+def test_categories_match_ignores_surrounding_whitespace():
+    assert st.categories_match([" no ", "yes\t"], ["no", "yes"])
+
+
+def test_categories_match_is_order_sensitive():
+    # Order is the whole point — position determines which output neuron a class
+    # maps to, so a reversed order must NOT be treated as equal.
+    assert not st.categories_match(["yes", "no"], ["no", "yes"])
+
+
+def test_categories_match_different_lengths():
+    assert not st.categories_match(["no", "yes", "not provided"], ["no", "yes"])
+
+
+def test_categories_match_none_inputs():
+    assert not st.categories_match(None, ["no", "yes"])
+    assert not st.categories_match(["no", "yes"], None)
+
+
+# ---------------------------------------------------------------------------
+# extract_categories
+# ---------------------------------------------------------------------------
+
+def test_extract_categories_from_attribute():
+    model = MagicMock(spec=["categories"])
+    model.categories = ["no", "yes"]
+    assert st.extract_categories(model) == ["no", "yes"]
+
+
+def test_extract_categories_from_hparams_mapping():
+    model = MagicMock(spec=["hparams"])
+    model.hparams = {"categories": [" no", "yes "]}
+    assert st.extract_categories(model) == ["no", "yes"]
+
+
+def test_extract_categories_returns_none_when_unavailable():
+    model = MagicMock(spec=[])
+    assert st.extract_categories(model) is None
+
+
+# ---------------------------------------------------------------------------
+# verify_class_order
+# ---------------------------------------------------------------------------
+
+def _model_with(categories):
+    model = MagicMock(spec=["categories"])
+    model.categories = categories
+    return model
+
+
+def test_verify_passes_when_order_matches(monkeypatch):
+    monkeypatch.delenv(st.ENV_EXPECTED_CATEGORIES, raising=False)
+    observed = st.verify_class_order(
+        {"num_classes": 2}, _model_with(["Lynch Syndrome", "sporadic"]),
+        expected_categories=["Lynch syndrome", "Sporadic"],
+    )
+    assert observed == ["Lynch Syndrome", "sporadic"]
+
+
+def test_verify_raises_on_reversed_order():
+    with pytest.raises(ValueError, match="Class-order mismatch"):
+        st.verify_class_order(
+            {"num_classes": 2}, _model_with(["yes", "no"]),
+            expected_categories=["no", "yes"],
+        )
+
+
+def test_verify_raises_when_extra_label_widens_the_head():
+    # A stray third label ('not provided') is the other real-world failure mode.
+    with pytest.raises(ValueError, match="inferred 3 classes"):
+        st.verify_class_order(
+            {"num_classes": 2}, _model_with(["no", "yes", "not provided"]),
+        )
+
+
+def test_verify_reads_expected_order_from_environment(monkeypatch):
+    monkeypatch.setenv(st.ENV_EXPECTED_CATEGORIES, "no, yes")
+    st.verify_class_order({"num_classes": 2}, _model_with(["No", "Yes"]))
+    monkeypatch.setenv(st.ENV_EXPECTED_CATEGORIES, "yes, no")
+    with pytest.raises(ValueError, match="Class-order mismatch"):
+        st.verify_class_order({"num_classes": 2}, _model_with(["No", "Yes"]))
+
+
+def test_verify_is_opt_in_when_env_unset(monkeypatch):
+    # Unset => log only, never raise, so existing runs are unaffected.
+    monkeypatch.delenv(st.ENV_EXPECTED_CATEGORIES, raising=False)
+    assert st.verify_class_order(
+        {"num_classes": 2}, _model_with(["anything", "goes"])
+    ) == ["anything", "goes"]
+
+
+def test_verify_returns_none_when_order_unreadable(monkeypatch):
+    monkeypatch.delenv(st.ENV_EXPECTED_CATEGORIES, raising=False)
+    assert st.verify_class_order({"num_classes": 2}, MagicMock(spec=[])) is None


### PR DESCRIPTION
Recovers a fix that only ever existed in a hand-edited job copy, and generalises it.

## The failure it prevents
Swarm aggregation averages the classifier head **position by position**. If one site infers `["no", "yes"]` and another `["yes", "no"]`, every round averages weights that mean opposite things: the run completes, the loss looks plausible, and the result is silently meaningless. Neither NVFlare nor STAMP notices — the tensor shapes match, only the semantics differ.

STAMP infers the order from each site's own clinical table, so it depends on that site's label spelling and on which labels are present. Both failure modes are real:
- a site leaving a third label (`not provided`, `FAP`) in its table gets a 3-class head while everyone else has 2;
- sites disagreeing on capitalisation (`Lynch syndrome` vs `Lynch Syndrome`).

**The second aborted a DECADE Lynch/Sporadic run mid-flight** (`EXECUTION_EXCEPTION`, 2026-08-04). It was rescued by an ad-hoc `casefold()` patch applied to a *staged job copy* that never made it back into the repo — so the next job prepared from the image would have hit it again.

## What this adds
`stamp_training.verify_class_order()`, called from `main.py` before any training in every mode:
- **always** checks the inferred class count against `STAMP_NUM_CLASSES`, catching the stray-extra-label case with an actionable message;
- **enforces the order** when `STAMP_EXPECTED_CATEGORIES` is set, e.g. `STAMP_EXPECTED_CATEGORIES="Lynch syndrome,Sporadic"` or `"no,yes"`. Comparison is case- and whitespace-insensitive but **order-sensitive**, since the order is exactly what must agree.

**Opt-in:** with the variable unset the inferred order is logged and not enforced, so existing runs (MSI-High, deploy tests, CI) are unaffected. Failing before round 0 is deliberate — the alternative is a run that finishes and cannot be trusted.

## Testing
17 new unit tests (`tests/unit_tests/test_stamp_class_order.py`), including a direct regression for the capitalisation bug and for order-sensitivity. Full suite: **375 passed, 7 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)