### PR TITLE
feat(active-learning): sample-selection strategies for D3.2 (#527)

### DIFF
--- a/scripts/active_learning/selection.py
+++ b/scripts/active_learning/selection.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Sample-selection strategies for the active-learning study (D3.2 / T3.2, #527).
+
+What this is for
+----------------
+D3.2 asks whether active learning is *useful*: whether selecting which cases to
+label by model uncertainty reaches a given performance with fewer labels than
+selecting at random. That is a property of the selection rule and the data, so
+it is measured here on per-case class probabilities rather than by running a
+swarm round per iteration -- 2.2 h per round measured on the 8-site run makes
+the federated form of this experiment cost ~110 h across two arms, which does
+not fit before M48.
+
+Strategies
+----------
+``entropy``  predictive entropy over the class distribution. Highest when the
+             model spreads mass evenly; picks cases it cannot commit on.
+``margin``   top-1 probability minus top-2. Small margin means the model is
+             torn between two specific classes -- often more useful than
+             entropy when one class is rare, because entropy can be dominated
+             by a long flat tail over classes the model never predicts.
+``random``   the control. An active-learning result is only meaningful against
+             this, at identical budget and seed.
+
+A caution that shapes the analysis
+----------------------------------
+Uncertainty sampling naturally over-selects rare classes, and ODELIA's benign
+class is rare at every site. A gain over random must therefore be shown to
+survive when the class composition of the selected set is controlled for --
+otherwise the experiment measures class imbalance and calls it active learning.
+``class_composition`` is provided so that check is cheap and hard to skip.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Dict, List, Sequence
+
+STRATEGIES = ("entropy", "margin", "random")
+
+
+def _normalise(probs: Sequence[float]) -> List[float]:
+    """Return a proper distribution, or a uniform one if the input is degenerate.
+
+    Rows come from CSVs written by six different model implementations; a row
+    that does not sum to 1 is a data problem, not a reason to crash a study.
+    """
+    vals = [max(0.0, float(p)) for p in probs]
+    total = sum(vals)
+    if total <= 0:
+        n = len(vals) or 1
+        return [1.0 / n] * n
+    return [v / total for v in vals]
+
+
+def entropy(probs: Sequence[float]) -> float:
+    """Shannon entropy in nats. Higher means less certain."""
+    return -sum(p * math.log(p) for p in _normalise(probs) if p > 0)
+
+
+def margin_uncertainty(probs: Sequence[float]) -> float:
+    """1 - (top1 - top2), so that larger means less certain.
+
+    Returned in the same direction as entropy so both can feed one ranking
+    routine; a caller comparing raw margins directly would otherwise have to
+    remember that small margin means high uncertainty.
+    """
+    ordered = sorted(_normalise(probs), reverse=True)
+    if len(ordered) < 2:
+        return 0.0
+    return 1.0 - (ordered[0] - ordered[1])
+
+
+def score(row: Dict[str, str], strategy: str, rng: random.Random) -> float:
+    """Uncertainty score for one prediction row. Higher is selected first."""
+    if strategy == "random":
+        return rng.random()
+    probs = [float(row[k]) for k in sorted(row) if k.startswith("prob_class_")]
+    if strategy == "entropy":
+        return entropy(probs)
+    if strategy == "margin":
+        return margin_uncertainty(probs)
+    raise ValueError(f"unknown strategy {strategy!r}; expected one of {STRATEGIES}")
+
+
+def select(rows: Sequence[Dict[str, str]], budget: int, strategy: str,
+           seed: int = 0) -> List[Dict[str, str]]:
+    """Pick ``budget`` rows under ``strategy``.
+
+    Ties are broken by uid, not by input order: the CSVs arrive in whatever
+    order each site's dataloader produced, so an order-dependent tie-break
+    would make the same experiment give different answers at different sites.
+    """
+    if budget <= 0:
+        return []
+    rng = random.Random(seed)
+    scored = [(score(r, strategy, rng), str(r.get("uid", "")), r) for r in rows]
+    scored.sort(key=lambda t: (-t[0], t[1]))
+    return [r for _, _, r in scored[:budget]]
+
+
+def class_composition(rows: Sequence[Dict[str, str]]) -> Dict[int, int]:
+    """Ground-truth class counts of a selection.
+
+    Required for reporting: a selection that beats random while quietly
+    containing three times the malignant cases has not demonstrated that
+    uncertainty sampling works.
+    """
+    counts: Dict[int, int] = {}
+    for r in rows:
+        gt = r.get("ground_truth")
+        if gt is None or gt == "":
+            continue
+        k = int(float(gt))
+        counts[k] = counts.get(k, 0) + 1
+    return dict(sorted(counts.items()))

--- a/tests/unit_tests/test_active_learning_selection.py
+++ b/tests/unit_tests/test_active_learning_selection.py
@@ -1,0 +1,105 @@
+"""Unit tests for the active-learning selection strategies (D3.2, #527).
+
+These pin the properties the study depends on: that uncertainty is measured in a
+consistent direction, that selection is reproducible across sites, and that the
+class-composition check the analysis must not skip actually works.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "active_learning"))
+import selection as sel  # noqa: E402
+
+
+def _row(uid, gt, probs):
+    r = {"uid": uid, "ground_truth": str(gt)}
+    for i, p in enumerate(probs):
+        r[f"prob_class_{i}"] = str(p)
+    return r
+
+
+# ---- uncertainty measures -------------------------------------------------
+
+def test_entropy_is_maximal_for_a_uniform_distribution():
+    import math
+    assert sel.entropy([1/3, 1/3, 1/3]) == pytest.approx(math.log(3))
+    assert sel.entropy([1.0, 0.0, 0.0]) == pytest.approx(0.0)
+
+
+def test_entropy_orders_certain_below_uncertain():
+    assert sel.entropy([0.9, 0.05, 0.05]) < sel.entropy([0.4, 0.35, 0.25])
+
+
+def test_margin_points_the_same_way_as_entropy():
+    """Both must mean 'higher = less certain', or one ranking routine cannot serve both."""
+    confident, torn = [0.9, 0.08, 0.02], [0.45, 0.44, 0.11]
+    assert sel.margin_uncertainty(confident) < sel.margin_uncertainty(torn)
+    assert sel.entropy(confident) < sel.entropy(torn)
+
+
+def test_degenerate_rows_do_not_crash():
+    """Six model implementations write these CSVs; a bad row is a data problem."""
+    assert sel.entropy([0.0, 0.0, 0.0]) == pytest.approx(sel.entropy([1/3, 1/3, 1/3]))
+    assert sel.entropy([-1.0, 0.0, 0.0]) >= 0.0
+
+
+def test_unnormalised_probabilities_are_normalised():
+    assert sel.entropy([2.0, 2.0, 2.0]) == pytest.approx(sel.entropy([1/3, 1/3, 1/3]))
+
+
+# ---- selection ------------------------------------------------------------
+
+def test_entropy_selects_the_uncertain_cases():
+    rows = [_row("certain", 0, [0.98, 0.01, 0.01]),
+            _row("torn",    2, [0.34, 0.33, 0.33]),
+            _row("clear",   0, [0.95, 0.03, 0.02])]
+    picked = sel.select(rows, budget=1, strategy="entropy")
+    assert [r["uid"] for r in picked] == ["torn"]
+
+
+def test_selection_is_reproducible_regardless_of_input_order():
+    """Sites produce rows in dataloader order; the same experiment must not
+    depend on which order a given site happened to write."""
+    rows = [_row(f"u{i}", i % 3, [0.5, 0.3, 0.2]) for i in range(10)]
+    a = [r["uid"] for r in sel.select(rows, 4, "entropy")]
+    b = [r["uid"] for r in sel.select(list(reversed(rows)), 4, "entropy")]
+    assert a == b
+
+
+def test_random_is_reproducible_for_a_seed_and_varies_across_seeds():
+    rows = [_row(f"u{i}", 0, [0.5, 0.3, 0.2]) for i in range(50)]
+    assert [r["uid"] for r in sel.select(rows, 5, "random", seed=1)] == \
+           [r["uid"] for r in sel.select(rows, 5, "random", seed=1)]
+    assert [r["uid"] for r in sel.select(rows, 5, "random", seed=1)] != \
+           [r["uid"] for r in sel.select(rows, 5, "random", seed=2)]
+
+
+def test_budget_bounds_and_edge_cases():
+    rows = [_row(f"u{i}", 0, [0.4, 0.35, 0.25]) for i in range(5)]
+    assert sel.select(rows, 0, "entropy") == []
+    assert len(sel.select(rows, 3, "entropy")) == 3
+    assert len(sel.select(rows, 99, "entropy")) == 5      # budget above pool size
+
+
+def test_unknown_strategy_is_rejected():
+    with pytest.raises(ValueError):
+        sel.select([_row("u", 0, [1.0, 0, 0])], 1, "leastconfident")
+
+
+# ---- the check the analysis must not skip ---------------------------------
+
+def test_class_composition_exposes_rare_class_over_selection():
+    """Uncertainty sampling over-selects rare classes; the study must report it."""
+    rows = ([_row(f"n{i}", 0, [0.97, 0.02, 0.01]) for i in range(20)] +
+            [_row(f"b{i}", 1, [0.36, 0.34, 0.30]) for i in range(3)])
+    picked = sel.select(rows, budget=3, strategy="entropy")
+    comp = sel.class_composition(picked)
+    assert comp == {1: 3}, "entropy took every benign case out of a 20:3 pool"
+    assert sel.class_composition(rows) == {0: 20, 1: 3}
+
+
+def test_class_composition_ignores_rows_without_labels():
+    assert sel.class_composition([{"uid": "x"}, _row("y", 2, [0.1, 0.2, 0.7])]) == {2: 1}


### PR DESCRIPTION
Refs #527. First code for D3.2; nothing on active learning existed in-tree.

## Why this is measured on prediction rows, not swarm rounds

D3.2 asks whether uncertainty-based selection reaches a given performance with **fewer labels** than random. That is a property of the selection rule and the data.

The federated form costs about **110 h of consortium time** across two arms — 2.2 h/round measured on the completed 8-site run, and `compute_weighted_epochs` gives every ODELIA site 1 epoch per round. That does not fit before M48 alongside D2.5 and D3.4, on a fleet that currently cannot hold a long run together. One federated confirmation run on the winning strategy demonstrates it in the real system for roughly a tenth of the cost.

## What's here

`entropy`, `margin` (top-1 minus top-2) and `random` as the control. Margin is returned as `1-(top1-top2)` so both measures point the same way — otherwise every caller has to remember that a *small* margin means *high* uncertainty.

## Two choices driven by how the data actually arrives

**Ties break on uid, not input order.** These CSVs come in whatever order each site's dataloader produced; an order-dependent tie-break would make the same experiment give different answers at different sites. Pinned by a test that reverses the input.

**Degenerate probability rows normalise rather than raise.** Six model implementations write these files. A row that doesn't sum to 1 is a data problem, not a reason to abort a study.

## The function that exists to stop a wrong conclusion

`class_composition()` is included because the analysis must not skip it. Uncertainty sampling over-selects rare classes, and ODELIA's benign class is rare at every site — so a gain over random has to survive controlling for class mix, or the experiment has measured class imbalance and called it active learning. The test shows entropy taking **all three** benign cases out of a 20:3 pool.

This is the same trap as E1 in `docs/EVALUATION_PITFALLS.md`, which has already produced one wrong conclusion about a partner site.

## Tests

12 new; full suite **419 passed, 7 skipped**.

## Dependency

The study needs per-case probabilities returned from each site — the same plumbing #526 (D2.5) is blocked on and #528 (D3.3 testing node) requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)