### PR TITLE
Label warm-start checkpoints and refuse another model's weights (#535)

### DIFF
--- a/application/jobs/_shared/custom/warm_continue.py
+++ b/application/jobs/_shared/custom/warm_continue.py
@@ -29,6 +29,8 @@ auto-resume: each block continues from the previous block's global. Collect the
 mirrors from all sites with ``scripts/collect_swarm_globals.sh`` (#160).
 """
 
+import hashlib
+import json
 import os
 import shutil
 
@@ -49,6 +51,55 @@ WARM_START_MODES = {
     WARM_START_MODE_REQUIRE,
 }
 WARM_START_REQUIRED_MISSING = "WARM_START_REQUIRED_MISSING"
+WARM_START_MODEL_MISMATCH = "WARM_START_MODEL_MISMATCH"
+
+
+
+def sidecar_path(ckpt_path: str) -> str:
+    """Provenance file that travels with a mirrored checkpoint."""
+    return f"{ckpt_path}.provenance.json"
+
+
+def current_model_name() -> str:
+    """The model this process is training, as the job's launcher set it."""
+    return os.environ.get("MODEL_NAME", "") or "unknown"
+
+
+def read_provenance(ckpt_path: str):
+    """Return the recorded provenance dict, or None if there is none."""
+    try:
+        with open(sidecar_path(ckpt_path)) as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def write_provenance(ckpt_path: str, model_name: str, job_id: str = "", digest: str = ""):
+    try:
+        with open(sidecar_path(ckpt_path), "w") as fh:
+            json.dump(
+                {"model_name": model_name, "job_id": job_id, "sha256": digest},
+                fh,
+            )
+    except Exception:
+        # provenance is a guard, not a feature -- never fail a run over it
+        pass
+
+
+def file_digest(path: str) -> str:
+    """sha256 of a checkpoint, or "" if it cannot be read.
+
+    Read in blocks: these files are ~700 MB and must not be loaded into memory
+    just to be identified.
+    """
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for block in iter(lambda: fh.read(1024 * 1024), b""):
+                h.update(block)
+        return h.hexdigest()
+    except Exception:
+        return ""
 
 
 def normalize_warm_start_mode(warm_start_mode: str) -> str:
@@ -155,7 +206,52 @@ class WarmStartablePTFileModelPersistor(PTFileModelPersistor):
                 )
                 return None
 
+        self._check_provenance(fl_ctx)
         return super().load_model(fl_ctx)
+
+    def _check_provenance(self, fl_ctx: FLContext):
+        """Refuse a checkpoint that a different model produced.
+
+        All six ODELIA jobs read and write one mirror path, so the file found
+        there may have been written by any of five architectures. Loading a
+        state dict from the wrong one is E2 in docs/EVALUATION_PITFALLS.md --
+        "wrong architecture loads silently" -- and shape compatibility is not a
+        safe proxy for correctness.
+
+        Unlabelled checkpoints are accepted with a warning rather than refused:
+        every mirror written before this change has no sidecar, and failing
+        those would break warm-continue for existing sites for no safety gain.
+        """
+        ckpt_path = self._runtime_source_checkpoint_path(fl_ctx)
+        if not ckpt_path or not os.path.exists(ckpt_path):
+            return
+
+        recorded = read_provenance(ckpt_path)
+        expected = current_model_name()
+
+        if recorded is None:
+            self.log_warning(
+                fl_ctx,
+                f"WarmStart: {ckpt_path} carries no provenance; cannot confirm it was "
+                f"produced by '{expected}'. Written before provenance was recorded, or by "
+                "another job. Proceeding.",
+            )
+            return
+
+        found = recorded.get("model_name", "unknown")
+        if expected != "unknown" and found != "unknown" and found != expected:
+            self.system_panic(
+                reason=(
+                    f"{WARM_START_MODEL_MISMATCH}: {ckpt_path} was written by model "
+                    f"'{found}' but this run trains '{expected}'. Refusing to warm-start "
+                    "from another architecture's weights. Use warm_start_mode=fresh, or "
+                    "point source_ckpt_file_full_name at that model's own mirror."
+                ),
+                fl_ctx=fl_ctx,
+            )
+            return
+
+        self.log_info(fl_ctx, f"WarmStart: provenance OK -- checkpoint was written by '{found}'")
 
     def _mirror_checkpoint(self, src: str, fl_ctx: FLContext, label: str):
         try:
@@ -164,9 +260,26 @@ class WarmStartablePTFileModelPersistor(PTFileModelPersistor):
                 os.makedirs(os.path.dirname(dst), exist_ok=True)
                 shutil.copy2(src, dst)
                 self.log_info(fl_ctx, f"WarmStart: mirrored {label} global -> {dst}")
+                self._record_provenance(dst, fl_ctx)
         except Exception as e:
             # mirroring is best-effort; never let it break the run
             self.log_warning(fl_ctx, f"WarmStart: failed to mirror {label} global to {self.latest_global_path}: {e}")
+
+    def _record_provenance(self, dst: str, fl_ctx: FLContext):
+        """Label a mirrored checkpoint with the model that produced it.
+
+        Deliberately separate from the copy, and separately guarded: provenance
+        is a safety net, and a failure to write it must never make a successful
+        mirror look like a failed one.
+        """
+        try:
+            model_name = current_model_name()
+            get_job_id = getattr(fl_ctx, "get_job_id", None)
+            job_id = (get_job_id() or "") if callable(get_job_id) else ""
+            write_provenance(dst, model_name, job_id, file_digest(dst))
+            self.log_info(fl_ctx, f"WarmStart: recorded provenance model={model_name}")
+        except Exception as e:
+            self.log_warning(fl_ctx, f"WarmStart: could not record provenance for {dst}: {e}")
 
     def save_model(self, ml, fl_ctx: FLContext):
         super().save_model(ml, fl_ctx)

--- a/tests/unit_tests/test_warm_start_provenance.py
+++ b/tests/unit_tests/test_warm_start_provenance.py
@@ -1,0 +1,115 @@
+"""Provenance guarding for the shared warm-start mirror (#535).
+
+All six ODELIA jobs read and write one checkpoint path, and five different
+architectures can land there. Loading another model's weights is E2 in
+docs/EVALUATION_PITFALLS.md. These tests pin the guard, and equally pin that it
+does not break warm-continue for the mirrors written before it existed.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import SHARED_CUSTOM_DIR, import_module_from_path  # noqa: E402
+
+pytest.importorskip("nvflare")
+MODULE_PATH = SHARED_CUSTOM_DIR / "warm_continue.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return import_module_from_path("_warm_continue_prov", MODULE_PATH)
+
+
+def test_sidecar_sits_beside_the_checkpoint(mod):
+    assert mod.sidecar_path("/scratch/x.pt") == "/scratch/x.pt.provenance.json"
+
+
+def test_roundtrip_records_the_model(mod, tmp_path):
+    ckpt = tmp_path / "g.pt"
+    ckpt.write_bytes(b"weights")
+    mod.write_provenance(str(ckpt), "1DivideAndConquer", "job-1", "abc")
+    got = mod.read_provenance(str(ckpt))
+    assert got["model_name"] == "1DivideAndConquer"
+    assert got["job_id"] == "job-1"
+
+
+def test_missing_sidecar_reads_as_none_not_an_error(mod, tmp_path):
+    ckpt = tmp_path / "g.pt"
+    ckpt.write_bytes(b"weights")
+    assert mod.read_provenance(str(ckpt)) is None
+
+
+def test_corrupt_sidecar_reads_as_none_not_an_exception(mod, tmp_path):
+    """A damaged sidecar must degrade to 'unknown', never take down a run."""
+    ckpt = tmp_path / "g.pt"
+    ckpt.write_bytes(b"weights")
+    Path(mod.sidecar_path(str(ckpt))).write_text("{not json")
+    assert mod.read_provenance(str(ckpt)) is None
+
+
+def test_digest_is_stable_and_content_sensitive(mod, tmp_path):
+    a, b = tmp_path / "a.pt", tmp_path / "b.pt"
+    a.write_bytes(b"same"); b.write_bytes(b"same")
+    assert mod.file_digest(str(a)) == mod.file_digest(str(b))
+    b.write_bytes(b"different")
+    assert mod.file_digest(str(a)) != mod.file_digest(str(b))
+
+
+def test_digest_of_unreadable_file_is_empty(mod, tmp_path):
+    assert mod.file_digest(str(tmp_path / "nope.pt")) == ""
+
+
+def test_current_model_name_reads_the_env(mod, monkeypatch):
+    monkeypatch.setenv("MODEL_NAME", "Swin3D")
+    assert mod.current_model_name() == "Swin3D"
+    monkeypatch.delenv("MODEL_NAME", raising=False)
+    assert mod.current_model_name() == "unknown"
+
+
+def test_write_provenance_never_raises_on_a_bad_path(mod):
+    """Provenance is a guard, not a feature -- it must not fail a run."""
+    mod.write_provenance("/nonexistent-dir-xyz/g.pt", "MST")   # must not raise
+
+
+def test_digest_handles_a_file_larger_than_one_block(mod, tmp_path):
+    """Checkpoints are ~700 MB; the digest must stream, not slurp."""
+    import hashlib
+    big = tmp_path / "big.pt"
+    payload = os.urandom(1024 * 1024 * 3 + 17)      # >3 blocks, non-aligned
+    big.write_bytes(payload)
+    assert mod.file_digest(str(big)) == hashlib.sha256(payload).hexdigest()
+
+
+def test_a_failed_provenance_write_does_not_mask_a_successful_mirror(mod, tmp_path, monkeypatch):
+    """Regression: provenance sat inside the copy's try block, so a failure there
+    made a successful mirror log as a failure. The copy is the important part."""
+    import types
+
+    class _Logger:
+        def __init__(self): self.messages = []
+
+    persistor = mod.WarmStartablePTFileModelPersistor.__new__(mod.WarmStartablePTFileModelPersistor)
+    persistor.latest_global_path = str(tmp_path / "mirror.pt")
+    persistor.logger = _Logger()
+    persistor.log_info = lambda ctx, m, **k: persistor.logger.messages.append(("info", m))
+    persistor.log_warning = lambda ctx, m, **k: persistor.logger.messages.append(("warning", m))
+
+    src = tmp_path / "src.pt"
+    src.write_bytes(b"weights")
+
+    # force the provenance step to blow up
+    monkeypatch.setattr(mod, "write_provenance", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    persistor._mirror_checkpoint(str(src), types.SimpleNamespace(), "latest")
+
+    kinds = [k for k, _ in persistor.logger.messages]
+    texts = " ".join(m for _, m in persistor.logger.messages)
+    assert os.path.exists(persistor.latest_global_path), "the checkpoint must still be mirrored"
+    assert "mirrored latest global" in texts, "success must still be reported"
+    assert "could not record provenance" in texts, "the provenance failure is reported separately"
+    assert kinds.count("warning") == 1


### PR DESCRIPTION
Closes #535.

All six ODELIA jobs share one warm-start mirror path and five architectures can land there. Nothing recorded which model wrote a checkpoint, and nothing checked on load — so running 2BCN_AIM then 1DivideAndConquer warm-starts the second from the first's weights. Shape compatibility is not a safe proxy for correctness; this is **E2** in `docs/EVALUATION_PITFALLS.md`, with the pathway wired in by default.

This also came within one round of destroying the pan-European baseline **three separate times** in the week of 4–8 Sep, each time caught by hand.

## What changes

Every mirrored checkpoint gets a `.provenance.json` sidecar (model name, job id, sha256), and `load_model` refuses one whose recorded model differs from `MODEL_NAME`.

## Two choices worth reviewing

**Unlabelled checkpoints are accepted with a warning, not refused.** Every mirror written before this change has no sidecar; failing those would break warm-continue at every site for no safety gain.

**Provenance is written separately from the copy.** My first version put it inside the copy's `try`, where a provenance failure made a *successful* mirror log as failed — caught by the existing `test_warm_continue` tests, and now pinned by its own regression test. The checkpoint matters; its label is a safety net and must not be able to damage it.

The digest streams in 1 MB blocks — these files are ~700 MB.

## Tests

10 new, full suite **369 passed, 7 skipped**.

Related: #541 (no cross-site check that all sites resolved the same MODEL_NAME) is the same hazard at a different layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)