### PR TITLE
fix(stamp): install the pinned tag from a tarball, not a git clone

### DIFF
--- a/docker_config/Dockerfile_STAMP
+++ b/docker_config/Dockerfile_STAMP
@@ -54,8 +54,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # NVFlare fork declares support only through 3.12. Sites extract features with
 # STAMP 2.5.0; the patch below lets this loader read them (the H5 layout and the
 # UNI extractor are identical between 2.4.0 and 2.5.0).
+#
+# Fetched as a release tarball rather than "git+https://...@2.4.0" on purpose.
+# The git form makes pip shell out to `git clone`; when GitHub throttles that
+# unauthenticated request it returns a non-protocol response, git then falls
+# back to asking for a username and dies under no tty with the misleading
+# "could not read Username for 'https://github.com'" -- which reads as a
+# permission problem but is rate limiting. It broke validate-swarm on several
+# unrelated PRs. A tarball is a plain HTTPS GET with no credential path.
 RUN python3 -m pip install --no-cache-dir \
-    "stamp @ git+https://github.com/KatherLab/STAMP.git@2.4.0"
+    "stamp @ https://github.com/KatherLab/STAMP/archive/refs/tags/2.4.0.tar.gz"
 
 # Raise STAMP's *readable* feature-extraction version ceiling to 2.5.0 so that
 # features extracted by STAMP 2.5.0 load here. Fails the build loudly if the


### PR DESCRIPTION
Fixes the `validate-swarm` failures that have hit several unrelated PRs (#518, `fix/503-total-rounds-single-source`) at the STAMP install layer.

## What is happening

`docker_config/Dockerfile_STAMP` installed STAMP as a git requirement:

```dockerfile
"stamp @ git+https://github.com/KatherLab/STAMP.git@2.4.0"
```

pip shells out to `git clone`. When GitHub throttles that unauthenticated request it returns a non-protocol response, git falls back to prompting for credentials, and the build dies with no tty:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

It reads as a permission problem. It is not — `KatherLab/STAMP` is public, returns HTTP 200 unauthenticated, and `git ls-remote` for tag 2.4.0 succeeds from cosmos and from both dl0 and dl2. The `expected flush after ref listing` line is the actual signal: rate limiting, not authorization.

The same failure hit branches touching neither Dockerfile, which is what rules out any individual PR as the cause.

## The change

Fetch the pinned tag as a release tarball — plain HTTPS, no git subprocess, no credential path:

```dockerfile
"stamp @ https://github.com/KatherLab/STAMP/archive/refs/tags/2.4.0.tar.gz"
```

The pin stays at 2.4.0 and the surrounding rationale comment is unchanged.

## Verification

Run in the real base image (`pytorch/pytorch:2.7.1-cuda12.6-cudnn9-runtime`, Python 3.11.13):

- pip resolves and installs `stamp 2.4.0` with its full dependency set.
- `patch_stamp_feature_version_gate.py` still finds and patches its upstream guard:
  `[patch_stamp] patched .../stamp/modeling/data.py: readable extraction version ceiling raised to 2.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)