### PR TITLE
fix(stamp): take the scheduler horizon from the job's num_rounds (#503)

### DIFF
--- a/application/jobs/STAMP_classification/app/custom/main.py
+++ b/application/jobs/STAMP_classification/app/custom/main.py
@@ -39,9 +39,11 @@ if TRAINING_MODE == TM_SWARM:
     # prepare_training (weighted_epochs=True).
     NUM_EPOCHS = 1  # placeholder — replaced by weighted computation
     USE_WEIGHTED_EPOCHS = True
-    # Total federated rounds — needed to size OneCycleLR scheduler steps.
-    # Must match num_rounds in config_fed_server.conf (default 20).
-    TOTAL_ROUNDS = int(os.getenv("STAMP_NUM_ROUNDS", "20"))
+    # Total federated rounds — sizes the OneCycleLR scheduler. Read from the job's
+    # own config_fed_server.conf (deployed alongside this app), falling back to
+    # STAMP_NUM_ROUNDS. Taking it from the job removes the two-sources-of-truth
+    # split that let the server outrun the scheduler and kill training mid-run
+    # with "Tried to step N times..." (#503).
 elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
     SITE_NAME = os.getenv("SITE_NAME")
     if not SITE_NAME:
@@ -62,7 +64,6 @@ elif TRAINING_MODE in [TM_PREFLIGHT_CHECK, TM_LOCAL_TRAINING]:
     except ValueError:
         raise ValueError("NUM_EPOCHS must be an integer")
     USE_WEIGHTED_EPOCHS = False
-    TOTAL_ROUNDS = 1
 else:
     raise ValueError(f"Unsupported TRAINING_MODE: {TRAINING_MODE}")
 
@@ -82,12 +83,16 @@ def main():
         # Override with runtime settings
         env["site_name"] = SITE_NAME
 
+        total_rounds = (
+            stamp_training.resolve_total_rounds() if TRAINING_MODE == TM_SWARM else 1
+        )
+
         # Prepare training (data, model, trainer)
         train_dl, valid_dl, model, checkpointing, trainer, output_dir, metric_callback = (
             stamp_training.prepare_training(
                 env, NUM_EPOCHS,
                 weighted_epochs=USE_WEIGHTED_EPOCHS,
-                total_rounds=TOTAL_ROUNDS,
+                total_rounds=total_rounds,
             )
         )
 

--- a/application/jobs/STAMP_classification/app/custom/stamp_training.py
+++ b/application/jobs/STAMP_classification/app/custom/stamp_training.py
@@ -15,6 +15,7 @@ Key differences from standalone STAMP training:
 
 import logging
 import os
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -377,6 +378,112 @@ def compute_weighted_epochs(num_train_samples: int, site_name: str = "") -> int:
         f"raw={raw:.1f}, clamped={epochs}"
     )
     return epochs
+
+
+# ---------------------------------------------------------------------------
+# Scheduler horizon (#503)
+# ---------------------------------------------------------------------------
+# STAMP sizes its OneCycleLR scheduler once, for max_epochs x total_rounds steps.
+# The rounds actually executed come from num_rounds in the job's
+# config_fed_server.conf. These were two independent sources of truth: the client
+# read STAMP_NUM_ROUNDS from its environment, nothing checked the two agreed, and
+# when the server outran the scheduler training died mid-run with
+#
+#     ValueError: Tried to step 9 times. The specified number of total steps is 8
+#
+# reported to the server as EXECUTION_EXCEPTION -> FATAL_SYSTEM_ERROR. The message
+# names neither variable, and because oversizing is harmless the mismatch stays
+# invisible until someone RAISES num_rounds -- so it surfaces late, on a long run.
+#
+# The job's app (including config/) is deployed to every client, so the client can
+# read the authoritative value straight off disk instead of being told separately.
+
+ENV_NUM_ROUNDS = "STAMP_NUM_ROUNDS"
+DEFAULT_TOTAL_ROUNDS = 20
+
+
+def parse_num_rounds(text):
+    """Extract ``num_rounds`` from a config_fed_server.conf body, or None."""
+    if not text:
+        return None
+    match = re.search(r"^\s*num_rounds\s*=\s*(\d+)", text, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def find_server_config(explicit_path=None):
+    """Locate the deployed ``config_fed_server.conf``, or None if not found.
+
+    main.py runs as ``app_<SITE>/custom/main.py``, so the job's config sits at
+    ``app_<SITE>/config/``. Also tries the working directory, since the launcher's
+    cwd has differed between NVFlare versions.
+    """
+    candidates = []
+    if explicit_path:
+        candidates.append(Path(explicit_path))
+    here = Path(__file__).resolve().parent
+    candidates += [
+        here.parent / "config" / "config_fed_server.conf",
+        Path.cwd() / "config" / "config_fed_server.conf",
+        Path.cwd().parent / "config" / "config_fed_server.conf",
+    ]
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def resolve_total_rounds(env_value=None, server_config=None, default=DEFAULT_TOTAL_ROUNDS):
+    """Return the round count the LR scheduler must be sized for.
+
+    Precedence: the job's ``num_rounds`` (authoritative -- it is what the server
+    actually runs) > ``STAMP_NUM_ROUNDS`` > ``default``. When both are present and
+    disagree, the job wins and the discrepancy is logged loudly, because following
+    the environment instead is what kills the run partway through.
+    """
+    if env_value is None:
+        env_value = os.environ.get(ENV_NUM_ROUNDS)
+    env_rounds = None
+    if env_value not in (None, ""):
+        try:
+            env_rounds = int(env_value)
+        except (TypeError, ValueError):
+            logger.warning("%s=%r is not an integer — ignoring it", ENV_NUM_ROUNDS, env_value)
+
+    config_path = server_config if server_config is not None else find_server_config()
+    job_rounds = None
+    if config_path is not None:
+        try:
+            job_rounds = parse_num_rounds(Path(config_path).read_text())
+        except OSError as exc:
+            logger.warning("Could not read %s: %s", config_path, exc)
+
+    if job_rounds is not None:
+        if env_rounds is not None and env_rounds != job_rounds:
+            logger.warning(
+                "%s=%d disagrees with the job's num_rounds=%d. Using the job's value: "
+                "it is what the server runs, and sizing the LR scheduler for fewer "
+                "rounds makes training fail partway through (#503).",
+                ENV_NUM_ROUNDS, env_rounds, job_rounds,
+            )
+        logger.info("Scheduler horizon: %d rounds (from the job's config)", job_rounds)
+        return job_rounds
+
+    if env_rounds is not None:
+        logger.info(
+            "Scheduler horizon: %d rounds (from %s; the job's config_fed_server.conf "
+            "was not found, so this value is unverified)", env_rounds, ENV_NUM_ROUNDS,
+        )
+        return env_rounds
+
+    logger.warning(
+        "Scheduler horizon: falling back to %d rounds — neither the job's config nor "
+        "%s was readable. If the job runs more rounds than this, training will fail "
+        "partway through (#503).", default, ENV_NUM_ROUNDS,
+    )
+    return default
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_stamp_total_rounds.py
+++ b/tests/unit_tests/test_stamp_total_rounds.py
@@ -1,0 +1,120 @@
+"""Unit tests for the scheduler-horizon resolver (#503).
+
+STAMP sizes its OneCycleLR scheduler once, for max_epochs x total_rounds steps,
+while the rounds actually executed come from num_rounds in the job's
+config_fed_server.conf. When those disagreed, training died mid-run with
+"Tried to step N times. The specified number of total steps is M" — an error
+naming neither value. The job's config is now the single source of truth.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("lightning")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP_CUSTOM_DIR = (
+    REPO_ROOT / "application" / "jobs" / "STAMP_classification" / "app" / "custom"
+)
+if str(STAMP_CUSTOM_DIR) not in sys.path:
+    sys.path.insert(0, str(STAMP_CUSTOM_DIR))
+
+import stamp_training as st  # noqa: E402
+
+
+def _server_conf(tmp_path, num_rounds):
+    p = tmp_path / "config_fed_server.conf"
+    p.write_text(
+        "format_version = 2\n"
+        "workflows = [\n  {\n    args {\n"
+        f"      num_rounds = {num_rounds}\n"
+        "      start_task_timeout = 1800\n    }\n  }\n]\n"
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# parse_num_rounds
+# ---------------------------------------------------------------------------
+
+def test_parse_num_rounds_reads_the_value(tmp_path):
+    assert st.parse_num_rounds(_server_conf(tmp_path, 20).read_text()) == 20
+
+
+def test_parse_num_rounds_ignores_other_numeric_keys(tmp_path):
+    text = "start_task_timeout = 1800\nnum_rounds = 3\nprogress_timeout = 28800\n"
+    assert st.parse_num_rounds(text) == 3
+
+
+def test_parse_num_rounds_absent_or_empty():
+    assert st.parse_num_rounds("workflows = []\n") is None
+    assert st.parse_num_rounds("") is None
+    assert st.parse_num_rounds(None) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_total_rounds — precedence
+# ---------------------------------------------------------------------------
+
+def test_job_config_wins_over_environment(tmp_path):
+    # The exact 1.7.0 failure: env said 2, the job ran 20.
+    assert st.resolve_total_rounds(
+        env_value="2", server_config=_server_conf(tmp_path, 20)
+    ) == 20
+
+
+def test_job_config_used_when_env_unset(tmp_path):
+    assert st.resolve_total_rounds(
+        env_value=None, server_config=_server_conf(tmp_path, 7)
+    ) == 7
+
+
+def test_env_used_when_job_config_missing(tmp_path):
+    missing = tmp_path / "nope.conf"
+    assert st.resolve_total_rounds(env_value="5", server_config=missing) == 5
+
+
+def test_default_when_neither_available(tmp_path):
+    missing = tmp_path / "nope.conf"
+    assert st.resolve_total_rounds(
+        env_value=None, server_config=missing, default=11
+    ) == 11
+
+
+def test_non_integer_env_is_ignored(tmp_path):
+    missing = tmp_path / "nope.conf"
+    assert st.resolve_total_rounds(
+        env_value="not-a-number", server_config=missing, default=9
+    ) == 9
+
+
+def test_agreeing_values_resolve_cleanly(tmp_path):
+    assert st.resolve_total_rounds(
+        env_value="20", server_config=_server_conf(tmp_path, 20)
+    ) == 20
+
+
+def test_mismatch_is_logged_loudly(tmp_path, caplog):
+    import logging
+    with caplog.at_level(logging.WARNING):
+        st.resolve_total_rounds(env_value="2", server_config=_server_conf(tmp_path, 20))
+    assert any("disagrees with the job" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# find_server_config
+# ---------------------------------------------------------------------------
+
+def test_find_server_config_honours_explicit_path(tmp_path):
+    conf = _server_conf(tmp_path, 4)
+    assert st.find_server_config(conf) == conf
+
+
+def test_find_server_config_falls_back_when_explicit_path_missing(tmp_path):
+    # A missing explicit path must not be returned; the resolver falls through to
+    # its other candidates (which may or may not exist in a test checkout).
+    missing = tmp_path / "definitely_missing.conf"
+    assert st.find_server_config(missing) != missing


### PR DESCRIPTION
Closes #503.

## The problem
STAMP sizes its OneCycleLR scheduler **once**, for `max_epochs x total_rounds` steps. The rounds actually executed come from `num_rounds` in the job's `config_fed_server.conf`. These were two independent sources of truth — the client read `STAMP_NUM_ROUNDS` from its environment, and nothing checked they agreed.

When the server outran the scheduler, training died mid-run with:

```
ValueError: Tried to step 9 times. The specified number of total steps is 8
 -> EXECUTION_EXCEPTION -> Aborting current RUN due to FATAL_SYSTEM_ERROR
```

The message names neither value. Worse: **oversizing is harmless**, so a mismatch stays invisible until someone *raises* `num_rounds` — it then bites hours into a long run. This aborted the first 1.7.0 validation at **round 4 of 20**.

## The fix
The job's app — including `config/` — is deployed to every client, so the client can read the authoritative value off disk rather than being told separately. Verified on a live client:

```
/home/swarm/.../<job-id>/app_UKB_1/config/config_fed_server.conf:      num_rounds = 20
```

`resolve_total_rounds()` therefore resolves, for swarm runs:

```
job's num_rounds  >  STAMP_NUM_ROUNDS  >  default 20
```

When both are present and disagree the **job wins**, and the discrepancy is logged loudly — following the environment is exactly what kills the run. When the config can't be read we fall back to the environment *and say so*, rather than guessing silently.

No fork patch was needed. (`FLModel` has a `total_rounds` field and `FLModelUtils` maps `AppConstants.NUM_ROUNDS` onto it, but CCWF never sets that header — confirmed both in the source and empirically in real run logs — so the client API route is not available today.)

## Testing
12 new unit tests covering precedence, the exact 1.7.0 case (env said 2, job ran 20), non-integer env, missing config, and that a mismatch is logged. Full suite: **371 passed, 7 skipped**.

Note this removes the *silent* failure mode; the deploy-test half was already fixed in #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)