### PR TITLE
security: scrub real infra addresses and third-party usernames from the public tree

### DIFF
--- a/application/provision/project_DECADE_allsites.yml
+++ b/application/provision/project_DECADE_allsites.yml
@@ -55,8 +55,8 @@ builders:
         overseer_exists: false
         args:
           # SERVER_NAME:FL_PORT:ADMIN_PORT — must match the server above.
-          # Server runs on TUD (Tailscale 100.100.101.100); clients map
-          # dl3.tud.de -> 100.100.101.100 in /etc/hosts.
+          # Server runs on TUD; clients map dl3.tud.de -> <SERVER_IP> in
+          # /etc/hosts. The real address is in the members-only site registry.
           sp_end_point: dl3.tud.de:8002:8003
   - path: nvflare.lighter.impl.cert.CertBuilder
   - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/deploy_and_test.sh
+++ b/deploy_and_test.sh
@@ -466,7 +466,9 @@ cmd_all() {
 
     echo ""
     ok "Full pipeline complete!"
-    info "Monitor progress at: http://172.24.4.65:8080/"
+    # Real address intentionally not in the public tree; set MEDISWARM_MONITOR_URL
+    # (see the members-only site registry) to print a clickable URL here.
+    info "Monitor progress at: ${MEDISWARM_MONITOR_URL:-http://<SERVER_IP>:8080/}"
     info "Check status with: ./deploy_and_test.sh status"
     info "View logs with: ./deploy_and_test.sh logs <MHA|RSH|server>"
 }

--- a/deploy_sites.conf.example
+++ b/deploy_sites.conf.example
@@ -22,23 +22,23 @@ DEFAULT_JOB=challenge_1DivideAndConquer
 ADMIN_USER=jiefu.zhu@tu-dresden.de
 
 # ── Site: MHA ──────────────────────────────────────────────────────
-MHA_HOST=172.24.4.91
-MHA_USER=odelia
+MHA_HOST=100.100.100.191
+MHA_USER=REDACTED
 MHA_PASS='CHANGEME'
 MHA_SITE_NAME=MHA_1
-MHA_DATADIR=/home/odelia/MediSwarm/data
-MHA_SCRATCHDIR=/home/odelia/MediSwarm/data/MHA_1/tmp
-MHA_DEPLOY_DIR=/home/odelia/Odelia
+MHA_DATADIR=/path/to/data
+MHA_SCRATCHDIR=/path/to/data/MHA_1/tmp
+MHA_DEPLOY_DIR=/path/to/deploy
 MHA_GPU="device=0"
 
 # ── Site: RSH ──────────────────────────────────────────────────────
-RSH_HOST=172.24.4.71
-RSH_USER=asoro
+RSH_HOST=100.100.100.171
+RSH_USER=REDACTED
 RSH_PASS='CHANGEME'
 RSH_SITE_NAME=RSH_1
-RSH_DATADIR=/home/asoro/odelia/RSH/
-RSH_SCRATCHDIR=/home/asoro/odelia/RSH/scratch/
-RSH_DEPLOY_DIR=/home/asoro/Odelia
+RSH_DATADIR=/path/to/data/RSH/
+RSH_SCRATCHDIR=/path/to/data/RSH/scratch/
+RSH_DEPLOY_DIR=/path/to/deploy
 RSH_GPU="device=0"
 
 # ── Site: DL0 (Duke Benchmark) ────────────────────────────────────

--- a/deploy_sites_duke_iid_2client.local.conf.example
+++ b/deploy_sites_duke_iid_2client.local.conf.example
@@ -27,10 +27,10 @@ COSMOS_USER=swarm
 # auto-detect via `tailscale ip -4` (the Tailscale IP the dl nodes route to).
 # Only set it if auto-detection is wrong — and it MUST be an address the clients
 # can actually reach (the Tailscale IP, NOT a GoodAccess/other-subnet address).
-#SERVER_HOST_IP=100.100.101.100
+#SERVER_HOST_IP=100.100.100.100
 
 # dl0: node_A
-DL0_HOST=100.64.4.100
+DL0_HOST=100.100.100.101
 DL0_USER=swarm
 DL0_SITE_NAME=node_A
 DL0_DATADIR=/mnt/dlhd0/DUKE_iid
@@ -41,7 +41,7 @@ DL0_DEPLOY_DIR=/home/swarm/deploy_test_duke_iid_2client
 DL0_GPU="device=0"
 
 # dl2: node_B
-DL2_HOST=100.64.4.102
+DL2_HOST=100.100.100.102
 DL2_USER=swarm
 DL2_SITE_NAME=node_B
 DL2_DATADIR=/mnt/sda1/DUKE_iid

--- a/deploy_sites_rsh_mha.local.conf.example
+++ b/deploy_sites_rsh_mha.local.conf.example
@@ -5,26 +5,26 @@ CLIENT_SITES=(RSH MHA)
 
 COSMOS_DEPLOY_DIR=/home/jeff/deploy_test
 # Optional override when clients cannot reach the automatically selected Cosmos IP.
-# COSMOS_HOST_IP=172.24.4.65
+# COSMOS_HOST_IP=100.100.100.165
 SERVER_NAME=dl3.tud.de
 ADMIN_USER=jiefu.zhu@tu-dresden.de
 
-RSH_HOST=172.24.4.71
-RSH_USER=asoro
+RSH_HOST=100.100.100.171
+RSH_USER=REDACTED
 RSH_PASS_ENV=RSH_PASS
 RSH_SITE_NAME=RSH_1
-RSH_DATADIR=/home/asoro/JULIA_ITERATION/odelia_breast_mri/odelia/RSH
-RSH_SCRATCHDIR=/home/asoro/JULIA_ITERATION/odelia_breast_mri/odelia/RSH/scratch
-RSH_DEPLOY_DIR=/home/asoro/mediswarm_warm_continue
+RSH_DATADIR=/path/to/data/RSH
+RSH_SCRATCHDIR=/path/to/data/RSH/scratch
+RSH_DEPLOY_DIR=/path/to/deploy
 RSH_GPU="device=0"
 
-MHA_HOST=172.24.4.91
-MHA_USER=odelia
+MHA_HOST=100.100.100.191
+MHA_USER=REDACTED
 MHA_PASS_ENV=MHA_PASS
 MHA_SITE_NAME=MHA_1
-MHA_DATADIR=/home/odelia/MediSwarm/data
-MHA_SCRATCHDIR=/home/odelia/MediSwarm/data/MHA_1/tmp
-MHA_DEPLOY_DIR=/home/odelia/mediswarm_warm_continue
+MHA_DATADIR=/path/to/data
+MHA_SCRATCHDIR=/path/to/data/MHA_1/tmp
+MHA_DEPLOY_DIR=/path/to/deploy
 MHA_GPU="device=0"
 
 EVAL_SITE_NAME=UKA_1

--- a/kit_live_sync/sync.conf.example
+++ b/kit_live_sync/sync.conf.example
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REMOTE_HOST="172.24.4.65"
+REMOTE_HOST="100.100.100.165"
 REMOTE_USER="mediswarm-upload"
 REMOTE_BASE="/srv/mediswarm/live"
 

--- a/scripts/collect_swarm_globals.sh
+++ b/scripts/collect_swarm_globals.sh
@@ -12,7 +12,7 @@
 # Sites are read from a config file (default: ./swarm_sites.conf), one per line:
 #     <SITE_NAME> <SSH_HOST> [<CLIENT_CONTAINER_NAME>]
 # e.g.:
-#     UKA   swarm@172.24.4.79   odelia_swarm_client_UKA_1
+#     UKA   swarm@<SITE_IP>     odelia_swarm_client_UKA_1
 # SSH auth uses your ssh config / agent (no credentials are stored here).
 # If <CLIENT_CONTAINER_NAME> is omitted, the first container matching 'client'
 # is used. Prefix the ssh command with sudo on the remote via your ssh config if

--- a/server_tools/README.md
+++ b/server_tools/README.md
@@ -11,7 +11,7 @@ cp server_tools/app.py /srv/mediswarm/app.py
 /srv/mediswarm/venv/bin/uvicorn app:app --app-dir /srv/mediswarm --host 0.0.0.0 --port 8080
 
 Then open:
-http://172.24.4.65:8080/
+http://<SERVER_IP>:8080/
 
 # Detailed version: MediSwarm Live Monitor: installation and usage
 
@@ -168,7 +168,7 @@ Start the FastAPI server with:
 If it starts successfully, open:
 
 ```text
-http://172.24.4.65:8080/
+http://<SERVER_IP>:8080/
 ```
 
 If you are testing on the server itself, you can also open:
@@ -334,7 +334,7 @@ sudo ufw allow 8080/tcp
 Then verify from another machine:
 
 ```bash
-curl http://172.24.4.65:8080/
+curl http://<SERVER_IP>:8080/
 ```
 
 ---
@@ -410,5 +410,5 @@ pip install fastapi uvicorn
 Then open:
 
 ```text
-http://172.24.4.65:8080/
+http://<SERVER_IP>:8080/
 ```


### PR DESCRIPTION
Follow-up to the go-public work (#e2bf29a), which moved *"infra target maps (site VPN IP / SSH user / on-disk data paths)"* off the public tree but **missed several files**. This repository is public, so these were readable by anyone.

## Removed
| File | What was exposed |
|---|---|
| `deploy_sites.conf.example`, `deploy_sites_rsh_mha.local.conf.example` | Real ODELIA site VPN addresses, a **third-party SSH username**, and that person's on-disk data and deploy paths |
| `deploy_sites_duke_iid_2client.local.conf.example` | Real Tailscale addresses of the orchestrator and two dl nodes |
| `kit_live_sync/sync.conf.example` | The **live-sync ingest server address** — where every site uploads its training artifacts |
| `project_DECADE_allsites.yml`, `scripts/collect_swarm_globals.sh`, `server_tools/README.md` | Addresses in comments and docs |
| `deploy_and_test.sh` | Monitor URL is now `MEDISWARM_MONITOR_URL`-overridable, printing a placeholder by default |

Follows the style already used in `scripts/deploy/distribute_data.conf.example`: fabricated `100.100.100.x` addresses and `REDACTED` usernames. These are `.example` templates, so **nothing that runs is affected**; the provisioning file's functional `sp_end_point` uses the hostname and is unchanged.

## Deliberately NOT changed
`scripts/client_node_setup/vpn_health_monitor.sh` keeps `172.24.4.1` as the `VPN_GATEWAY` default. It is a **functional default that deployed partner monitors rely on**, already overridable via the environment. Replacing it would break health monitoring at sites, to hide a private, non-routable gateway address — a bad trade.

## Scope limit worth stating
This only cleans the **current tree**. The 30 docs removed by `e2bf29a` — including partner correspondence naming individuals, and 4 partner email addresses in the site registry — remain retrievable from git history, per the explicit go-public decision not to rewrite `main`. Changing that means a history rewrite, which breaks every clone and fork, so it is left as a separate decision.

Full suite: **359 passed, 7 skipped**. Shell syntax checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)