### PR TITLE
feat(metrics): publish per-site metrics with class support (#525, #441)

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -51,6 +51,13 @@ jobs:
           # fold validation). Without them pytest silently SKIPS those files, which is
           # how a broken guard test reached main (#416/#423).
           pip install torchio pandas
+          # The NVFlare fork gates the server-side metric collector tests
+          # (test_per_site_metrics.py). Same trap as torchio/pandas above: without
+          # it pytest SKIPS the file and the job still reports green, which is how
+          # an empty cross_val_results.json survived two live 8-site runs (#525).
+          # Installed from the in-tree fork so CI tests the same NVFlare the image
+          # ships, not whatever PyPI currently calls 'nvflare'.
+          pip install ./docker_config/NVFlare
 
       - name: Run unit tests
         run: |

--- a/application/jobs/ODELIA_ternary_classification/app/config/config_fed_server.conf
+++ b/application/jobs/ODELIA_ternary_classification/app/config/config_fed_server.conf
@@ -8,6 +8,14 @@ components = [
     path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
     args {}
   }
+  {
+    # Collect the per-site metrics clients already stream (fed.analytix_log_stats)
+    # and hand them to json_generator at end of run, so cross_val_results.json is
+    # populated instead of {}. See #525 and docs/EVALUATION_PITFALLS.md (E1).
+    id = "per_site_metrics"
+    path = "per_site_metrics.PerSiteMetricCollector"
+    args {}
+  }
 ]
 workflows = [
   {

--- a/application/jobs/_shared/custom/models/base_model.py
+++ b/application/jobs/_shared/custom/models/base_model.py
@@ -198,6 +198,15 @@ class BasicClassifier(BasicModel):
             for state in EXTENDED_METRIC_STATES
         })
 
+        # Ground-truth label counts per class, reset each epoch alongside the
+        # metrics. A per-class metric reported without its support invites the
+        # reader to compare numbers that are not comparable -- an AUROC over two
+        # positives is noise, but it looks like a score. See
+        # docs/EVALUATION_PITFALLS.md (E1). Plain ints, so there is no device to
+        # manage and no cost worth measuring.
+        self.num_classes = out_ch
+        self._support = {state: [0] * out_ch for state in ["train_", "val_", "test_"]}
+
     def _build_extended_metrics(self, num_classes, state):
         """Metrics beyond ACC/AUROC. All accept raw logits (torchmetrics softmaxes)."""
         kwargs = {"task": "multiclass", "num_classes": num_classes}
@@ -235,6 +244,15 @@ class BasicClassifier(BasicModel):
             f"{state}/ACC": self.acc[key].compute(),
             f"{state}/AUC_ROC": self.auc_roc[key].compute(),
         }
+        # Emitted before the early return below, so support travels with the
+        # metrics whether or not the extended tier is enabled.
+        counts = self._support.get(key)
+        if counts is not None:
+            # 0-dim tensors, matching every other value in this dict so callers
+            # can treat the mapping uniformly (Lightning logs them either way).
+            for index, count in enumerate(counts):
+                values[f"{state}/support_class{index}"] = torch.tensor(float(count))
+            values[f"{state}/n"] = torch.tensor(float(sum(counts)))
         if key not in self.extra_metrics:
             return values
         for name, metric in self.extra_metrics[key].items():
@@ -266,9 +284,24 @@ class BasicClassifier(BasicModel):
         if state + "_" in self.extra_metrics:
             for metric in self.extra_metrics[state + "_"].values():
                 metric.update(pred, target_squeezed)
+        self._update_support(state, target_squeezed)
 
         self.log(f"{state}/loss", loss_val, batch_size=batch_size, on_step=True, on_epoch=True)
         return loss_val
+
+    def _update_support(self, state, target_squeezed):
+        """Count ground-truth labels seen this epoch, per class.
+
+        Pure bookkeeping -- no gradients, no device transfer beyond the labels
+        already on hand.
+        """
+        counts = self._support.get(state + "_")
+        if counts is None:
+            return
+        for label in target_squeezed.detach().flatten().tolist():
+            index = int(label)
+            if 0 <= index < len(counts):
+                counts[index] += 1
 
     def _epoch_end(self, state):
         metric_values = self.compute_epoch_metrics(state)
@@ -286,6 +319,7 @@ class BasicClassifier(BasicModel):
         if state + "_" in self.extra_metrics:
             for metric in self.extra_metrics[state + "_"].values():
                 metric.reset()
+        self._support[state + "_"] = [0] * self.num_classes
 
     def compute_loss(self, pred, target):
         target_squeezed = torch.squeeze(target, 1)  # TODO Why is this necessary and is it the right thing to do?

--- a/application/jobs/_shared/custom/per_site_metrics.py
+++ b/application/jobs/_shared/custom/per_site_metrics.py
@@ -60,8 +60,27 @@ class PerSiteMetricCollector(AnalyticsReceiver):
         with self._lock:
             self._metrics = {}
 
+    @staticmethod
+    def _as_scalar(value):
+        """Coerce a streamed value to a plain number, or None if it is not one."""
+        if hasattr(value, "item"):          # torch / numpy scalar
+            try:
+                value = value.item()
+            except Exception:
+                return None
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return value
+
     def save(self, fl_ctx: FLContext, shareable: Shareable, record_origin: str):
-        """Record one streamed metric for ``record_origin``.
+        """Record streamed metrics for ``record_origin``.
+
+        Two payload shapes arrive, depending on which writer the training side
+        uses. ``MLflowWriter.log_metrics`` -- what ``ClientLogger`` calls, and so
+        what the Lightning path produces -- sends a whole dict under the single
+        tag ``"metrics"``; ``log_metric`` and ``SummaryWriter`` send one scalar
+        per record. Both are handled, because dropping the batch shape would
+        silently discard everything the Lightning trainer reports.
 
         Later values for the same key overwrite earlier ones, so what is
         published is each site's final value rather than its first.
@@ -72,21 +91,27 @@ class PerSiteMetricCollector(AnalyticsReceiver):
             # A malformed record from one site must not take down the run.
             self.log_warning(fl_ctx, f"Unparseable metric from {record_origin}: {exc}", fire_event=False)
             return
-        if not data or not data.tag or not str(data.tag).startswith(self._prefixes):
+        if not data:
             return
 
-        value = data.value
-        if hasattr(value, "item"):          # torch/np scalar
-            try:
-                value = value.item()
-            except Exception:
-                return
-        if not isinstance(value, (int, float, bool)):
+        if isinstance(data.value, dict):
+            incoming = {
+                str(k): self._as_scalar(v)
+                for k, v in data.value.items()
+                if str(k).startswith(self._prefixes)
+            }
+            incoming = {k: v for k, v in incoming.items() if v is not None}
+        else:
+            tag = str(data.tag or "")
+            value = self._as_scalar(data.value)
+            incoming = {tag: value} if tag.startswith(self._prefixes) and value is not None else {}
+
+        if not incoming:
             return
 
         with self._lock:
             site = self._metrics.setdefault(record_origin, {})
-            site[str(data.tag)] = value
+            site.update(incoming)
             if data.step is not None:
                 site["_last_step"] = data.step
 

--- a/application/jobs/_shared/custom/per_site_metrics.py
+++ b/application/jobs/_shared/custom/per_site_metrics.py
@@ -28,6 +28,7 @@ from threading import Lock
 
 from nvflare.apis.analytix import AnalyticsData
 from nvflare.apis.dxo import DXO, DataKind, from_shareable
+from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 from nvflare.app_common.app_constant import AppConstants
@@ -54,11 +55,34 @@ class PerSiteMetricCollector(AnalyticsReceiver):
         self._model_owner = model_owner
         self._prefixes = tuple(metric_prefixes or ("val/", "test/"))
         self._metrics = {}
+        self._published = False
         self._lock = Lock()
 
     def initialize(self, fl_ctx: FLContext):
         with self._lock:
             self._metrics = {}
+            self._published = False
+
+    def handle_event(self, event_type: str, fl_ctx: FLContext):
+        """Publish on ABOUT_TO_END_RUN rather than waiting for END_RUN.
+
+        ``ValidationJsonGenerator`` dumps ``cross_val_results.json`` inside its own
+        ``END_RUN`` handler, and within one event the components run in the order
+        they are listed in ``config_fed_server.conf``. Publishing on ``END_RUN``
+        therefore only works when this collector happens to be listed first: with
+        the generator first, the file is written empty and the metrics land in its
+        dict a moment too late. That is exactly what job 7c6e72c6 did -- all eight
+        sites reported, and the JSON was still ``{}``.
+
+        ``ABOUT_TO_END_RUN`` is fired strictly before ``END_RUN``, so publishing
+        there removes the dependency on component order. ``END_RUN`` is still
+        handled as a fallback for any path that skips the earlier event;
+        ``finalize`` is idempotent, so the second pass is a no-op.
+        """
+        if event_type == EventType.ABOUT_TO_END_RUN:
+            self._handle_end_run_event(fl_ctx)
+            return
+        super().handle_event(event_type, fl_ctx)
 
     @staticmethod
     def _as_scalar(value):
@@ -122,6 +146,10 @@ class PerSiteMetricCollector(AnalyticsReceiver):
         ``cross_site_val/cross_val_results.json`` as
         ``{site: {model_owner: metrics}}``.
         """
+        if self._published:
+            return
+        self._published = True
+
         with self._lock:
             collected = {site: dict(values) for site, values in self._metrics.items()}
 

--- a/application/jobs/_shared/custom/per_site_metrics.py
+++ b/application/jobs/_shared/custom/per_site_metrics.py
@@ -1,0 +1,126 @@
+"""Collect per-site training metrics on the coordinator (#525, #441).
+
+Why this exists
+---------------
+Clients already stream their metrics server-ward: ``MetricRelay`` fires
+``fed.analytix_log_stats``, ``ClientFedEventRunner`` relays it, and
+``ServerFedEventRunner`` delivers it to server handlers. Nothing on the server
+ever handled it, so ``cross_site_val/cross_val_results.json`` came back ``{}``
+after every peer-to-peer run -- on the two-day 20-round run and on a 52-second
+smoke run alike -- and per-site figures had to be gathered by logging into
+individual hospitals by hand.
+
+This receiver closes that last hop. It accumulates the streamed metrics per
+site and, at end of run, hands them to the already-configured
+``ValidationJsonGenerator`` by firing ``VALIDATION_RESULT_RECEIVED``. No client
+change and no new transport are needed.
+
+Reporting shape
+---------------
+Metrics are recorded with the support counts emitted alongside them by
+``BaseModel.compute_epoch_metrics`` (``*/support_class{i}`` and ``*/n``). A
+per-class metric must never travel without its support: ranking centres by a
+bare macro AUROC, where one class had two positives, is what produced a wrong
+conclusion about UMCU. See ``docs/EVALUATION_PITFALLS.md`` (E1).
+"""
+
+from threading import Lock
+
+from nvflare.apis.analytix import AnalyticsData
+from nvflare.apis.dxo import DXO, DataKind, from_shareable
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.widgets.streaming import AnalyticsReceiver
+
+GLOBAL_MODEL_OWNER = "swarm_global"
+
+
+class PerSiteMetricCollector(AnalyticsReceiver):
+    """Accumulate streamed per-site metrics and publish them at end of run.
+
+    Args:
+        model_owner: label recorded as the owner of the evaluated model. In a
+            swarm every site evaluates the shared model on its own data, so the
+            default is a single global label rather than a peer's name.
+        metric_prefixes: only metrics whose key starts with one of these are
+            kept. Defaults to validation and test; training-time noise is
+            dropped so the published summary stays readable.
+    """
+
+    def __init__(self, model_owner: str = GLOBAL_MODEL_OWNER, metric_prefixes=None):
+        super().__init__()
+        self._model_owner = model_owner
+        self._prefixes = tuple(metric_prefixes or ("val/", "test/"))
+        self._metrics = {}
+        self._lock = Lock()
+
+    def initialize(self, fl_ctx: FLContext):
+        with self._lock:
+            self._metrics = {}
+
+    def save(self, fl_ctx: FLContext, shareable: Shareable, record_origin: str):
+        """Record one streamed metric for ``record_origin``.
+
+        Later values for the same key overwrite earlier ones, so what is
+        published is each site's final value rather than its first.
+        """
+        try:
+            data = AnalyticsData.from_dxo(from_shareable(shareable))
+        except Exception as exc:
+            # A malformed record from one site must not take down the run.
+            self.log_warning(fl_ctx, f"Unparseable metric from {record_origin}: {exc}", fire_event=False)
+            return
+        if not data or not data.tag or not str(data.tag).startswith(self._prefixes):
+            return
+
+        value = data.value
+        if hasattr(value, "item"):          # torch/np scalar
+            try:
+                value = value.item()
+            except Exception:
+                return
+        if not isinstance(value, (int, float, bool)):
+            return
+
+        with self._lock:
+            site = self._metrics.setdefault(record_origin, {})
+            site[str(data.tag)] = value
+            if data.step is not None:
+                site["_last_step"] = data.step
+
+    def finalize(self, fl_ctx: FLContext):
+        """Publish one validation record per site.
+
+        ``ValidationJsonGenerator`` catches these and writes
+        ``cross_site_val/cross_val_results.json`` as
+        ``{site: {model_owner: metrics}}``.
+        """
+        with self._lock:
+            collected = {site: dict(values) for site, values in self._metrics.items()}
+
+        if not collected:
+            self.log_warning(
+                fl_ctx,
+                "No per-site metrics were received; cross_val_results.json will be empty. "
+                "Check that the clients configure metric_relay with event_type "
+                "'fed.analytix_log_stats'.",
+                fire_event=False,
+            )
+            return
+
+        for site, values in collected.items():
+            dxo = DXO(data_kind=DataKind.METRICS, data=values)
+            fl_ctx.set_prop(AppConstants.MODEL_OWNER, self._model_owner, private=True, sticky=False)
+            fl_ctx.set_prop(AppConstants.DATA_CLIENT, site, private=True, sticky=False)
+            fl_ctx.set_prop(
+                AppConstants.VALIDATION_RESULT, dxo.to_shareable(), private=True, sticky=False
+            )
+            self.fire_event(AppEventType.VALIDATION_RESULT_RECEIVED, fl_ctx)
+
+        self.log_info(
+            fl_ctx,
+            f"Published metrics for {len(collected)} site(s): {', '.join(sorted(collected))}",
+            fire_event=False,
+        )

--- a/application/jobs/_shared/custom/threedcnn_ptl.py
+++ b/application/jobs/_shared/custom/threedcnn_ptl.py
@@ -582,6 +582,26 @@ def prepare_training(logger, max_epochs: int, site_name: str = None,
         # compared to pure SGD updates every sample.
         accumulate_grad_batches = 8
 
+        # Metrics reach the coordinator only if something writes them to
+        # NVFlare's pipe. TensorBoardLogger writes to local disk, which is why
+        # per-site results had to be collected by logging into each hospital by
+        # hand and cross_val_results.json came back empty (#525). ClientLogger
+        # forwards the same self.log() calls through the pipe, where MetricRelay
+        # turns them into fed.analytix_log_stats and PerSiteMetricCollector
+        # publishes them server-side.
+        #
+        # Only meaningful inside a swarm run: outside one there is no client
+        # runtime to write to, so the local TensorBoard logger stands alone.
+        trainer_loggers = [TensorBoardLogger(save_dir=path_run_dir)]
+        if os.environ.get("TRAINING_MODE", "") == "swarm":
+            try:
+                from nvflare.app_opt.lightning.loggers.client_logger import ClientLogger
+                trainer_loggers.append(ClientLogger())
+                logger.info("ClientLogger attached: metrics will stream to the coordinator")
+            except Exception as exc:
+                # A missing metric stream must not stop a training run.
+                logger.warning(f"ClientLogger unavailable, metrics stay local: {exc}")
+
         trainer = Trainer(
             accelerator='gpu',
             accumulate_grad_batches=accumulate_grad_batches,
@@ -594,7 +614,7 @@ def prepare_training(logger, max_epochs: int, site_name: str = None,
             log_every_n_steps=log_every_n_steps,
             max_epochs=max_epochs,
             num_sanity_val_steps=2,
-            logger=TensorBoardLogger(save_dir=path_run_dir)
+            logger=trainer_loggers
         )
 
     except Exception as e:

--- a/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_1DivideAndConquer/app/config/config_fed_server.conf
@@ -8,6 +8,14 @@ components = [
     path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
     args {}
   }
+  {
+    # Collect the per-site metrics clients already stream (fed.analytix_log_stats)
+    # and hand them to json_generator at end of run, so cross_val_results.json is
+    # populated instead of {}. See #525 and docs/EVALUATION_PITFALLS.md (E1).
+    id = "per_site_metrics"
+    path = "per_site_metrics.PerSiteMetricCollector"
+    args {}
+  }
 ]
 workflows = [
   {

--- a/application/jobs/challenge_2BCN_AIM/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_2BCN_AIM/app/config/config_fed_server.conf
@@ -8,6 +8,14 @@ components = [
     path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
     args {}
   }
+  {
+    # Collect the per-site metrics clients already stream (fed.analytix_log_stats)
+    # and hand them to json_generator at end of run, so cross_val_results.json is
+    # populated instead of {}. See #525 and docs/EVALUATION_PITFALLS.md (E1).
+    id = "per_site_metrics"
+    path = "per_site_metrics.PerSiteMetricCollector"
+    args {}
+  }
 ]
 workflows = [
   {

--- a/application/jobs/challenge_3agaldran/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_3agaldran/app/config/config_fed_server.conf
@@ -8,6 +8,14 @@ components = [
     path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
     args {}
   }
+  {
+    # Collect the per-site metrics clients already stream (fed.analytix_log_stats)
+    # and hand them to json_generator at end of run, so cross_val_results.json is
+    # populated instead of {}. See #525 and docs/EVALUATION_PITFALLS.md (E1).
+    id = "per_site_metrics"
+    path = "per_site_metrics.PerSiteMetricCollector"
+    args {}
+  }
 ]
 workflows = [
   {

--- a/application/jobs/challenge_4abmil/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_4abmil/app/config/config_fed_server.conf
@@ -8,6 +8,14 @@ components = [
     path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
     args {}
   }
+  {
+    # Collect the per-site metrics clients already stream (fed.analytix_log_stats)
+    # and hand them to json_generator at end of run, so cross_val_results.json is
+    # populated instead of {}. See #525 and docs/EVALUATION_PITFALLS.md (E1).
+    id = "per_site_metrics"
+    path = "per_site_metrics.PerSiteMetricCollector"
+    args {}
+  }
 ]
 workflows = [
   {

--- a/application/jobs/challenge_5pimed/app/config/config_fed_server.conf
+++ b/application/jobs/challenge_5pimed/app/config/config_fed_server.conf
@@ -8,6 +8,14 @@ components = [
     path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
     args {}
   }
+  {
+    # Collect the per-site metrics clients already stream (fed.analytix_log_stats)
+    # and hand them to json_generator at end of run, so cross_val_results.json is
+    # populated instead of {}. See #525 and docs/EVALUATION_PITFALLS.md (E1).
+    id = "per_site_metrics"
+    path = "per_site_metrics.PerSiteMetricCollector"
+    args {}
+  }
 ]
 workflows = [
   {

--- a/application/jobs/minimal_training_pytorch_cnn/app/config/config_fed_server.conf
+++ b/application/jobs/minimal_training_pytorch_cnn/app/config/config_fed_server.conf
@@ -8,6 +8,14 @@ components = [
     path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
     args {}
   }
+  {
+    # Collect the per-site metrics clients already stream (fed.analytix_log_stats)
+    # and hand them to json_generator at end of run, so cross_val_results.json is
+    # populated instead of {}. See #525 and docs/EVALUATION_PITFALLS.md (E1).
+    id = "per_site_metrics"
+    path = "per_site_metrics.PerSiteMetricCollector"
+    args {}
+  }
 ]
 workflows = [
   {

--- a/application/jobs/minimal_training_pytorch_cnn/app/custom/minimal_training.py
+++ b/application/jobs/minimal_training_pytorch_cnn/app/custom/minimal_training.py
@@ -86,6 +86,18 @@ def prepare_training(logger):
             mode=min_max,
         )
 
+        # Stream metrics to the coordinator as well as to local TensorBoard, so
+        # this smoke job exercises the full metric path (#525) and can verify it
+        # in under a minute instead of a multi-hour ODELIA round.
+        trainer_loggers = [TensorBoardLogger(save_dir=path_run_dir)]
+        if os.environ.get("TRAINING_MODE", "") == "swarm":
+            try:
+                from nvflare.app_opt.lightning.loggers.client_logger import ClientLogger
+                trainer_loggers.append(ClientLogger())
+                logger.info("ClientLogger attached: metrics will stream to the coordinator")
+            except Exception as exc:
+                logger.warning(f"ClientLogger unavailable, metrics stay local: {exc}")
+
         trainer = Trainer(
             accelerator=accelerator,
             precision=16,
@@ -96,7 +108,7 @@ def prepare_training(logger):
             log_every_n_steps=log_every_n_steps,
             max_epochs=2,
             num_sanity_val_steps=2,
-            logger=TensorBoardLogger(save_dir=path_run_dir)
+            logger=trainer_loggers
         )
     except Exception as e:
         logger.error(f"Error in set_up_training: {e}")

--- a/application/jobs/minimal_training_pytorch_cnn/app/custom/per_site_metrics.py
+++ b/application/jobs/minimal_training_pytorch_cnn/app/custom/per_site_metrics.py
@@ -1,0 +1,1 @@
+../../_shared/custom/per_site_metrics.py

--- a/application/jobs/minimal_training_pytorch_cnn/app/custom/per_site_metrics.py
+++ b/application/jobs/minimal_training_pytorch_cnn/app/custom/per_site_metrics.py
@@ -1,1 +1,1 @@
-../../_shared/custom/per_site_metrics.py
+../../../_shared/custom/per_site_metrics.py

--- a/docs/SWARM_FAILURE_MODES.md
+++ b/docs/SWARM_FAILURE_MODES.md
@@ -21,6 +21,7 @@ Most of these are now caught automatically by the pre-run checks in the startup-
 | F7 | `DataLoader worker killed by signal: Bus error … shared memory` | `/dev/shm` too small for the dataloader workers | `--ipc=host` (already set for swarm clients) / `--shm-size` |
 | F8 | Run trains on a **subset**: `clients [...] did not configure within timeout but min_clients=N allows proceeding` | Controller stops waiting once `configure_min_clients` answer; slower sites lose the key exchange | Set `configure_min_clients` **= number of participating sites** |
 | F9 | Site never appears in `check_status server`, container reports `(healthy)` for weeks | Startup kit older than the server's provisioning generation → `ClientConnectorCertificateError` | Re-issue the current startup kit to that site |
+| F10 | `cross_val_results.json` is `{}` although the server logged `Published metrics for N site(s)` | Two components act on the same `END_RUN`; `ValidationJsonGenerator` writes the file before the later-listed collector publishes into it | Publish on `ABOUT_TO_END_RUN`, which is fired strictly earlier (already fixed in `per_site_metrics.py`) |
 
 ---
 
@@ -116,6 +117,36 @@ Most of these are now caught automatically by the pre-run checks in the startup-
   Success looks like `Successfully registered client:<SITE> for project ...` / `Connected to server`.
 - **Prevention:** after every kit roll-out, verify the expected site count in `check_status server` rather than assuming; a silently-stale site can persist for weeks.
 - **Observed 2026-07-31:** `RSH_1` had been looping on `ClientConnectorCertificateError` for **three weeks** on a v1.5.0 kit while reporting `(healthy)`; installing the current kit registered it immediately.
+
+## F10 — Empty `cross_val_results.json` from event ordering
+
+- **Symptom:** every peer-to-peer run leaves `cross_site_val/cross_val_results.json` as `{}` — on a
+  two-day 20-round run and on a 52-second smoke run alike — so per-site figures have to be collected
+  by logging into each hospital by hand.
+- **What makes it deceptive:** the server log says the metrics arrived.
+  ```
+  PerSiteMetricCollector - INFO - Published metrics for 8 site(s):
+      CAM_1, MHA_1, RSH_1, RUMC_1, UKA_1, UMCU_1, USZ_1, VHIO_1
+  ```
+  Every hop works — `ClientLogger` → `MLflowWriter` → metric `CellPipe` → `MetricRelay` →
+  `fed.analytix_log_stats` → `ClientFedEventRunner` → `ServerFedEventRunner` → the collector.
+  Nothing is missing and nothing errors.
+- **Root cause:** ordering *within a single event*. `ValidationJsonGenerator` dumps the JSON in its
+  own `END_RUN` handler; `AnalyticsReceiver.finalize` also runs on `END_RUN`; and
+  `fire_event_to_components` invokes components in the order they are listed in
+  `config_fed_server.conf`. With `json_generator` listed first — as it is in all seven job configs —
+  the file is written and only then does the collector publish into the generator's in-memory dict.
+- **Why it reads as a missing metric:** `ServerRunner` logs `END_RUN fired` *after* the dispatch
+  returns, so the publish line appears ~2 s *before* it in the log. The two look sequential when
+  they are in fact the same event.
+- **Fix:** publish on `EventType.ABOUT_TO_END_RUN`, which is fired strictly before `END_RUN`, so the
+  result does not depend on how a job config happens to be ordered. `END_RUN` remains a fallback;
+  `finalize` is idempotent.
+- **Prevention:** when two components react to the same event and one consumes what the other
+  produces, do not rely on config order — separate them onto different events. And note that CI was
+  green throughout: `pytest.importorskip("nvflare")` skipped the collector's tests entirely because
+  the workflow never installed NVFlare (cf. #416/#423). A skipped test file is not a passing one.
+- **Observed 2026-09-04:** job `7c6e72c6` reported all eight sites and still wrote `{}`.
 
 ## Operator diagnostic playbook
 

--- a/docs/SWARM_FAILURE_MODES.md
+++ b/docs/SWARM_FAILURE_MODES.md
@@ -47,6 +47,33 @@ Most of these are now caught automatically by the pre-run checks in the startup-
 - **Fix:** delete `daemon_pid.fl` in the kit root, then relaunch `./docker.sh --start_client`.
 - **Prevention:** always clear the lock when recreating a client; the pre-run check now does this automatically.
 
+**F3b — a host reboot mid-run triggers this silently, and the run then hangs for a full day.**
+Observed 2026-09-04 on UKA during job `24cdf247`: the node rebooted (`uptime` showed 1:16 while the
+run had started two hours earlier), Docker auto-restarted the client at boot, `start.sh` hit a
+`daemon_pid.fl` dated **five weeks earlier** and refused to launch. The container then sat as
+`Up (healthy)` running only `/bin/bash` -- no FL client, no training process, GPU at 0 %.
+
+Server-side the consequence is worse than the site outage: the swarm logs
+`Client UKA_1 is deemed disconnected!`, the remaining peers wait on a gather that can never
+complete, and with `progress_timeout = 86400` the job stays `RUNNING` for **24 hours** before
+anything fails. The server log simply stops advancing.
+
+- **Detection:** `uptime` on the node; GPU utilisation 0 % with the job still `RUNNING`;
+  `docker exec <client> ps -eo pid,args` showing no `python3 -m nvflare...`; server `log.txt`
+  mtime frozen while job status is still `RUNNING`.
+- **Recovery:** remove `daemon_pid.fl` **and** `pid.fl` from the kit root, relaunch the client
+  (`docker exec -d <client> /bin/bash -c 'cd /startupkit/startup && nohup ./start.sh >> ../nohup.out 2>&1'`
+  restarts it inside the existing container without recreating it), confirm
+  `Successfully registered client:<SITE>`, then abort the wedged job.
+- **Aborting:** `abort_job <job_id>` needs a `y` confirmation -- an automated session that does not
+  send it will appear to hang on the abort itself. Only if the abort genuinely will not take should
+  you kill that job's `runner_process` in the server container (`ps -eo pid,args | grep runner_process`,
+  match the job id, `kill -TERM`); the job then lands as `FINISHED:EXECUTION_EXCEPTION`. This stops
+  one job, not the server.
+- **Worth knowing:** the warm-start mirror is only rewritten when a round completes, so a run killed
+  mid-round leaves the previous global intact. Verified here: the `87c5bbee` mirror was still
+  byte-identical afterwards. See #535 for the mirror's lack of provenance guarding.
+
 ## F4 — Read-only preprocessing-cache path
 - **Symptom:** instant crash `OSError: [Errno 30] Read-only file system: '/data/.../odelia_preprocess_cache'`.
 - **Root cause:** `ODELIA_PREPROCESS_CACHE_DIR` was set under `/data`, which is mounted **read-only** in the container.

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -200,4 +200,9 @@ From the 4-node deploy test with `challenge_1DivideAndConquer` (20 rounds):
 - ~19 min per round (includes training + P2P model exchange)
 - ~380 min total (6.3 hours) for 20 rounds
 - Model size: ~689 MB (3D CNN)
-- Sites: RUMC_1 (22 samples), MHA_1 (~50 samples), CAM_1 (~200 samples), UMCU_1 (~150 samples)
+- Sites (training samples, read from `Weighted epochs` log lines — `len(ds_train)`, batch_size=1):
+  RUMC_1 **3582**, MHA_1 **1120**, CAM_1 **1778**, UMCU_1 **6133**.
+  An earlier revision of this line claimed 22 / ~50 / ~200 / ~150. Those figures were wrong by
+  two orders of magnitude and were quoted into planning for D2.5 (#526) before being caught on
+  2026-09-07. If you need a site's size, read it from its `Weighted epochs` line rather than
+  from a doc — it prints `train_samples=` on every run.

--- a/scripts/evaluation/compare_regional_finetune.py
+++ b/scripts/evaluation/compare_regional_finetune.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Compare a regionally fine-tuned model against the pan-European baseline (D2.5 / T2.4, #526).
+
+Design notes, because the obvious analysis is the wrong one here
+----------------------------------------------------------------
+The regional test partitions carved out of the 8-site run are small, and their
+class support is very uneven:
+
+    Dutch (RUMC + UMCU)   n=49   no-lesion 38   benign  2   malignant 9
+    Greek (MHA)           n=26   no-lesion 18   benign  1   malignant 7
+
+A macro AUROC over three classes therefore averages in a benign one-vs-rest
+figure computed from one or two positive cases. That is not a measurement, and
+ranking by it is exactly what produced the wrong conclusion about UMCU --
+recorded as E1 in ``docs/EVALUATION_PITFALLS.md``. So:
+
+* the **primary endpoint is malignant-vs-rest AUROC**, the clinically decisive
+  discrimination and the only one with usable support in both cohorts;
+* ``lesion-vs-none`` is reported as a secondary;
+* macro AUROC is reported only with per-class support attached, and never as the
+  basis for a claim.
+
+The comparison is **paired**. Both models score the *same* cases, so the
+uncertainty that matters is on the difference, not on each arm separately.
+Resampling cases (not sites) and recomputing the delta each draw gives a CI that
+correctly cancels the shared case-difficulty variance; comparing two independent
+per-arm CIs would be far more conservative and would hide a real effect at these
+sample sizes. Cases are resampled jointly for both models, which is what makes it
+paired.
+
+Usage
+-----
+    compare_regional_finetune.py --baseline <dir> --finetuned <dir> \
+        --sites RUMC_1 UMCU_1 --label "Dutch cohort" [--bootstrap 10000]
+
+Each directory is a per-site tree of ``<SITE>/predictions_*.csv`` with columns
+uid, ground_truth, prediction, prob_class_0..2 -- the layout
+``scripts/evaluation/predict.py`` already writes.
+"""
+
+import argparse
+import csv
+import glob
+import json
+import os
+import random
+from collections import Counter
+
+CLS = {0: "No lesion", 1: "Benign", 2: "Malignant"}
+
+
+def auroc(scores, labels):
+    """One-vs-rest AUROC via the rank statistic. None if either class is absent.
+
+    Same implementation as workspace/eval_87c5bbee/analyze_best.py, kept
+    dependency-free so this runs anywhere the predictions land.
+    """
+    pos = sum(1 for l in labels if l == 1)
+    neg = len(labels) - pos
+    if not pos or not neg:
+        return None
+    order = sorted(range(len(scores)), key=lambda i: scores[i])
+    ranks, i = [0.0] * len(scores), 0
+    while i < len(order):                        # average tied ranks
+        j = i
+        while j + 1 < len(order) and scores[order[j + 1]] == scores[order[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    rsum = sum(r for r, l in zip(ranks, labels) if l == 1)
+    return (rsum - pos * (pos + 1) / 2.0) / (pos * neg)
+
+
+def load(base, sites):
+    """Load per-case rows for the given sites, keyed by uid."""
+    rows = {}
+    for site in sites:
+        pattern = os.path.join(base, site, "predictions_*.csv")
+        for f in glob.glob(pattern):
+            with open(f) as fh:
+                for r in csv.DictReader(fh):
+                    r["_site"] = site
+                    rows[r["uid"]] = r
+    return rows
+
+
+def _scores(rows, uids, kind):
+    if kind == "malignant_vs_rest":
+        return [float(rows[u]["prob_class_2"]) for u in uids]
+    if kind == "lesion_vs_none":
+        return [float(rows[u]["prob_class_1"]) + float(rows[u]["prob_class_2"]) for u in uids]
+    raise ValueError(kind)
+
+
+def _labels(rows, uids, kind):
+    gt = [int(float(rows[u]["ground_truth"])) for u in uids]
+    if kind == "malignant_vs_rest":
+        return [1 if g == 2 else 0 for g in gt]
+    return [1 if g in (1, 2) else 0 for g in gt]
+
+
+def paired_bootstrap(base_rows, fine_rows, uids, kind, draws, seed=0):
+    """Bootstrap the *difference* in AUROC over jointly resampled cases.
+
+    Returns (delta_point, lo, hi, frac_favouring_finetuned). Draws in which
+    either arm is undefined (a resample with no positives or no negatives) are
+    skipped rather than counted as zero -- counting them would drag the interval
+    toward no-effect for reasons that have nothing to do with the models.
+    """
+    rng = random.Random(seed)
+    b_lab = _labels(base_rows, uids, kind)
+    a0 = auroc(_scores(base_rows, uids, kind), b_lab)
+    a1 = auroc(_scores(fine_rows, uids, kind), _labels(fine_rows, uids, kind))
+    if a0 is None or a1 is None:
+        return None, None, None, None
+    point = a1 - a0
+
+    deltas = []
+    n = len(uids)
+    for _ in range(draws):
+        pick = [uids[rng.randrange(n)] for _ in range(n)]
+        d0 = auroc(_scores(base_rows, pick, kind), _labels(base_rows, pick, kind))
+        d1 = auroc(_scores(fine_rows, pick, kind), _labels(fine_rows, pick, kind))
+        if d0 is None or d1 is None:
+            continue
+        deltas.append(d1 - d0)
+    if not deltas:
+        return point, None, None, None
+    deltas.sort()
+    lo = deltas[int(0.025 * len(deltas))]
+    hi = deltas[min(len(deltas) - 1, int(0.975 * len(deltas)))]
+    favour = sum(1 for d in deltas if d > 0) / len(deltas)
+    return point, lo, hi, favour
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--baseline", required=True, help="per-site predictions dir, pan-European model")
+    ap.add_argument("--finetuned", required=True, help="per-site predictions dir, fine-tuned model")
+    ap.add_argument("--sites", required=True, nargs="+", help="sites forming the regional cohort")
+    ap.add_argument("--label", default="cohort", help="cohort name for the report")
+    ap.add_argument("--bootstrap", type=int, default=10000)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+
+    base_rows = load(args.baseline, args.sites)
+    fine_rows = load(args.finetuned, args.sites)
+    uids = sorted(set(base_rows) & set(fine_rows))
+    if not uids:
+        raise SystemExit("no overlapping cases between the two prediction sets")
+
+    # A silently reduced overlap would compare the models on different cases.
+    missing = (set(base_rows) | set(fine_rows)) - set(uids)
+    gt = [int(float(base_rows[u]["ground_truth"])) for u in uids]
+    support = {CLS[k]: v for k, v in sorted(Counter(gt).items())}
+
+    print(f"\n{args.label} — {', '.join(args.sites)}")
+    print(f"  paired cases: {len(uids)}"
+          + (f"   (WARNING: {len(missing)} case(s) present in only one set, excluded)" if missing else ""))
+    print(f"  support: " + ", ".join(f"{k} {v}" for k, v in support.items()))
+
+    report = {"label": args.label, "sites": args.sites, "n_paired": len(uids),
+              "n_excluded": len(missing), "support": support, "endpoints": {}}
+
+    for kind, role in (("malignant_vs_rest", "PRIMARY"), ("lesion_vs_none", "secondary")):
+        b = auroc(_scores(base_rows, uids, kind), _labels(base_rows, uids, kind))
+        f = auroc(_scores(fine_rows, uids, kind), _labels(fine_rows, uids, kind))
+        d, lo, hi, favour = paired_bootstrap(base_rows, fine_rows, uids, kind,
+                                             args.bootstrap, args.seed)
+        npos = sum(_labels(base_rows, uids, kind))
+        print(f"\n  [{role}] {kind}   (positives {npos} / negatives {len(uids)-npos})")
+        if b is None or f is None:
+            print("    undefined: a class is absent from this cohort")
+            report["endpoints"][kind] = {"undefined": True}
+            continue
+        print(f"    pan-European : {b:.3f}")
+        print(f"    fine-tuned   : {f:.3f}")
+        if lo is None:
+            print(f"    delta        : {d:+.3f}  (CI unavailable)")
+        else:
+            print(f"    delta        : {d:+.3f}   95% CI [{lo:+.3f}, {hi:+.3f}]"
+                  f"   favours fine-tuned in {favour:.0%} of draws")
+            if lo < 0 < hi:
+                print("    -> interval spans zero: no difference detectable at this sample size.")
+        report["endpoints"][kind] = {"baseline": b, "finetuned": f, "delta": d,
+                                     "ci_low": lo, "ci_high": hi, "favour_finetuned": favour,
+                                     "n_pos": npos, "n_neg": len(uids) - npos}
+
+    print("\n  Macro AUROC is deliberately not reported as a ranking metric for these")
+    print("  cohorts: benign support is 1-2 cases. See docs/EVALUATION_PITFALLS.md (E1).\n")
+
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump(report, fh, indent=2)
+        print(f"  wrote {args.json_out}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/test_base_model_metrics.py
+++ b/tests/unit_tests/test_base_model_metrics.py
@@ -44,7 +44,15 @@ def base_model():
 
 
 def _make(base_model, monkeypatch, **env):
-    """Build a classifier with a clean, explicitly-set environment."""
+    """Build a classifier with a clean, explicitly-set environment.
+
+    Seeded because BootStrapper resamples: with only six samples a resample can
+    contain a single class, and AUROC then raises "No samples to concatenate".
+    Whether that happens depended on how much RNG earlier tests had consumed, so
+    the bootstrap test passed alone and failed about 1 run in 20 as part of the
+    file. Seeding here makes every test in this module independent of run order.
+    """
+    torch.manual_seed(0)
     for key in ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
     for key, value in env.items():

--- a/tests/unit_tests/test_base_model_metrics.py
+++ b/tests/unit_tests/test_base_model_metrics.py
@@ -59,6 +59,7 @@ def _feed(model, state):
     if key in model.extra_metrics:
         for metric in model.extra_metrics[key].values():
             metric.update(LOGITS, TARGETS)
+    model._update_support(state, TARGETS)
     return model.compute_epoch_metrics(state)
 
 
@@ -77,7 +78,10 @@ def test_default_tier_keeps_compat_keys_and_adds_macro_scalars(base_model, monke
 
 def test_default_tier_excludes_per_class_calibration_and_ci(base_model, monkeypatch):
     values = _feed(_make(base_model, monkeypatch), "val")
-    assert not any("_class" in k for k in values)
+    # Support counts are per-class at every tier on purpose -- a per-class metric
+    # must never be read without its n (docs/EVALUATION_PITFALLS.md, E1). The
+    # tier gate is about per-class *metrics*.
+    assert not any("_class" in k and not k.startswith("val/support") for k in values)
     assert "val/ECE" not in values
     assert not any(k.endswith(("_ci_low", "_ci_high")) for k in values)
 
@@ -87,7 +91,8 @@ def test_train_state_has_no_extended_metrics(base_model, monkeypatch):
     model = _make(base_model, monkeypatch)
     assert "train_" not in model.extra_metrics
     values = _feed(model, "train")
-    assert set(values) == {"train/ACC", "train/AUC_ROC"}
+    support = {f"train/support_class{i}" for i in range(NUM_CLASSES)} | {"train/n"}
+    assert set(values) == {"train/ACC", "train/AUC_ROC"} | support
 
 
 def test_full_tier_adds_per_class_and_calibration(base_model, monkeypatch):
@@ -120,3 +125,83 @@ def test_bootstrap_off_by_default(base_model, monkeypatch):
     model = _make(base_model, monkeypatch)
     assert model.eval_bootstrap is False
     assert not any("boot" in name for name in model.extra_metrics["test_"])
+
+
+def _logits_for(labels, num_classes=NUM_CLASSES):
+    """Confident, correct logits for each label -- metric values are not the
+    point in these tests, only that `compute()` has state to work from."""
+    valid = [int(x) for x in labels.tolist() if 0 <= int(x) < num_classes]
+    out = torch.zeros(len(valid), num_classes)
+    for row, label in enumerate(valid):
+        out[row][label] = 3.0
+    return out, torch.tensor(valid)
+
+
+def _feed_labels(model, state, labels):
+    """Update every metric and the support counter, then compute.
+
+    Labels outside [0, num_classes) are passed to the support counter (which
+    must ignore them) but withheld from torchmetrics, which would raise.
+    """
+    key = state + "_"
+    logits, valid = _logits_for(labels)
+    model.acc[key].update(logits, valid)
+    model.auc_roc[key].update(logits, valid)
+    if key in model.extra_metrics:
+        for metric in model.extra_metrics[key].values():
+            metric.update(logits, valid)
+    model._update_support(state, labels)
+    return model.compute_epoch_metrics(state)
+
+
+
+# --- support counts (#441) -------------------------------------------------
+# A per-class metric read without its support is what produced a wrong
+# conclusion about UMCU: macro AUROC ranked centres by how many benign cases
+# their split happened to hold (0, 1, 2, 2, 12), not by performance.
+# See docs/EVALUATION_PITFALLS.md (E1).
+
+def test_support_counts_are_emitted_at_every_tier(base_model, monkeypatch):
+    for env in ({}, {"ODELIA_EVAL_METRICS": "full"}):
+        values = _feed(_make(base_model, monkeypatch, **env), "val")
+        for index in range(NUM_CLASSES):
+            assert f"val/support_class{index}" in values, f"missing support at tier {env}"
+        assert "val/n" in values
+
+
+def test_support_counts_match_the_labels_seen(base_model, monkeypatch):
+    values = _feed(_make(base_model, monkeypatch), "val")
+    # TARGETS is [0, 1, 2, 0, 1, 2] -> two of each class, six in total
+    for index in range(NUM_CLASSES):
+        assert values[f"val/support_class{index}"].item() == pytest.approx(2.0)
+    assert values["val/n"].item() == pytest.approx(6.0)
+
+
+def test_support_counts_are_scalar_tensors_like_every_other_value(base_model, monkeypatch):
+    values = _feed(_make(base_model, monkeypatch, ODELIA_EVAL_METRICS="full"), "val")
+    assert all(v.ndim == 0 for v in values.values())
+
+
+def test_support_reflects_imbalance_not_just_totals(base_model, monkeypatch):
+    """The case that matters: one class barely represented."""
+    model = _make(base_model, monkeypatch)
+    values = _feed_labels(model, "val", torch.tensor([0, 0, 0, 0, 0, 1, 2, 2]))
+    assert values["val/support_class0"].item() == pytest.approx(5.0)
+    assert values["val/support_class1"].item() == pytest.approx(1.0)
+    assert values["val/support_class2"].item() == pytest.approx(2.0)
+    assert values["val/n"].item() == pytest.approx(8.0)
+
+
+def test_support_resets_between_epochs(base_model, monkeypatch):
+    """Counts must not accumulate across epochs, or n grows without bound."""
+    model = _make(base_model, monkeypatch)
+    model._update_support("val", TARGETS)
+    model._support["val_"] = [0] * model.num_classes      # what _epoch_end does
+    values = _feed_labels(model, "val", TARGETS)
+    assert values["val/n"].item() == pytest.approx(6.0)
+
+
+def test_support_ignores_out_of_range_labels(base_model, monkeypatch):
+    model = _make(base_model, monkeypatch)
+    values = _feed_labels(model, "val", torch.tensor([0, 1, 2, 7, -1]))
+    assert values["val/n"].item() == pytest.approx(3.0)

--- a/tests/unit_tests/test_compare_regional_finetune.py
+++ b/tests/unit_tests/test_compare_regional_finetune.py
@@ -1,0 +1,114 @@
+"""Unit tests for the D2.5 regional fine-tuning comparison (#526).
+
+The analysis is paired: both models score the same cases, so the bootstrap must
+resample cases jointly and report a CI on the difference. These tests pin that
+behaviour, plus the guards that keep an underpowered cohort from being read as a
+result.
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import import_module_from_path  # noqa: E402
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "evaluation" / "compare_regional_finetune.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return import_module_from_path("_cmp_regional", SCRIPT)
+
+
+def _write(tmp, site, rows):
+    d = tmp / site
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / "predictions_x.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["uid", "ground_truth", "prediction",
+                                           "prob_class_0", "prob_class_1", "prob_class_2"])
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def _row(uid, gt, p2):
+    """A case whose malignant score is p2; the rest is split over the other classes."""
+    rest = 1.0 - p2
+    return {"uid": uid, "ground_truth": gt, "prediction": 2 if p2 > 0.5 else 0,
+            "prob_class_0": rest * 0.7, "prob_class_1": rest * 0.3, "prob_class_2": p2}
+
+
+def test_auroc_matches_known_value(mod):
+    # two positives ranked above two negatives -> perfect separation
+    assert mod.auroc([0.9, 0.8, 0.2, 0.1], [1, 1, 0, 0]) == 1.0
+    # perfectly inverted
+    assert mod.auroc([0.1, 0.2, 0.8, 0.9], [1, 1, 0, 0]) == 0.0
+    # ties average to chance
+    assert mod.auroc([0.5, 0.5, 0.5, 0.5], [1, 1, 0, 0]) == 0.5
+
+
+def test_auroc_is_none_when_a_class_is_absent(mod):
+    assert mod.auroc([0.1, 0.2], [0, 0]) is None
+    assert mod.auroc([0.1, 0.2], [1, 1]) is None
+
+
+def test_detects_a_real_improvement(mod, tmp_path):
+    base, fine = tmp_path / "b", tmp_path / "f"
+    # baseline scores malignants no better than chance; fine-tuned separates them
+    b = [_row(f"c{i}", 2, 0.4) for i in range(8)] + [_row(f"n{i}", 0, 0.5) for i in range(20)]
+    f = [_row(f"c{i}", 2, 0.9) for i in range(8)] + [_row(f"n{i}", 0, 0.1) for i in range(20)]
+    _write(base, "RUMC_1", b)
+    _write(fine, "RUMC_1", f)
+    br, fr = mod.load(str(base), ["RUMC_1"]), mod.load(str(fine), ["RUMC_1"])
+    uids = sorted(set(br) & set(fr))
+    d, lo, hi, favour = mod.paired_bootstrap(br, fr, uids, "malignant_vs_rest", 400, seed=1)
+    assert d > 0.3
+    assert lo > 0, "a large real effect should give an interval clear of zero"
+    assert favour == 1.0
+
+
+def test_no_difference_gives_an_interval_spanning_zero(mod, tmp_path):
+    base, fine = tmp_path / "b", tmp_path / "f"
+    rows = [_row(f"c{i}", 2, 0.6) for i in range(7)] + [_row(f"n{i}", 0, 0.4) for i in range(19)]
+    _write(base, "MHA_1", rows)
+    _write(fine, "MHA_1", rows)          # identical models
+    br, fr = mod.load(str(base), ["MHA_1"]), mod.load(str(fine), ["MHA_1"])
+    uids = sorted(set(br) & set(fr))
+    d, lo, hi, _ = mod.paired_bootstrap(br, fr, uids, "malignant_vs_rest", 400, seed=1)
+    assert d == 0.0
+    assert lo <= 0 <= hi
+
+
+def test_pairing_uses_only_overlapping_cases(mod, tmp_path):
+    """A case scored by only one model must not enter the comparison."""
+    base, fine = tmp_path / "b", tmp_path / "f"
+    _write(base, "MHA_1", [_row("a", 2, 0.8), _row("b", 0, 0.2), _row("only_base", 0, 0.9)])
+    _write(fine, "MHA_1", [_row("a", 2, 0.8), _row("b", 0, 0.2)])
+    br, fr = mod.load(str(base), ["MHA_1"]), mod.load(str(fine), ["MHA_1"])
+    uids = sorted(set(br) & set(fr))
+    assert uids == ["a", "b"]
+    assert "only_base" not in uids
+
+
+def test_undefined_endpoint_is_reported_not_faked(mod, tmp_path):
+    """A cohort with no malignant cases must yield None, never a number."""
+    base, fine = tmp_path / "b", tmp_path / "f"
+    rows = [_row(f"n{i}", 0, 0.3) for i in range(6)]
+    _write(base, "RUMC_1", rows)
+    _write(fine, "RUMC_1", rows)
+    br, fr = mod.load(str(base), ["RUMC_1"]), mod.load(str(fine), ["RUMC_1"])
+    uids = sorted(set(br) & set(fr))
+    d, lo, hi, favour = mod.paired_bootstrap(br, fr, uids, "malignant_vs_rest", 100, seed=1)
+    assert d is None and lo is None and hi is None and favour is None
+
+
+def test_multi_site_cohort_pools_cases(mod, tmp_path):
+    base, fine = tmp_path / "b", tmp_path / "f"
+    for d in (base, fine):
+        _write(d, "RUMC_1", [_row("r1", 2, 0.7), _row("r2", 0, 0.2)])
+        _write(d, "UMCU_1", [_row("u1", 2, 0.8), _row("u2", 0, 0.1)])
+    br = mod.load(str(base), ["RUMC_1", "UMCU_1"])
+    assert len(br) == 4, "the Dutch cohort must pool both sites' cases"

--- a/tests/unit_tests/test_per_site_metrics.py
+++ b/tests/unit_tests/test_per_site_metrics.py
@@ -223,3 +223,41 @@ def test_non_numeric_values_in_a_batch_are_skipped(module):
     data = from_shareable(ctx.events[0][1]["_validation_result_"]).data
     assert "val/note" not in data
     assert data["val/AUC_ROC"] == pytest.approx(0.8)
+
+
+def test_publishes_on_about_to_end_run_not_end_run(module):
+    """Regression for the empty cross_val_results.json (#525).
+
+    ``ValidationJsonGenerator`` dumps the JSON inside its own ``END_RUN``
+    handler, and components are invoked in the order they appear in
+    ``config_fed_server.conf``. With the generator listed first -- which is how
+    every job config is written -- publishing on ``END_RUN`` writes the file
+    before the metrics land in the generator's dict. Job 7c6e72c6 reported all
+    eight sites and still produced ``{}``. Publishing on ``ABOUT_TO_END_RUN``
+    removes the dependency on component order.
+    """
+    from nvflare.apis.event_type import EventType
+
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c._initialized = True
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.82), "UMCU_1")
+
+    c.handle_event(EventType.ABOUT_TO_END_RUN, ctx)
+    assert len(ctx.events) == 1, "metrics must be published before END_RUN"
+
+
+def test_end_run_does_not_publish_twice(module):
+    """finalize is idempotent, so the END_RUN fallback is a no-op."""
+    from nvflare.apis.event_type import EventType
+
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c._initialized = True
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.82), "UMCU_1")
+
+    c.handle_event(EventType.ABOUT_TO_END_RUN, ctx)
+    c.handle_event(EventType.END_RUN, ctx)
+    assert len(ctx.events) == 1

--- a/tests/unit_tests/test_per_site_metrics.py
+++ b/tests/unit_tests/test_per_site_metrics.py
@@ -159,3 +159,67 @@ def test_model_owner_is_recorded(module):
     c.save(ctx, _metric(module, "val/AUC_ROC", 0.82), "UKA_1")
     c.finalize(ctx)
     assert ctx.events[0][1]["_model_owner_"] == "swarm_global"
+
+def _metrics_batch(module, values, step=0):
+    """The shape MLflowWriter.log_metrics sends: a dict under the tag "metrics".
+
+    This is what ClientLogger produces, so it is what the Lightning training
+    path actually puts on the wire.
+    """
+    from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType
+
+    return AnalyticsData(key="metrics", value=values, data_type=AnalyticsDataType.METRICS,
+                         global_step=step).to_dxo().to_shareable()
+
+
+def test_batch_payload_from_the_lightning_path_is_recorded(module):
+    """Regression: the dict shape was silently dropped, so nothing was published."""
+    from nvflare.apis.dxo import from_shareable
+
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, _metrics_batch(module, {
+        "val/AUC_ROC": 0.82,
+        "val/AUC_ROC_class1": 0.372,
+        "val/support_class1": 2.0,
+        "val/n": 41.0,
+        "train/loss": 0.5,          # filtered out
+    }), "UMCU_1")
+    c.finalize(ctx)
+
+    assert len(ctx.events) == 1
+    data = from_shareable(ctx.events[0][1]["_validation_result_"]).data
+    assert data["val/AUC_ROC"] == pytest.approx(0.82)
+    assert data["val/support_class1"] == pytest.approx(2.0)
+    assert data["val/n"] == pytest.approx(41.0)
+    assert "train/loss" not in data
+
+
+def test_batch_and_scalar_payloads_merge(module):
+    from nvflare.apis.dxo import from_shareable
+
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, _metrics_batch(module, {"val/AUC_ROC": 0.60}), "UKA_1")
+    c.save(ctx, _metric(module, "val/ACC", 0.75), "UKA_1")
+    c.finalize(ctx)
+
+    data = from_shareable(ctx.events[0][1]["_validation_result_"]).data
+    assert data["val/AUC_ROC"] == pytest.approx(0.60)
+    assert data["val/ACC"] == pytest.approx(0.75)
+
+
+def test_non_numeric_values_in_a_batch_are_skipped(module):
+    from nvflare.apis.dxo import from_shareable
+
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, _metrics_batch(module, {"val/AUC_ROC": 0.8, "val/note": "n/a"}), "UKA_1")
+    c.finalize(ctx)
+
+    data = from_shareable(ctx.events[0][1]["_validation_result_"]).data
+    assert "val/note" not in data
+    assert data["val/AUC_ROC"] == pytest.approx(0.8)

--- a/tests/unit_tests/test_per_site_metrics.py
+++ b/tests/unit_tests/test_per_site_metrics.py
@@ -1,0 +1,161 @@
+"""Unit tests for the per-site metric collector (#525, #441).
+
+The collector closes the last hop of a transport that already works: clients
+stream `fed.analytix_log_stats`, NVFlare relays it, and nothing on the server
+handled it -- so `cross_val_results.json` was `{}` after every p2p run.
+
+These tests use stub FLContext/DXO objects, so no NVFlare runtime, server or
+network is needed.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import SHARED_CUSTOM_DIR, import_module_from_path  # noqa: E402
+
+pytest.importorskip("nvflare")
+
+COLLECTOR_PATH = SHARED_CUSTOM_DIR / "per_site_metrics.py"
+
+
+@pytest.fixture(scope="module")
+def module():
+    return import_module_from_path("_test_per_site_metrics", COLLECTOR_PATH)
+
+
+class FakeCtx:
+    """Minimal FLContext: records props and the events fired against it."""
+
+    def __init__(self):
+        self.props = {}
+        self.events = []
+
+    def set_prop(self, key, value, private=True, sticky=False):
+        self.props[key] = value
+
+    def get_prop(self, key, default=None):
+        return self.props.get(key, default)
+
+
+def _collector(module, **kwargs):
+    c = module.PerSiteMetricCollector(**kwargs)
+    # Widget logging expects a real engine; these tests only care about behaviour.
+    c.log_info = lambda *a, **k: None
+    c.log_warning = lambda *a, **k: None
+    c.log_error = lambda *a, **k: None
+    c.fire_event = lambda event_type, fl_ctx: fl_ctx.events.append(
+        (event_type, dict(fl_ctx.props))
+    )
+    return c
+
+
+def _metric(module, tag, value, step=0):
+    """Build the shareable a client would stream for one metric."""
+    from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType
+
+    return AnalyticsData(key=tag, value=value, data_type=AnalyticsDataType.SCALAR,
+                         global_step=step).to_dxo().to_shareable()
+
+
+def test_publishes_one_record_per_site(module):
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.82), "UMCU_1")
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.71), "CAM_1")
+    c.finalize(ctx)
+
+    assert len(ctx.events) == 2
+    sites = {props["_data_client_"] for _, props in ctx.events}
+    assert sites == {"UMCU_1", "CAM_1"}
+
+
+def test_published_record_carries_support_alongside_the_metric(module):
+    """The point of the change: a per-class metric never travels without its n."""
+    from nvflare.apis.dxo import from_shareable
+
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    for tag, value in [
+        ("val/AUC_ROC_class1", 0.372),
+        ("val/support_class1", 2.0),
+        ("val/n", 41.0),
+    ]:
+        c.save(ctx, _metric(module, tag, value), "UMCU_1")
+    c.finalize(ctx)
+
+    _, props = ctx.events[0]
+    data = from_shareable(props["_validation_result_"]).data
+    assert data["val/AUC_ROC_class1"] == pytest.approx(0.372)
+    assert data["val/support_class1"] == pytest.approx(2.0)
+    assert data["val/n"] == pytest.approx(41.0)
+
+
+def test_training_noise_is_dropped(module):
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, _metric(module, "train/loss", 0.5), "UKA_1")
+    c.finalize(ctx)
+    assert ctx.events == []
+
+
+def test_later_values_win(module):
+    """Each site's final value is published, not its first."""
+    from nvflare.apis.dxo import from_shareable
+
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.60, step=1), "UKA_1")
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.82, step=9), "UKA_1")
+    c.finalize(ctx)
+
+    _, props = ctx.events[0]
+    assert from_shareable(props["_validation_result_"]).data["val/AUC_ROC"] == pytest.approx(0.82)
+
+
+def test_a_malformed_record_does_not_lose_the_others(module):
+    """One bad site must not take down the run or the other sites' results."""
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, "not a shareable", "BROKEN_1")
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.82), "UKA_1")
+    c.finalize(ctx)
+
+    assert len(ctx.events) == 1
+    assert ctx.events[0][1]["_data_client_"] == "UKA_1"
+
+
+def test_no_metrics_publishes_nothing(module):
+    c = _collector(module)
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.finalize(ctx)
+    assert ctx.events == []
+
+
+def test_initialize_clears_state_between_runs(module):
+    c = _collector(module)
+    first = FakeCtx()
+    c.initialize(first)
+    c.save(first, _metric(module, "val/AUC_ROC", 0.82), "UKA_1")
+
+    second = FakeCtx()
+    c.initialize(second)          # START_RUN of the next job
+    c.finalize(second)
+    assert second.events == []
+
+
+def test_model_owner_is_recorded(module):
+    c = _collector(module, model_owner="swarm_global")
+    ctx = FakeCtx()
+    c.initialize(ctx)
+    c.save(ctx, _metric(module, "val/AUC_ROC", 0.82), "UKA_1")
+    c.finalize(ctx)
+    assert ctx.events[0][1]["_model_owner_"] == "swarm_global"


### PR DESCRIPTION
Closes #525. Closes #441.

Treated as one piece of work: per-site results never reached the coordinator, and the results we *did* gather by hand were reported in a shape that misled us. Fixing transport without fixing shape would have industrialised the second problem.

## Transport (#525)

Clients already stream metrics server-ward — `MetricRelay` fires `fed.analytix_log_stats`, `ClientFedEventRunner` relays it, `ServerFedEventRunner` delivers it. **Nothing on the server ever handled that event**, so `cross_site_val/cross_val_results.json` came back `{}` after every peer-to-peer run — the two-day 20-round run `87c5bbee` and a 52-second smoke run alike.

`PerSiteMetricCollector` closes the last hop: it accumulates the stream per site and, at end of run, hands it to the `ValidationJsonGenerator` **already configured in every server config**. No client change, no new transport, no image or kit rebuild — it ships with the job via `_shared/custom`.

## Shape (#441)

`compute_epoch_metrics` now emits `{state}/support_class{i}` and `{state}/n` at every tier.

A per-class metric read without its support is what produced a wrong conclusion about UMCU. Macro AUROC ranked centres by how many benign cases their split happened to contain, not by performance:

| Site | n | benign cases | benign AUROC | macro | macro w/o benign |
|---|---|---|---|---|---|
| UMCU_1 | 41 | 2 | 0.372 | 0.602 | **0.717** |
| CAM_1 | 64 | 2 | 0.315 | 0.710 | **0.908** |
| RUMC_1 | 8 | 0 | n/a | 0.857 | 0.857 |

CAM was penalised just as hard and nobody noticed; RUMC "led" only because two classes were averaged instead of three. Recorded as E1 in `docs/EVALUATION_PITFALLS.md` (#533).

## Choices worth reviewing

- Support values are **0-dim tensors**, keeping the returned mapping uniform — an existing test asserts `v.ndim == 0` for every value.
- They are emitted **before** the extended-tier early return, so support travels whether or not that tier is on.
- Two existing assertions were **reconciled, not weakened**: the tier gate is about per-class *metrics*, and train state now carries support too.
- `minimal_training_pytorch_cnn` gets a single-file symlink. It is deliberately self-contained, but the collector is job-agnostic and this is what makes a **52-second** verification of the transport possible instead of a multi-hour one.

## Verification

**Live, on all eight sites.** Job `c5520641`, 34 seconds, `FINISHED:COMPLETED`:

```json
{"MHA_1": {"swarm_global": {"val/loss_epoch": 0.6587, "val/ACC": 0.5, "val/AUC_ROC": 1.0}},
 "VHIO_1": {...}, "USZ_1": {...}, "RUMC_1": {...},
 "RSH_1": {...}, "UKA_1": {...}, "UMCU_1": {...}, "CAM_1": {...}}
```

All eight report identical values because `MiniDatasetForTesting` is deterministic — ten entries derived from the index, split with `random_state=42` — so every site holds byte-identical data. That confirms the transport, not the science.

### The live run found a second bug

The first live attempt still returned `{}`, and the server log said the metrics had arrived:

```
PerSiteMetricCollector - INFO - Published metrics for 8 site(s):
    CAM_1, MHA_1, RSH_1, RUMC_1, UKA_1, UMCU_1, USZ_1, VHIO_1
```

Every hop worked. The failure was ordering *within a single event*: `ValidationJsonGenerator` dumps the JSON in its own `END_RUN` handler, `AnalyticsReceiver.finalize` also runs on `END_RUN`, and components are invoked in the order they appear in `config_fed_server.conf`. `json_generator` is listed first in all seven job configs, so the file was written and only then did the collector publish into its in-memory dict.

It read as a missing metric rather than a race because `ServerRunner` logs `END_RUN fired` *after* the dispatch returns — the publish line appears ~2 s before it.

Fixed by publishing on `ABOUT_TO_END_RUN`, which is fired strictly earlier, so the result no longer depends on how any job config happens to be ordered. `END_RUN` stays as a fallback and `finalize` is idempotent. Recorded as **F10** in `docs/SWARM_FAILURE_MODES.md`.

### CI was green the whole time

`pytest.importorskip("nvflare")` **skipped `test_per_site_metrics.py` entirely** — the unit-tests workflow never installed NVFlare. The same trap the `torchio`/`pandas` lines were added for (#416/#423). The workflow now installs the in-tree fork, so CI tests the same NVFlare the image ships. A skipped test file is not a passing one.

16 tests, all running. Full suite locally: **378 passed, 7 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
