### PR TITLE
fix(ci): build startup kits before the weekly all-models preflight

### DIFF
--- a/scripts/ci/runIntegrationTests.sh
+++ b/scripts/ci/runIntegrationTests.sh
@@ -1228,6 +1228,14 @@ case "$1" in
         ;;
 
     run_all_models_preflight_check)
+        # The startup kits must be built here like every other preflight case:
+        # each workflow step is a separate invocation of this script, and the
+        # EXIT trap runs cleanup_temporary_data, which removes PROJECT_DIR. So
+        # the kits an earlier step built are gone by the time this one starts,
+        # and run_all_models_preflight_check begins with `cd $PROJECT_DIR/prod_00`.
+        # Without this the weekly run fails in about two seconds on a missing
+        # directory, which reads as "all six models are broken" and is not that.
+        create_startup_kits_and_check_contained_files
         create_synthetic_data
         run_all_models_preflight_check
         cleanup_temporary_data


### PR DESCRIPTION
Answers Ole's question on the weekly schedule.

## The schedule does fire

Run [34012983100](https://github.com/KatherLab/MediSwarm/actions/runs/34012983100) — `event: schedule`, branch `main`, **Sunday 2026-09-06 05:02 UTC**. (`0 5 * * 0` is 05:00 Sunday — cron is `min hour dom mon dow`, so the leading `0` is the minute.) It is not visible under a green filter because it failed.

## It fails in the harness, not in the models

It failed at step 23 after **about two seconds**. Two seconds is not six models being preflighted.

The dispatcher case is missing one line that every other preflight case has:

```bash
run_docker_gpu_preflight_check)
    create_startup_kits_and_check_contained_files   # present
run_data_access_preflight_check)
    create_startup_kits_and_check_contained_files   # present
run_all_models_preflight_check)
    create_synthetic_data                           # ← kits never built
```

Each workflow step is a separate invocation of `runIntegrationTests.sh`, and the `EXIT` trap runs `cleanup_temporary_data`, which `_rm_rf`s `PROJECT_DIR`. So the kits built by the earlier `create_startup_kits` step are already gone, and `run_all_models_preflight_check` opens with `cd "$PROJECT_DIR"/prod_00` against a missing directory.

## What this does and does not tell us

It fixes the harness. **It does not yet tell us whether the six models pass** — that has never actually been measured, because the step has never got as far as running them. A `workflow_dispatch` after this merges will give the first real answer, and Ole's report that at least one model fails locally may well still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)