### PR TITLE
Make the 2-node deploy test able to run at all (ports, min_clients, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+/build/            # repo-root build output only. Unanchored 'build/' also matched
+                   # scripts/build/, so new files added there were silently ignored.
 develop-eggs/
 dist/
 downloads/

--- a/application/provision/project_deploy_test_2site.yml
+++ b/application/provision/project_deploy_test_2site.yml
@@ -6,8 +6,15 @@ participants:
   - name: dl3.tud.de
     type: server
     org: TUD
-    fed_learn_port: 8002
-    admin_port: 8003
+    # 8102/8103, NOT 8002/8003. The productive ODELIA server runs on the same host
+    # under the same name and binds 8002/8003 with certificates from a different
+    # provisioning generation. Sharing the ports means the test server silently
+    # fails to bind, the test clients reach the PRODUCTIVE server instead, and they
+    # fail with ClientConnectorCertificateError -- which reads exactly like a stale
+    # startup kit (F9) and is not one. Same collision DECADE hit and solved the same
+    # way; project_MEVIS_test.yml uses 8032/8033 for the same reason.
+    fed_learn_port: 8102
+    admin_port: 8103
   - name: RUMC_1
     type: client
     org: TUD

--- a/scripts/build/buildDockerImageAndStartupKits.sh
+++ b/scripts/build/buildDockerImageAndStartupKits.sh
@@ -15,6 +15,7 @@ fi
 DOCKER_BUILD_ARGS="--no-cache --progress=plain";
 DOCKERFILE="docker_config/Dockerfile_ODELIA"
 NUM_ROUNDS_OVERRIDE=""
+MIN_CLIENTS_OVERRIDE=""
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -22,16 +23,20 @@ while [[ "$#" -gt 0 ]]; do
         -d|--dockerfile)     DOCKERFILE="$2"; shift ;;
         --use-docker-cache)  DOCKER_BUILD_ARGS="";;
         --num-rounds)        NUM_ROUNDS_OVERRIDE="$2"; shift ;;
+        --min-clients)       MIN_CLIENTS_OVERRIDE="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done
 
 if [ -z "$PROJECT_FILE" ]; then
-    echo "Usage: buildDockerImageAndStartupKits.sh -p <swarm_project.yml> [-d <Dockerfile>] [--use-docker-cache] [--num-rounds N]"
+    echo "Usage: buildDockerImageAndStartupKits.sh -p <swarm_project.yml> [-d <Dockerfile>] [--use-docker-cache] [--num-rounds N] [--min-clients N]"
     echo "  -d  Dockerfile to use (default: docker_config/Dockerfile_ODELIA)"
     echo "      For STAMP builds, use: -d docker_config/Dockerfile_STAMP"
     echo "  --num-rounds  Override num_rounds in all config_fed_server.conf (for CI/CD testing)"
+    echo "  --min-clients Override min_clients / configure_min_clients to match the test site count."
+    echo "                Required for any deploy test with fewer sites than the productive job"
+    echo "                assumes, else the run aborts in 30s with min_clients exceeds ..."
     exit 1
 fi
 
@@ -85,6 +90,27 @@ if [[ -n "$NUM_ROUNDS_OVERRIDE" ]]; then
     echo "Overriding num_rounds to $NUM_ROUNDS_OVERRIDE in all config_fed_server.conf files"
     find application/jobs -name "config_fed_server.conf" -exec \
         sed -i 's/num_rounds = [0-9]\+/num_rounds = '"$NUM_ROUNDS_OVERRIDE"'/' {} \;
+fi
+
+# Override min_clients in all server configs if requested.
+#
+# The productive jobs carry min_clients tuned for the full consortium
+# (challenge_1DivideAndConquer ships 5, for 8 sites with fault tolerance). Submit
+# such a job to a 2- or 3-node deploy test and the server aborts within 30 seconds:
+#
+#   RuntimeError: min_clients (5) exceeds the number of participating clients (2)
+#
+# The job is read from inside the image (the admin submits
+# MediSwarm/application/jobs/<job>), so this has to be patched at build time --
+# editing the repo copy after the image is built has no effect.
+#
+# configure_min_clients is moved in lockstep: it must equal the participating site
+# count or the controller advances before slower sites finish configuring and
+# trains on a subset while still reporting success (F8 in docs/SWARM_FAILURE_MODES.md).
+if [[ -n "$MIN_CLIENTS_OVERRIDE" ]]; then
+    echo "Overriding min_clients/configure_min_clients to $MIN_CLIENTS_OVERRIDE in all config_fed_server.conf files"
+    find application/jobs -name "config_fed_server.conf" -exec \
+        sed -i 's/min_clients = [0-9]\+/min_clients = '"$MIN_CLIENTS_OVERRIDE"'/g' {} \;
 fi
 
 # Only cache pretrained model weights for ODELIA builds (STAMP uses pre-extracted


### PR DESCRIPTION
Three fixes to the deploy-test infrastructure, all found by actually running the 2-node test rather than by inspection. Split out of #534 so that a metrics change is not held up by test tooling.

## The 2-site test project sat on the productive ports

`project_deploy_test_2site.yml` declared its server as `dl3.tud.de` on **8002/8003** — the same name and the same ports as the productive ODELIA server, which runs on the very host the test uses as its server and has held those ports for six weeks.

The failure this produced points nowhere near the cause. The test server never binds, the test clients resolve `dl3.tud.de` to that host, reach the **productive** server, and die against certificates from a different provisioning generation:

```
conn_manager ERROR - Connector [CH00001 ACTIVE http://dl3.tud.de:8002]
    failed with exception ClientConnectorCertificateError
...
[ERROR] Not all clients registered within 600s
```

That reads exactly like a stale startup kit (F9). It is not — the kits were minutes old. Moved to **8102/8103**; DECADE solved the identical collision the same way and `project_MEVIS_test.yml` already sits on 8032/8033.

## No way to lower min_clients for a small test

With the ports fixed, both clients registered and the run aborted 30 seconds later:

```
RuntimeError: min_clients (5) exceeds the number of participating clients (2): ['MHA_1', 'RUMC_1']
```

The productive jobs carry `min_clients` tuned for the full consortium. So `deploy_sites_2node_test.conf` and `deploy_sites_3node_test.conf` could not successfully run **any** productive job — they could only ever reach this abort.

Added `--min-clients N` to the build script, mirroring the existing `--num-rounds`. It has to happen at build time: the admin submits `MediSwarm/application/jobs/<job>`, read from inside the image, so patching the repo copy after the build changes nothing.

`configure_min_clients` moves in lockstep — the substitution matches both keys, which I verified rather than assumed — because it must equal the participating site count or the controller advances before slower sites finish configuring and trains on a subset while still reporting success (F8).

## `build/` in .gitignore also matched `scripts/build/`

Unanchored, so any **new** file under `scripts/build/` would have been silently skipped by `git add`. Existing tracked files were unaffected. Anchored to `/build/`.

## Verification

With the first two fixes in place, the 2-node run on dl0/dl2 reaches:

```
[OK] All 2 clients registered with the server
[OK] Job submitted: challenge_1DivideAndConquer
```

and proceeds through learn tasks — past both aborts. The productive server was never at risk: container cleanup is scoped to the kit's suffix (#505), and it stayed up throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
