### PR TITLE
docs: add the current decks and an index pointing at the latest

### DIFF
--- a/docs/PRESENTATIONS.md
+++ b/docs/PRESENTATIONS.md
@@ -19,7 +19,7 @@ Slide 6 is the model comparison — the eight-site swarm against the previous si
 swarm and against ten single-site models.
 
 ### `presentation_data_by_site.html` — training data by site
-**4 charts · 9 September 2026**
+**5 charts · 9 September 2026**
 
 How much data each hospital brought when it joined, how the consortium total
 accumulated to 34,462 volumes across eight sites, and the class distribution shown
@@ -28,6 +28,10 @@ malignant-rich at 63 % until you see that is 221 volumes against UKA's 1,251.
 
 Sources are each site's own `Class counts` and `Weighted epochs` log lines, so every
 site's three classes sum exactly to its training size.
+
+The last chart carries the same model comparison as slide 6 of the briefing — the
+eight-site swarm against the six-site swarm and ten single-site models — so the data
+and what it produced sit on one page.
 
 ### `report_wp2_wp3_status_M45.html` — WP2/WP3 status at M45
 **9 September 2026 · for the technical committee**

--- a/docs/PRESENTATIONS.md
+++ b/docs/PRESENTATIONS.md
@@ -1,0 +1,66 @@
+# ODELIA presentations and reports
+
+Newest first. Every figure in these is read from the live coordination server, the
+sites' own run logs, or CI — not from earlier notes. Where a number could not be
+verified, the page says so rather than omitting the gap.
+
+## Current
+
+### `presentation_consortium_briefing.html` — consortium technical meeting
+**8 slides · 9 September 2026 · built for a meeting, prints one slide per page**
+
+The deck to show partners. Opens with per-site results now reaching the coordinator,
+uses Radboud's 99.1 % accuracy against an AUROC of 0.417 to explain why support
+counts travel with every metric, states plainly that five consecutive runs failed on
+infrastructure, and closes on one request: permission in principle to return
+per-case predictions.
+
+Slide 6 is the model comparison — the eight-site swarm against the previous six-site
+swarm and against ten single-site models.
+
+### `presentation_data_by_site.html` — training data by site
+**4 charts · 9 September 2026**
+
+How much data each hospital brought when it joined, how the consortium total
+accumulated to 34,462 volumes across eight sites, and the class distribution shown
+twice: at true scale and as shares. Reading them together is the point — RSH looks
+malignant-rich at 63 % until you see that is 221 volumes against UKA's 1,251.
+
+Sources are each site's own `Class counts` and `Weighted epochs` log lines, so every
+site's three classes sum exactly to its training size.
+
+### `report_wp2_wp3_status_M45.html` — WP2/WP3 status at M45
+**9 September 2026 · for the technical committee**
+
+Where the four outstanding grant tasks stand with three deliverables due at M48, what
+is verified and what is not, and the recommended next task. A `.docx` of the same
+material for committee submission is at
+`workspace/reports/ODELIA_WP2_WP3_progress_2026-09-08.docx`.
+
+## Earlier
+
+### `presentation_swarm_results.html` — swarm learning results
+**18 slides · June 2026 · speaker notes in `presentation_swarm_results_SPEAKER_NOTES.md`**
+
+The experiments deck: Study A (mechanism proof on Duke, 3 clients), Study B (the
+6 × 6 model-by-site matrix, where the swarm global beat the best single-site model
+externally on 4 of 6 models), Study C (single-site checkpoint transfer), and USZ
+onboarding. Regenerate with `scripts/presentation/build_swarm_results_deck.py`
+rather than editing by hand.
+
+## Related material
+
+| Path | What it holds |
+|---|---|
+| `ODELIA_SINGLE_SITE_CKPT_CHALLENGE_EVAL_CONDENSED_REPORT.md` | Per-checkpoint external results behind Study C |
+| `EVALUATION_PITFALLS.md` | E1–E3 — the three ways our evaluation has misled us |
+| `SWARM_FAILURE_MODES.md` | F1–F10 operational failure catalogue |
+| `TIMEOUTS.md` | Per-site training sizes, and why to read them from the logs |
+
+## A note on the numbers
+
+The model comparison on slide 6 draws on three separate evaluations against
+overlapping but not identical subsets of the challenge set — 165 cases for the
+eight-site run, 300 for the June matrix. The ordering is consistent and repeated
+across them; the exact gaps are not a controlled comparison, and the deck says so on
+the slide.

--- a/docs/presentation_consortium_briefing.html
+++ b/docs/presentation_consortium_briefing.html
@@ -1,0 +1,405 @@
+<title>ODELIA Consortium Briefing</title>
+<style>
+  :root {
+    --ground:      #FAFBFC;
+    --slide:       #FFFFFF;
+    --slide-alt:   #F1F5F8;
+    --ink:         #131C24;
+    --ink-soft:    #35485A;
+    --muted:       #5B6B79;
+    --rule:        #D9E1E7;
+    --rule-soft:   #E9EFF3;
+    --accent:      #0F6E8C;
+    --accent-soft: #E0EEF3;
+    --good:        #2E7250;
+    --good-bg:     #E3F0E8;
+    --warn:        #96662A;
+    --warn-bg:     #F6EDDF;
+    --bad:         #9E3339;
+    --bad-bg:      #F7E5E6;
+    --serif: "Iowan Old Style", "Charter", "Bitstream Charter", "Palatino Linotype", Palatino, Georgia, serif;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground: #0B1116; --slide: #131C23; --slide-alt: #19242C;
+      --ink: #E3EBF0; --ink-soft: #BDCBD5; --muted: #92A4B1;
+      --rule: #253440; --rule-soft: #1B262D;
+      --accent: #57B7D2; --accent-soft: #11303B;
+      --good: #6FBE92; --good-bg: #15301F;
+      --warn: #D6A45C; --warn-bg: #33260F;
+      --bad: #E08088;  --bad-bg: #351A1D;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground: #0B1116; --slide: #131C23; --slide-alt: #19242C;
+    --ink: #E3EBF0; --ink-soft: #BDCBD5; --muted: #92A4B1;
+    --rule: #253440; --rule-soft: #1B262D;
+    --accent: #57B7D2; --accent-soft: #11303B;
+    --good: #6FBE92; --good-bg: #15301F;
+    --warn: #D6A45C; --warn-bg: #33260F;
+    --bad: #E08088;  --bad-bg: #351A1D;
+  }
+
+  body { background: var(--ground); color: var(--ink); font-family: var(--sans); line-height: 1.5; }
+
+  .deck { max-width: 68rem; margin: 0 auto; padding: 1.5rem 1rem 4rem; display: flex; flex-direction: column; gap: 1.5rem; }
+
+  .slide {
+    background: var(--slide);
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    padding: clamp(1.5rem, 3.5vw, 2.75rem);
+    aspect-ratio: 16 / 9;
+    min-height: 26rem;
+    display: flex; flex-direction: column;
+    position: relative;
+    overflow: hidden;
+  }
+  @media (max-width: 700px) { .slide { aspect-ratio: auto; min-height: 0; } }
+
+  .num {
+    position: absolute; top: 1rem; right: 1.25rem;
+    font-family: var(--mono); font-size: .7rem; color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .eyebrow {
+    font-family: var(--mono); font-size: .68rem; letter-spacing: .14em;
+    text-transform: uppercase; color: var(--accent); font-weight: 600;
+  }
+  h1 {
+    font-family: var(--serif); font-size: clamp(1.9rem, 4.4vw, 2.9rem);
+    line-height: 1.08; margin: .5rem 0 0; font-weight: 600; letter-spacing: -.015em;
+    text-wrap: balance;
+  }
+  h2 {
+    font-family: var(--serif); font-size: clamp(1.35rem, 2.8vw, 1.95rem);
+    line-height: 1.15; margin: .35rem 0 0; font-weight: 600; letter-spacing: -.01em;
+    text-wrap: balance;
+  }
+  .sub { color: var(--ink-soft); font-size: clamp(.95rem, 1.6vw, 1.08rem); margin-top: .75rem; max-width: 46rem; text-wrap: pretty; }
+  .body { margin-top: 1.4rem; display: flex; flex-direction: column; gap: .9rem; flex: 1; }
+  p { margin: 0; }
+  code { font-family: var(--mono); font-size: .86em; background: var(--slide-alt); border: 1px solid var(--rule-soft); border-radius: 3px; padding: .08em .34em; }
+  strong { font-weight: 650; }
+
+  ul { margin: 0; padding-left: 1.2rem; display: flex; flex-direction: column; gap: .55rem; }
+  li { color: var(--ink-soft); font-size: clamp(.92rem, 1.5vw, 1rem); }
+  li::marker { color: var(--accent); }
+
+  .big { font-family: var(--serif); font-size: clamp(2.4rem, 6vw, 4rem); font-weight: 600; line-height: 1; letter-spacing: -.02em; }
+  .big-note { color: var(--muted); font-size: .88rem; margin-top: .4rem; }
+
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); gap: 1px; background: var(--rule); border: 1px solid var(--rule); border-radius: 6px; overflow: hidden; }
+  .stats > div { background: var(--slide); padding: .9rem 1rem; }
+  .stats dt { font-family: var(--mono); font-size: .64rem; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); }
+  .stats dd { margin: .2rem 0 0; font-family: var(--serif); font-size: 1.55rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .stats .cap { display: block; font-family: var(--sans); font-size: .74rem; font-weight: 400; color: var(--muted); margin-top: .1rem; line-height: 1.35; }
+
+  .scroll { overflow-x: auto; border: 1px solid var(--rule); border-radius: 6px; }
+  table { border-collapse: collapse; width: 100%; font-size: .87rem; min-width: 34rem; }
+  th, td { text-align: left; padding: .55rem .8rem; border-bottom: 1px solid var(--rule-soft); }
+  thead th { font-family: var(--mono); font-size: .64rem; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); font-weight: 500; background: var(--slide-alt); border-bottom: 1px solid var(--rule); white-space: nowrap; }
+  tbody tr:last-child td { border-bottom: none; }
+  td.n { font-variant-numeric: tabular-nums; white-space: nowrap; }
+  td.id { font-family: var(--mono); font-size: .8rem; white-space: nowrap; }
+  tr.flag td { background: var(--bad-bg); }
+
+  .chip { display: inline-block; font-family: var(--mono); font-size: .64rem; letter-spacing: .06em; text-transform: uppercase; padding: .16em .5em; border-radius: 3px; font-weight: 600; white-space: nowrap; }
+  .chip.good { background: var(--good-bg); color: var(--good); }
+  .chip.warn { background: var(--warn-bg); color: var(--warn); }
+  .chip.bad  { background: var(--bad-bg);  color: var(--bad); }
+  .chip.info { background: var(--accent-soft); color: var(--accent); }
+
+  .callout { background: var(--accent-soft); border-left: 3px solid var(--accent); border-radius: 4px; padding: .9rem 1.1rem; font-size: .95rem; color: var(--ink-soft); }
+  .callout strong { color: var(--ink); }
+
+  .two { display: grid; grid-template-columns: 1fr 1fr; gap: 1.1rem; }
+  @media (max-width: 760px) { .two { grid-template-columns: 1fr; } }
+  .panel { background: var(--slide-alt); border: 1px solid var(--rule-soft); border-radius: 6px; padding: .95rem 1.1rem; }
+  .panel h3 { margin: 0 0 .4rem; font-size: .82rem; font-family: var(--mono); letter-spacing: .07em; text-transform: uppercase; color: var(--muted); font-weight: 600; }
+  .panel p, .panel li { font-size: .89rem; }
+
+  .ask { border: 1px solid var(--accent); border-radius: 6px; overflow: hidden; }
+  .ask-h { background: var(--accent-soft); padding: .7rem 1.1rem; font-family: var(--mono); font-size: .68rem; letter-spacing: .12em; text-transform: uppercase; color: var(--accent); font-weight: 600; }
+  .ask-b { padding: 1rem 1.1rem; font-size: .95rem; color: var(--ink-soft); }
+
+  footer { text-align: center; color: var(--muted); font-size: .8rem; padding-top: 1rem; }
+  @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
+  @media print {
+    body { background: #fff; }
+    .deck { gap: 0; padding: 0; max-width: none; }
+    .slide { page-break-after: always; border: none; border-radius: 0; aspect-ratio: auto; min-height: 100vh; }
+  }
+</style>
+
+<div class="deck">
+
+  <!-- 1 ------------------------------------------------------------- -->
+  <section class="slide">
+    <span class="num">1</span>
+    <div class="eyebrow">ODELIA consortium · technical meeting</div>
+    <h1>Per-site results now come back from every hospital</h1>
+    <p class="sub">
+      What changed this week, what it revealed about our evaluation, and the one thing we need
+      from partners next.
+    </p>
+    <div class="body" style="justify-content:flex-end">
+      <div class="stats">
+        <div><dt>Project month</dt><dd>45<span class="cap">of 60</span></dd></div>
+        <div><dt>Next deadline</dt><dd>M48<span class="cap">three deliverables</span></dd></div>
+        <div><dt>Sites online</dt><dd>8<span class="cap">full consortium</span></dd></div>
+        <div><dt>Status</dt><dd>Fixed<span class="cap">verified on real data</span></dd></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2 ------------------------------------------------------------- -->
+  <section class="slide">
+    <span class="num">2</span>
+    <div class="eyebrow">The problem</div>
+    <h2>Until this week, results never left the hospitals</h2>
+    <div class="body">
+      <p class="sub" style="margin-top:0">
+        The coordinator's results file came back empty after <em>every</em> peer-to-peer run — after
+        a two-day twenty-round run and after a fifty-second test run alike.
+      </p>
+      <div class="two">
+        <div class="panel">
+          <h3>What that cost us</h3>
+          <ul>
+            <li>Per-site figures had to be collected by logging into each hospital by hand</li>
+            <li>No central view of how the shared model performs at each centre</li>
+            <li>Blocked the regulatory testing node, the regional comparison, and privacy accounting</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>Why it went unnoticed</h3>
+          <ul>
+            <li>Every run reported success</li>
+            <li>The server log said metrics had arrived from all eight sites</li>
+            <li>Automated tests passed — while silently skipping the file that would have caught it</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3 ------------------------------------------------------------- -->
+  <section class="slide">
+    <span class="num">3</span>
+    <div class="eyebrow">Verified</div>
+    <h2>Radboud and Utrecht reported straight to the coordinator</h2>
+    <div class="body">
+      <div class="scroll">
+        <table>
+          <thead>
+            <tr><th>Site</th><th>Cases</th><th>No lesion</th><th>Benign</th><th>Malignant</th><th>Accuracy</th><th>AUROC</th></tr>
+          </thead>
+          <tbody>
+            <tr class="flag"><td class="id">Radboud</td><td class="n">896</td><td class="n">888</td><td class="n">0</td><td class="n">8</td><td class="n">0.991</td><td class="n">0.417</td></tr>
+            <tr><td class="id">Utrecht</td><td class="n">1557</td><td class="n">1361</td><td class="n">186</td><td class="n">10</td><td class="n">0.874</td><td class="n">0.698</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout">
+        <strong>Read the highlighted row carefully.</strong> 99.1&#8239;% accuracy with an AUROC of
+        0.417 — below chance. Of 896 cases, 888 carry no lesion and none are benign. A model that
+        answers "no lesion" almost always scores 99&#8239;% and discriminates nothing.
+      </div>
+      <p style="font-size:.9rem;color:var(--muted)">
+        These are validation figures shown as evidence that the mechanism works — not model
+        performance results.
+      </p>
+    </div>
+  </section>
+
+  <!-- 4 ------------------------------------------------------------- -->
+  <section class="slide">
+    <span class="num">4</span>
+    <div class="eyebrow">Why this matters clinically</div>
+    <h2>A number without its denominator is not a result</h2>
+    <div class="body">
+      <p class="sub" style="margin-top:0">
+        Reported on its own, Radboud's 99&#8239;% would make it look like the strongest centre in
+        the consortium. It is an artefact of a 99:1 class split.
+      </p>
+      <div class="two">
+        <div class="panel">
+          <h3>We have already been caught by this</h3>
+          <p>
+            UMC Utrecht was described as performing materially worse than other centres. That came
+            from a macro-averaged AUROC in which one class was represented by <strong>two</strong>
+            cases. Excluding that class, Utrecht moves 0.602&nbsp;→&nbsp;0.717 and Cambridge
+            0.710&nbsp;→&nbsp;0.908.
+          </p>
+        </div>
+        <div class="panel">
+          <h3>What we do now</h3>
+          <ul>
+            <li>Every metric travels with its per-class support count</li>
+            <li>Ranking centres by macro AUROC is off the table where a class has single-digit support</li>
+            <li>The failure modes are written up for all partners</li>
+          </ul>
+        </div>
+      </div>
+      <div class="callout">
+        <strong>Nothing here reflects on any centre's data quality.</strong> It reflects on how we
+        were summarising it.
+      </div>
+    </div>
+  </section>
+
+  <!-- 5 ------------------------------------------------------------- -->
+  <section class="slide">
+    <span class="num">5</span>
+    <div class="eyebrow">Honest status</div>
+    <h2>The software is fixed. The fleet is the bottleneck.</h2>
+    <div class="body">
+      <div class="scroll">
+        <table>
+          <thead><tr><th>When</th><th>What happened</th><th>Outcome</th></tr></thead>
+          <tbody>
+            <tr><td class="id">4 Sep</td><td>Aachen host rebooted mid-run, twice, at the same point</td><td><span class="chip bad">Lost</span></td></tr>
+            <tr><td class="id">7 Sep</td><td>Stopped deliberately — was about to overwrite the shared baseline model</td><td><span class="chip warn">Stopped</span></td></tr>
+            <tr><td class="id">7 Sep</td><td>Mitera could not download the model from Royal Surrey; Cambridge dropped</td><td><span class="chip bad">Lost</span></td></tr>
+            <tr><td class="id">7–8 Sep</td><td>Dutch run finished all five rounds, then failed to publish for five hours</td><td><span class="chip good">Recovered</span></td></tr>
+            <tr><td class="id">8 Sep</td><td>In-house test runs — three attempts, all lost to relayed model transfers</td><td><span class="chip info">Cause found</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="sub" style="margin-top:0">
+        Eight consecutive runs, no code defect among them. Development has moved to in-house
+        servers so the consortium fleet is used only for final benchmark runs.
+      </p>
+      <div class="callout">
+        <strong>We now know why the in-house runs failed too.</strong> Model transfers were being
+        relayed through Frankfurt: our two test machines sit on one subnet and talk in 1&nbsp;ms,
+        but the coordinating server is in another city, and the swarm routes every transfer through
+        it. A 700&nbsp;MB model was crossing the country twice per round. That is a network
+        topology problem, not a defect in the training software.
+      </div>
+    </div>
+  </section>
+
+  <!-- 5b ------------------------------------------------------------ -->
+  <section class="slide">
+    <span class="num">6</span>
+    <div class="eyebrow">Where the model stands</div>
+    <h2>The eight-site swarm is the best model we have produced</h2>
+    <div class="body">
+      <div class="scroll">
+        <table>
+          <thead>
+            <tr><th>Model</th><th>Sites</th><th>When</th><th>Malignant AUROC</th><th>Macro AUROC</th></tr>
+          </thead>
+          <tbody>
+            <tr style="background:var(--good-bg)">
+              <td class="id"><strong>Swarm · 1DivideAndConquer</strong></td><td class="n">8</td><td class="n">Aug 2026</td>
+              <td class="n"><strong>0.887</strong></td><td class="n"><strong>0.820</strong></td></tr>
+            <tr><td class="id">Swarm · 4LME_ABMIL</td><td class="n">6</td><td class="n">Jun 2026</td>
+                <td class="n">0.847</td><td class="n">0.764</td></tr>
+            <tr><td class="id">Best single site — UKA · 1DC</td><td class="n">1</td><td class="n">Jun 2026</td>
+                <td class="n">0.858</td><td class="n">0.709</td></tr>
+            <tr><td class="id">Median of 10 single-site models</td><td class="n">1</td><td class="n">Jun 2026</td>
+                <td class="n">0.658</td><td class="n">0.601</td></tr>
+            <tr><td class="id">Weakest single site — RUMC · 1DC</td><td class="n">1</td><td class="n">Jun 2026</td>
+                <td class="n">0.408</td><td class="n">0.483</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="two">
+        <div class="panel">
+          <h3>Against training alone</h3>
+          <ul>
+            <li><strong>+0.229</strong> malignant AUROC over the median single-site model</li>
+            <li><strong>+0.029</strong> over the strongest single site, which is UKA — the site holding half the consortium's data</li>
+            <li><strong>+0.111</strong> macro AUROC over that same best single site</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>Against the previous swarm</h3>
+          <ul>
+            <li><strong>+0.040</strong> malignant AUROC over the six-site June run</li>
+            <li><strong>+0.056</strong> macro AUROC</li>
+            <li>Two more sites, twenty rounds, and the first run to complete with the full consortium</li>
+          </ul>
+        </div>
+      </div>
+      <div class="callout">
+        <strong>Read the ordering, not the decimals.</strong> These come from three separate
+        evaluations on overlapping but not identical subsets of the challenge set — 165 cases for the
+        eight-site run, 300 for the June matrix. The direction is consistent and repeated; the exact
+        gaps are not a controlled comparison.
+      </div>
+    </div>
+  </section>
+
+  <!-- 6 ------------------------------------------------------------- -->
+  <section class="slide">
+    <span class="num">7</span>
+    <div class="eyebrow">The ask</div>
+    <h2>Let sites return per-case predictions, not just summaries</h2>
+    <div class="body">
+      <div class="ask">
+        <div class="ask-h">What we would send back</div>
+        <div class="ask-b">
+          A <strong>row number</strong>, the ground-truth label, and the model's class
+          probabilities. <strong>No case identifier and no patient identifier</strong> — the row
+          number is a position within your own validation split and means nothing outside it. No
+          images. Nothing new is computed; this is what your site already writes to its own disk
+          during a normal training run.
+        </div>
+      </div>
+      <div class="two">
+        <div class="panel">
+          <h3>Why we need it</h3>
+          <ul>
+            <li>Regional fine-tuning (D2.5) is currently blocked on moving a 722&nbsp;MB model out of two hospitals — this removes that need entirely</li>
+            <li>Proper statistical comparison needs case-level pairing; summaries cannot provide it</li>
+            <li>The regulatory testing node due at M54 requires it regardless</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>What we need from you</h3>
+          <ul>
+            <li>Confirmation that this is acceptable under your local data agreement</li>
+            <li>It stays off unless your site switches it on — the decision is yours, per site</li>
+            <li>Nothing technical — no new kit, no reconfiguration</li>
+            <li>Please keep clients online for the active-learning tests</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 7 ------------------------------------------------------------- -->
+  <section class="slide">
+    <span class="num">8</span>
+    <div class="eyebrow">Where we stand</div>
+    <h2>Three deliverables due in three months</h2>
+    <div class="body">
+      <div class="scroll">
+        <table>
+          <thead><tr><th>Deliverable</th><th>Due</th><th>Status</th><th>What it needs</th></tr></thead>
+          <tbody>
+            <tr><td class="id">D2.5 · regional fine-tuning</td><td class="n">M48</td><td><span class="chip warn">In progress</span></td><td>Per-case predictions (slide 6)</td></tr>
+            <tr><td class="id">D3.2 · active learning</td><td class="n">M48</td><td><span class="chip warn">Starting</span></td><td>Clients online; runs fit the round budget</td></tr>
+            <tr><td class="id">D3.4 · adversarial robustness</td><td class="n">M48</td><td><span class="chip warn">Starting</span></td><td>—</td></tr>
+            <tr><td class="id">D3.3 · testing node</td><td class="n">M54</td><td><span class="chip good">Unblocked</span></td><td>Builds on this week's fix</td></tr>
+            <tr><td class="id">T3.3 · differential privacy</td><td class="n">M54</td><td><span class="chip warn">Phase 1 done</span></td><td>Assessment written; calibrated noise and a privacy budget still to build</td></tr>
+            <tr><td class="id">MS6 · white-hat attack</td><td class="n">M54</td><td><span class="chip bad">Needs partners</span></td><td><strong>Cambridge and Radboud</strong> — scheduling now</td></tr>
+            <tr><td class="id">D3.5 · TRL7 demonstration</td><td class="n">M60</td><td><span class="chip info">Part-evidenced</span></td><td>Re-run on the released version</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout">
+        <strong>One request today:</strong> agreement in principle on returning per-case predictions,
+        and a slot with Cambridge and Radboud for the MS6 testing.
+      </div>
+    </div>
+  </section>
+
+  <footer>ODELIA WP2 / WP3 · 9 September 2026 · figures read from the coordination server and site logs</footer>
+</div>

--- a/docs/presentation_data_by_site.html
+++ b/docs/presentation_data_by_site.html
@@ -1,0 +1,462 @@
+<title>ODELIA Data by Site</title>
+<style>
+  .viz-root {
+    color-scheme: light;
+    --surface-0:      #f6f7f8;
+    --surface-1:      #fcfcfb;
+    --surface-2:      #eef2f5;
+    --text-primary:   #16202B;
+    --text-secondary: #52514e;
+    --text-muted:     #6b7a86;
+    --rule:           #dde4ea;
+    --rule-soft:      #eaeff3;
+    --accent:         #0F6E8C;
+    --series-1:       #2a78d6;   /* no lesion  */
+    --series-2:       #eb6834;   /* benign     */
+    --series-3:       #1baf7a;   /* malignant  */
+    --bar:            #2a78d6;
+    --serif: "Iowan Old Style", "Charter", "Bitstream Charter", "Palatino Linotype", Palatino, Georgia, serif;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) .viz-root {
+      color-scheme: dark;
+      --surface-0:      #10161a;
+      --surface-1:      #1a1a19;
+      --surface-2:      #202a31;
+      --text-primary:   #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted:     #94a5b1;
+      --rule:           #2b3941;
+      --rule-soft:      #212c33;
+      --accent:         #54B5D0;
+      --series-1:       #3987e5;
+      --series-2:       #d95926;
+      --series-3:       #199e70;
+      --bar:            #3987e5;
+    }
+  }
+  :root[data-theme="dark"] .viz-root {
+    color-scheme: dark;
+    --surface-0:      #10161a;
+    --surface-1:      #1a1a19;
+    --surface-2:      #202a31;
+    --text-primary:   #ffffff;
+    --text-secondary: #c3c2b7;
+    --text-muted:     #94a5b1;
+    --rule:           #2b3941;
+    --rule-soft:      #212c33;
+    --accent:         #54B5D0;
+    --series-1:       #3987e5;
+    --series-2:       #d95926;
+    --series-3:       #199e70;
+    --bar:            #3987e5;
+  }
+
+  body { background: var(--surface-0); color: var(--text-primary); font-family: var(--sans); line-height: 1.55; }
+  .viz-root { max-width: 60rem; margin: 0 auto; padding: clamp(1.5rem,4vw,3rem) clamp(1rem,4vw,2rem) 4rem;
+              display: flex; flex-direction: column; gap: 2.5rem; background: var(--surface-0); }
+
+  .eyebrow { font-family: var(--mono); font-size: .68rem; letter-spacing: .13em; text-transform: uppercase; color: var(--text-muted); }
+  h1 { font-family: var(--serif); font-size: clamp(1.8rem,4.5vw,2.6rem); line-height: 1.1; margin: .4rem 0 0; font-weight: 600; letter-spacing: -.015em; text-wrap: balance; }
+  h2 { font-family: var(--serif); font-size: clamp(1.2rem,2.6vw,1.5rem); margin: 0; font-weight: 600; letter-spacing: -.01em; }
+  .sub { color: var(--text-secondary); margin-top: .6rem; max-width: 42rem; text-wrap: pretty; }
+  p { margin: 0; }
+  figure { margin: 0; display: flex; flex-direction: column; gap: .7rem; }
+  figcaption { font-size: .84rem; color: var(--text-muted); max-width: 44rem; }
+  .card { background: var(--surface-1); border: 1px solid var(--rule); border-radius: 8px; padding: 1.2rem 1.3rem 1.4rem; }
+  svg { display: block; width: 100%; height: auto; overflow: visible; }
+  .scroll { overflow-x: auto; }
+
+  .lbl { font-family: var(--sans); font-size: 12px; fill: var(--text-secondary); }
+  .lbl-site { font-family: var(--mono); font-size: 12px; fill: var(--text-primary); }
+  .val { font-family: var(--mono); font-size: 12px; fill: var(--text-primary); font-weight: 600; }
+  .val-sm { font-family: var(--mono); font-size: 10.5px; fill: var(--text-secondary); }
+  .axis { stroke: var(--rule); stroke-width: 1; }
+  .grid { stroke: var(--rule-soft); stroke-width: 1; }
+  .bar rect, .stack rect { transition: opacity .12s; }
+  .bar:hover rect, .stack:hover rect { opacity: .82; }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 1rem; font-size: .82rem; color: var(--text-secondary); }
+  .legend span { display: inline-flex; align-items: center; gap: .4rem; }
+  .swatch { width: 11px; height: 11px; border-radius: 2px; display: inline-block; }
+
+  table { border-collapse: collapse; width: 100%; font-size: .85rem; min-width: 34rem; }
+  th, td { text-align: right; padding: .45rem .7rem; border-bottom: 1px solid var(--rule-soft); }
+  th:first-child, td:first-child { text-align: left; }
+  thead th { font-family: var(--mono); font-size: .66rem; letter-spacing: .09em; text-transform: uppercase;
+             color: var(--text-muted); font-weight: 500; background: var(--surface-2); border-bottom: 1px solid var(--rule); }
+  tbody tr:last-child td { border-bottom: none; }
+  td.n, th.n { font-variant-numeric: tabular-nums; }
+  tfoot td { font-weight: 650; border-top: 2px solid var(--rule); }
+  details { font-size: .85rem; color: var(--text-secondary); }
+  summary { cursor: pointer; font-family: var(--mono); font-size: .72rem; letter-spacing: .08em;
+            text-transform: uppercase; color: var(--text-muted); padding: .3rem 0; }
+  summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+  .note { background: var(--surface-2); border-left: 3px solid var(--accent); border-radius: 4px;
+          padding: .8rem 1rem; font-size: .88rem; color: var(--text-secondary); }
+  .note strong { color: var(--text-primary); }
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
+</style>
+
+<div class="viz-root">
+
+  <header>
+    <div class="eyebrow">ODELIA · breast-MRI swarm learning · 9 September 2026</div>
+    <h1>Training data by site</h1>
+    <p class="sub">
+      How much data each hospital brought when it joined, how the consortium total accumulated,
+      and how the classes are distributed. Every figure is read from the sites' own run logs.
+    </p>
+  </header>
+
+  <!-- ============ 1. per-site size ============ -->
+  <section class="card">
+    <figure>
+      <h2>What each site contributes today</h2>
+      <figcaption>
+        Training samples per site (unilateral breast volumes), from each site's
+        <code>Weighted epochs</code> log line — <code>len(ds_train)</code> at batch size 1.
+      </figcaption>
+      <svg viewBox="0 0 720 300" role="img" aria-label="Training samples per site: UKA 17834, UMCU 6133, RUMC 3608, USZ 3448, CAM 1778, MHA 1120, RSH 351, VHIO 190">
+        <g id="sizeBars"></g>
+      </svg>
+      <div class="note">
+        <strong>UKA alone is 51.7 % of the consortium's training data</strong> — more than the other
+        seven sites combined. The range across sites is 94-fold, from 17,834 down to 190.
+      </div>
+    </figure>
+  </section>
+
+  <!-- ============ 2. cumulative ============ -->
+  <section class="card">
+    <figure>
+      <h2>How the consortium total accumulated</h2>
+      <figcaption>
+        Running total of training data demonstrably available to the swarm, as each site came online.
+        Steps mark a site joining or a site's dataset growing.
+      </figcaption>
+      <svg viewBox="0 0 720 330" role="img" aria-label="Cumulative consortium training data growing from 452 samples in April 2026 to 34462 across 8 sites by 31 July 2026">
+        <g id="cumChart"></g>
+      </svg>
+      <div class="note">
+        Two events account for three quarters of the total: <strong>UKA joining on 11 June (+18,614)</strong>
+        and <strong>a UKA/USZ dataset expansion on 3 July (+6,755)</strong>. The last three sites to join —
+        RSH, VHIO and the April cohort's later growth — added under 1,000 between them.
+      </div>
+    </figure>
+  </section>
+
+  <!-- ============ 3a. class distribution, true scale ============ -->
+  <section class="card">
+    <figure>
+      <h2>Class distribution at true scale</h2>
+      <figcaption>
+        The same class counts, but bar length is the actual number of volumes rather than a share —
+        so the sites are comparable against each other, not just against themselves.
+      </figcaption>
+      <div class="legend" aria-hidden="true">
+        <span><i class="swatch" style="background:var(--series-1)"></i> No lesion</span>
+        <span><i class="swatch" style="background:var(--series-2)"></i> Benign</span>
+        <span><i class="swatch" style="background:var(--series-3)"></i> Malignant</span>
+      </div>
+      <svg viewBox="0 0 720 300" role="img" aria-label="Class counts per site at true scale: UKA's 17834 volumes dwarf the rest; VHIO's 190 and RSH's 351 are barely visible">
+        <g id="absBars"></g>
+      </svg>
+      <div class="note">
+        <strong>This is why the previous chart can mislead on its own.</strong> RSH looks
+        malignant-rich at 63 %, but that is 221 volumes — against UKA's 1,251. Read as shares the two
+        sites look comparable; read at scale, UKA contributes five times more malignant data than
+        RSH has volumes of any kind.
+      </div>
+    </figure>
+  </section>
+
+  <!-- ============ 3. class distribution ============ -->
+  <section class="card">
+    <figure>
+      <h2>Class distribution as shares</h2>
+      <figcaption>
+        Composition of each site's <strong>training set</strong>, logged by the trainer at dataset
+        setup (<code>Class counts</code>). Bars show each site's own class mix; the label gives its
+        size and benign count.
+      </figcaption>
+      <div class="legend" aria-hidden="true">
+        <span><i class="swatch" style="background:var(--series-1)"></i> No lesion</span>
+        <span><i class="swatch" style="background:var(--series-2)"></i> Benign</span>
+        <span><i class="swatch" style="background:var(--series-3)"></i> Malignant</span>
+      </div>
+      <svg viewBox="0 0 720 300" role="img" aria-label="Training-set class distribution per site: UKA is 66 percent benign, RSH is 63 percent malignant, RUMC and VHIO have almost no benign cases">
+        <g id="classBars"></g>
+      </svg>
+      <div class="note">
+        <strong>The consortium's benign cases are almost all in one hospital.</strong> UKA holds
+        11,836 of the 14,110 benign volumes — <strong>83.9 %</strong> — and 61 % of the malignant.
+        Two sites have essentially none: RUMC has 2 benign in 3,608, VHIO has 0 in 190.
+      </div>
+      <div class="note" style="border-left-color:var(--series-2)">
+        <strong>RSH is inverted relative to everyone else.</strong> Of its 351 volumes only 4 carry no
+        lesion and 221 are malignant (63 %). Every other site is majority no-lesion. A site that
+        unusual will pull an aggregation step in its own direction, and it is worth knowing before
+        reading any per-site result.
+      </div>
+    </figure>
+  </section>
+
+  <!-- ============ table view ============ -->
+  <section class="card">
+    <details>
+      <summary>Table view — all figures</summary>
+      <div class="scroll">
+        <table>
+          <caption class="lbl" style="text-align:left;padding:.4rem 0;color:var(--text-muted)">
+            Training size, join date, and challenge-test class counts
+          </caption>
+          <thead>
+            <tr><th>Site</th><th class="n">Joined</th><th class="n">n at join</th><th class="n">Training now</th>
+                <th class="n">Share</th><th class="n">No lesion</th><th class="n">Benign</th><th class="n">Malignant</th><th class="n">Benign %</th></tr>
+          </thead>
+          <tbody id="tableBody"></tbody>
+          <tfoot>
+            <tr><td>Consortium</td><td class="n">—</td><td class="n">—</td><td class="n">34,462</td>
+                <td class="n">100 %</td><td class="n">18,311</td><td class="n">14,110</td><td class="n">2,041</td><td class="n">40.9 %</td></tr>
+          </tfoot>
+        </table>
+      </div>
+    </details>
+  </section>
+
+  <section class="card">
+    <div class="note">
+      <strong>Provenance.</strong> Class counts are the trainer's own <code>Class counts</code> line,
+      emitted at dataset setup; each site's three classes sum exactly to its training size, and the
+      eight sites sum to 34,462. Figures are the most recent run whose training size matches the
+      site's production configuration — 7 Sep for five sites, 4 Sep for UKA, 6 Jul for USZ and
+      21 Jun for RUMC, those two having not run since. Records written by the two-node deploy test,
+      which reuses the site names RUMC_1 and MHA_1, were excluded.
+    </div>
+  </section>
+
+<script>
+(function () {
+  const SITES = [
+    { s:"UKA",  joined:"2026-06-11", atJoin:17834, now:17834, c:[4747,11836,1251], d:"2026-09-04" },
+    { s:"UMCU", joined:"2026-04-07", atJoin:122,   now:6133,  c:[5337,740,56],     d:"2026-09-07" },
+    { s:"RUMC", joined:"2026-04-07", atJoin:22,    now:3608,  c:[3571,2,35],       d:"2026-06-21" },
+    { s:"USZ",  joined:"2026-06-05", atJoin:3448,  now:3448,  c:[1911,1244,293],   d:"2026-07-06" },
+    { s:"CAM",  joined:"2026-04-07", atJoin:190,   now:1778,  c:[1678,42,58],      d:"2026-09-07" },
+    { s:"MHA",  joined:"2026-04-05", atJoin:452,   now:1120,  c:[904,120,96],      d:"2026-09-07" },
+    { s:"RSH",  joined:"2026-06-29", atJoin:351,   now:351,   c:[4,126,221],       d:"2026-09-07" },
+    { s:"VHIO", joined:"2026-07-31", atJoin:190,   now:190,   c:[159,0,31],        d:"2026-09-07" }
+  ];
+  const CUM = [
+    { d:"2026-04-05", t:452,   n:1, ev:"MHA joins" },
+    { d:"2026-04-07", t:786,   n:4, ev:"UMCU, RUMC, CAM join" },
+    { d:"2026-04-30", t:4730,  n:4, ev:"RUMC dataset expands" },
+    { d:"2026-06-05", t:8178,  n:5, ev:"USZ joins" },
+    { d:"2026-06-11", t:26792, n:6, ev:"UKA joins" },
+    { d:"2026-06-29", t:27143, n:7, ev:"RSH joins" },
+    { d:"2026-07-03", t:33898, n:7, ev:"dataset expansion" },
+    { d:"2026-07-31", t:34462, n:8, ev:"VHIO joins" }
+  ];
+  const TOTAL = 34462;
+  const NS = "http://www.w3.org/2000/svg";
+  const el = (n, a = {}) => { const e = document.createElementNS(NS, n);
+    for (const k in a) e.setAttribute(k, a[k]); return e; };
+  const fmt = v => v.toLocaleString("en-GB");
+
+  /* ---------- 1. per-site bars ---------- */
+  (function () {
+    const g = document.getElementById("sizeBars");
+    const L = 58, R = 96, T = 10, rowH = 34, barH = 17;
+    const W = 720 - L - R;
+    const max = Math.max(...SITES.map(d => d.now));
+    SITES.forEach((d, i) => {
+      const y = T + i * rowH;
+      const w = Math.max(2, (d.now / max) * W);
+      const grp = el("g", { class: "bar" });
+      grp.appendChild(el("text", { x: L - 10, y: y + barH - 3, "text-anchor": "end", class: "lbl-site" }))
+         .textContent = d.s;
+      const r = el("rect", { x: L, y, width: w, height: barH, rx: 4, fill: "var(--bar)" });
+      grp.appendChild(r);
+      const t = el("text", { x: L + w + 8, y: y + barH - 3, class: "val" });
+      t.textContent = fmt(d.now);
+      grp.appendChild(t);
+      const p = el("text", { x: L + w + 8, y: y + barH + 10, class: "val-sm" });
+      p.textContent = (d.now / TOTAL * 100).toFixed(1) + " %";
+      grp.appendChild(p);
+      const title = el("title");
+      title.textContent = `${d.s}: ${fmt(d.now)} training samples (${(d.now/TOTAL*100).toFixed(1)}% of consortium), joined ${d.joined} with ${fmt(d.atJoin)}`;
+      grp.appendChild(title);
+      g.appendChild(grp);
+    });
+    g.appendChild(el("line", { x1: L, y1: T - 4, x2: L, y2: T + SITES.length * rowH - 12, class: "axis" }));
+  })();
+
+  /* ---------- 2. cumulative step ---------- */
+  (function () {
+    const g = document.getElementById("cumChart");
+    const L = 56, R = 22, T = 18, B = 62, H = 330;
+    const W = 720 - L - R, PH = H - T - B;
+    const t0 = Date.parse("2026-04-01"), t1 = Date.parse("2026-08-15");
+    const x = d => L + (Date.parse(d) - t0) / (t1 - t0) * W;
+    const maxY = 36000;
+    const y = v => T + PH - (v / maxY) * PH;
+
+    [0, 9000, 18000, 27000, 36000].forEach(v => {
+      g.appendChild(el("line", { x1: L, y1: y(v), x2: L + W, y2: y(v), class: "grid" }));
+      const t = el("text", { x: L - 9, y: y(v) + 4, "text-anchor": "end", class: "lbl" });
+      t.textContent = v === 0 ? "0" : (v / 1000) + "k";
+      g.appendChild(t);
+    });
+
+    let dPath = `M ${x(CUM[0].d)} ${y(0)}`, aPath = dPath;
+    CUM.forEach((p, i) => {
+      const px = x(p.d), py = y(p.t);
+      dPath += ` L ${px} ${i ? y(CUM[i-1].t) : y(0)} L ${px} ${py}`;
+      aPath += ` L ${px} ${i ? y(CUM[i-1].t) : y(0)} L ${px} ${py}`;
+    });
+    const endX = L + W;
+    dPath += ` L ${endX} ${y(TOTAL)}`;
+    aPath += ` L ${endX} ${y(TOTAL)} L ${endX} ${y(0)} Z`;
+    g.appendChild(el("path", { d: aPath, fill: "var(--bar)", "fill-opacity": ".12" }));
+    g.appendChild(el("path", { d: dPath, fill: "none", stroke: "var(--bar)", "stroke-width": "2",
+                               "stroke-linejoin": "round" }));
+
+    CUM.forEach((p, i) => {
+      const px = x(p.d), py = y(p.t);
+      const grp = el("g", { class: "bar" });
+      grp.appendChild(el("circle", { cx: px, cy: py, r: 4.5, fill: "var(--bar)",
+                                     stroke: "var(--surface-1)", "stroke-width": "2" }));
+      const ti = el("title");
+      ti.textContent = `${p.d} — ${fmt(p.t)} samples across ${p.n} site${p.n>1?"s":""} (${p.ev})`;
+      grp.appendChild(ti);
+      g.appendChild(grp);
+      if (["2026-06-11", "2026-07-31", "2026-04-05"].includes(p.d)) {
+        const lab = el("text", { x: px, y: py - 12, "text-anchor": i === 0 ? "start" : "middle", class: "val" });
+        lab.textContent = fmt(p.t);
+        g.appendChild(lab);
+      }
+    });
+
+    g.appendChild(el("line", { x1: L, y1: T + PH, x2: L + W, y2: T + PH, class: "axis" }));
+    [["2026-04-01","Apr"],["2026-05-01","May"],["2026-06-01","Jun"],["2026-07-01","Jul"],["2026-08-01","Aug"]]
+      .forEach(([d, lbl]) => {
+        const px = x(d);
+        g.appendChild(el("line", { x1: px, y1: T + PH, x2: px, y2: T + PH + 5, class: "axis" }));
+        const t = el("text", { x: px, y: T + PH + 19, "text-anchor": "middle", class: "lbl" });
+        t.textContent = lbl; g.appendChild(t);
+      });
+
+    [["2026-06-11","UKA joins  +18,614", -4],["2026-07-31","VHIO joins", 4]].forEach(([d, txt, dx]) => {
+      const px = x(d);
+      const t = el("text", { x: px + dx, y: T + PH + 40, "text-anchor": dx < 0 ? "end" : "start", class: "val-sm" });
+      t.textContent = txt; g.appendChild(t);
+      g.appendChild(el("line", { x1: px, y1: T + PH + 26, x2: px, y2: T + PH + 32, class: "axis" }));
+    });
+  })();
+
+  /* ---------- 3a. class stacks at TRUE SCALE ---------- */
+  (function () {
+    const g = document.getElementById("absBars");
+    const rows = SITES.slice().sort((a, b) => b.now - a.now);
+    const L = 62, R = 130, T = 12, rowH = 30, barH = 16, GAP = 2;
+    const W = 720 - L - R;
+    const max = Math.max(...rows.map(d => d.now));
+    const COL = ["var(--series-1)", "var(--series-2)", "var(--series-3)"];
+    const NAME = ["No lesion", "Benign", "Malignant"];
+
+    // gridlines so the scale is readable, not just implied
+    [0, 5000, 10000, 15000].forEach(v => {
+      const gx = L + (v / max) * W;
+      g.appendChild(el("line", { x1: gx, y1: T - 6, x2: gx, y2: T + rows.length * rowH - 8, class: "grid" }));
+      const t = el("text", { x: gx, y: T + rows.length * rowH + 6, "text-anchor": "middle", class: "val-sm" });
+      t.textContent = v === 0 ? "0" : (v / 1000) + "k";
+      g.appendChild(t);
+    });
+
+    rows.forEach((d, i) => {
+      const y = T + i * rowH;
+      let xoff = L;
+      const full = (d.now / max) * W;
+      d.c.forEach((v, k) => {
+        if (v === 0) return;
+        const w = Math.max(1, (v / d.now) * full - (full > 12 ? GAP : 0));
+        const grp = el("g", { class: "stack" });
+        grp.appendChild(el("rect", { x: xoff, y, width: w, height: barH, rx: w > 6 ? 3 : 1, fill: COL[k] }));
+        const ti = el("title");
+        ti.textContent = `${d.s} — ${NAME[k]}: ${fmt(v)} of ${fmt(d.now)} (${(v/d.now*100).toFixed(1)}%)`;
+        grp.appendChild(ti);
+        g.appendChild(grp);
+        xoff += w + (full > 12 ? GAP : 0);
+      });
+      const sl = el("text", { x: L - 10, y: y + barH - 3, "text-anchor": "end", class: "lbl-site" });
+      sl.textContent = d.s; g.appendChild(sl);
+      const tl = el("text", { x: L + full + 10, y: y + barH - 3, class: "val-sm" });
+      tl.textContent = `${fmt(d.now)}  ·  ${fmt(d.c[1])} benign`;
+      g.appendChild(tl);
+    });
+    g.appendChild(el("line", { x1: L, y1: T - 6, x2: L, y2: T + rows.length * rowH - 8, class: "axis" }));
+  })();
+
+  /* ---------- 3. class stacks (share of each site's training set) ---------- */
+  (function () {
+    const g = document.getElementById("classBars");
+    const rows = SITES.slice().sort((a, b) => b.now - a.now)
+      .concat([{ s: "CONSORTIUM", now: 34462, c: [18311, 14110, 2041], pooled: true }]);
+    const L = 70, R = 150, T = 8, rowH = 30, barH = 16, GAP = 2;
+    const W = 720 - L - R;
+    const COL = ["var(--series-1)", "var(--series-2)", "var(--series-3)"];
+    const NAME = ["No lesion", "Benign", "Malignant"];
+    rows.forEach((d, i) => {
+      const y = T + i * rowH + (d.pooled ? 10 : 0);
+      let xoff = L;
+      d.c.forEach((v, k) => {
+        if (v === 0) return;
+        const w = Math.max(1.5, (v / d.now) * W - GAP);
+        const grp = el("g", { class: "stack" });
+        grp.appendChild(el("rect", { x: xoff, y, width: w, height: barH, rx: 3, fill: COL[k] }));
+        const ti = el("title");
+        ti.textContent = `${d.s} — ${NAME[k]}: ${fmt(v)} of ${fmt(d.now)} (${(v/d.now*100).toFixed(1)}%)`;
+        grp.appendChild(ti);
+        g.appendChild(grp);
+        if (w > 34) {
+          const t = el("text", { x: xoff + w / 2, y: y + barH - 4, "text-anchor": "middle",
+                                 class: "val-sm", fill: "#fff" });
+          t.textContent = (v / d.now * 100).toFixed(0) + "%";
+          g.appendChild(t);
+        }
+        xoff += w + GAP;
+      });
+      const sl = el("text", { x: L - 10, y: y + barH - 3, "text-anchor": "end",
+                              class: d.pooled ? "val" : "lbl-site" });
+      sl.textContent = d.s; g.appendChild(sl);
+      const tl = el("text", { x: L + W + 10, y: y + barH - 3, class: "val-sm" });
+      tl.textContent = `n=${fmt(d.now)}  ·  benign ${fmt(d.c[1])}`;
+      g.appendChild(tl);
+    });
+  })();
+
+  /* ---------- table ---------- */
+  (function () {
+    const tb = document.getElementById("tableBody");
+    SITES.slice().sort((a, b) => b.now - a.now).forEach(d => {
+      const tr = document.createElement("tr");
+      [ d.s, d.joined, fmt(d.atJoin), fmt(d.now),
+        (d.now / TOTAL * 100).toFixed(1) + " %",
+        fmt(d.c[0]), fmt(d.c[1]), fmt(d.c[2]),
+        (d.c[1] / d.now * 100).toFixed(1) + " %"
+      ].forEach((c, i) => {
+        const td = document.createElement("td");
+        if (i) td.className = "n";
+        td.textContent = c;
+        tr.appendChild(td);
+      });
+      tb.appendChild(tr);
+    });
+  })();
+})();
+</script>
+</div>

--- a/docs/presentation_data_by_site.html
+++ b/docs/presentation_data_by_site.html
@@ -205,6 +205,36 @@
     </figure>
   </section>
 
+  <!-- ============ 4. model comparison ============ -->
+  <section class="card">
+    <figure>
+      <h2>What that data has produced</h2>
+      <figcaption>
+        The eight-site swarm model against the previous six-site swarm and against ten single-site
+        models, all scored on the external ODELIA challenge. Higher is better; 0.5 is chance.
+      </figcaption>
+      <div class="legend" aria-hidden="true">
+        <span><i class="swatch" style="background:var(--series-1)"></i> Malignant vs rest AUROC</span>
+        <span><i class="swatch" style="background:var(--series-2)"></i> Macro AUROC</span>
+      </div>
+      <svg viewBox="0 0 720 300" role="img" aria-label="External challenge AUROC: the eight-site swarm reaches 0.887 malignant and 0.820 macro, above the six-site swarm at 0.847 and 0.764, the best single site at 0.858 and 0.709, and the median single site at 0.658 and 0.601">
+        <g id="modelBars"></g>
+      </svg>
+      <div class="note">
+        <strong>The narrowest margin is the most demanding one.</strong> The swarm beats the best
+        single-site model by only +0.029 on malignant AUROC — but that model is UKA's, trained on the
+        site holding half the consortium's data and 84 % of its benign cases. Against the median
+        single-site model the gap is +0.229.
+      </div>
+      <div class="note" style="border-left-color:var(--series-2)">
+        <strong>Read the ordering, not the decimals.</strong> These are three separate evaluations on
+        overlapping but not identical subsets of the challenge set — 165 cases for the eight-site
+        run, 300 for the June matrix. The direction is consistent and repeated; the exact gaps are
+        not a controlled comparison.
+      </div>
+    </figure>
+  </section>
+
   <!-- ============ table view ============ -->
   <section class="card">
     <details>
@@ -437,6 +467,55 @@
       tl.textContent = `n=${fmt(d.now)}  ·  benign ${fmt(d.c[1])}`;
       g.appendChild(tl);
     });
+  })();
+
+  /* ---------- 4. model comparison ---------- */
+  (function () {
+    const g = document.getElementById("modelBars");
+    const M = [
+      { m:"Swarm · 8 sites · 1DC",      sub:"Aug 2026 · current",  mal:0.887, mac:0.820, hi:true },
+      { m:"Best single site · UKA 1DC", sub:"trained alone",       mal:0.858, mac:0.709 },
+      { m:"Swarm · 6 sites · 4LME",     sub:"Jun 2026",            mal:0.847, mac:0.764 },
+      { m:"Median single-site model",   sub:"of 10",               mal:0.658, mac:0.601 },
+      { m:"Weakest single site · RUMC", sub:"trained alone",       mal:0.408, mac:0.483 }
+    ];
+    const L = 176, R = 58, T = 14, rowH = 52, barH = 15, GAP = 4;
+    const W = 720 - L - R;
+    const x = v => L + v * W;                       // AUROC 0..1 on one axis
+
+    [0, .25, .5, .75, 1].forEach(v => {
+      g.appendChild(el("line", { x1: x(v), y1: T - 6, x2: x(v), y2: T + M.length * rowH - 14, class: "grid" }));
+      const t = el("text", { x: x(v), y: T + M.length * rowH + 2, "text-anchor": "middle", class: "val-sm" });
+      t.textContent = v.toFixed(2); g.appendChild(t);
+    });
+    // chance reference
+    const ch = el("line", { x1: x(.5), y1: T - 6, x2: x(.5), y2: T + M.length * rowH - 14,
+                            stroke: "var(--text-muted)", "stroke-width": "1", "stroke-dasharray": "3 3" });
+    g.appendChild(ch);
+    const cl = el("text", { x: x(.5), y: T - 10, "text-anchor": "middle", class: "val-sm" });
+    cl.textContent = "chance"; g.appendChild(cl);
+
+    M.forEach((d, i) => {
+      const y = T + i * rowH;
+      [["mal", "var(--series-1)", 0], ["mac", "var(--series-2)", barH + GAP]].forEach(([k, col, dy]) => {
+        const w = Math.max(2, d[k] * W);
+        const grp = el("g", { class: "bar" });
+        grp.appendChild(el("rect", { x: L, y: y + dy, width: w, height: barH, rx: 4, fill: col }));
+        const ti = el("title");
+        ti.textContent = `${d.m} — ${k === "mal" ? "malignant vs rest" : "macro"} AUROC ${d[k].toFixed(3)}`;
+        grp.appendChild(ti);
+        g.appendChild(grp);
+        const t = el("text", { x: L + w + 7, y: y + dy + barH - 3,
+                               class: d.hi ? "val" : "val-sm" });
+        t.textContent = d[k].toFixed(3); g.appendChild(t);
+      });
+      const nm = el("text", { x: L - 12, y: y + barH - 2, "text-anchor": "end",
+                              class: d.hi ? "val" : "lbl" });
+      nm.textContent = d.m; g.appendChild(nm);
+      const sb = el("text", { x: L - 12, y: y + barH + 12, "text-anchor": "end", class: "val-sm" });
+      sb.textContent = d.sub; g.appendChild(sb);
+    });
+    g.appendChild(el("line", { x1: L, y1: T - 6, x2: L, y2: T + M.length * rowH - 14, class: "axis" }));
   })();
 
   /* ---------- table ---------- */

--- a/docs/report_wp2_wp3_status_M45.html
+++ b/docs/report_wp2_wp3_status_M45.html
@@ -1,0 +1,604 @@
+<title>ODELIA at M45</title>
+<style>
+  :root {
+    --ground:      #FBFCFD;
+    --surface:     #FFFFFF;
+    --surface-alt: #F2F6F8;
+    --ink:         #16202B;
+    --ink-soft:    #35485A;
+    --muted:       #59697A;
+    --rule:        #DCE3E9;
+    --rule-soft:   #EBF0F4;
+    --accent:      #0F6E8C;
+    --accent-soft: #E2EFF4;
+    --good:        #2E7250;
+    --good-bg:     #E4F0E9;
+    --warn:        #96662A;
+    --warn-bg:     #F6EDDF;
+    --bad:         #9E3339;
+    --bad-bg:      #F7E5E6;
+    --shadow:      0 1px 2px rgba(22,32,43,.05), 0 8px 24px -16px rgba(22,32,43,.28);
+
+    --serif: "Iowan Old Style", "Charter", "Bitstream Charter", "Palatino Linotype", Palatino, Georgia, serif;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground:      #0D1418;
+      --surface:     #141D23;
+      --surface-alt: #1A252C;
+      --ink:         #E2EAEF;
+      --ink-soft:    #BDCBD5;
+      --muted:       #93A5B2;
+      --rule:        #25333C;
+      --rule-soft:   #1C282F;
+      --accent:      #54B5D0;
+      --accent-soft: #12303A;
+      --good:        #6FBE92;
+      --good-bg:     #163024;
+      --warn:        #D6A45C;
+      --warn-bg:     #33260F;
+      --bad:         #E08088;
+      --bad-bg:      #351A1D;
+      --shadow:      0 1px 2px rgba(0,0,0,.4), 0 8px 24px -16px rgba(0,0,0,.7);
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground:      #0D1418;
+    --surface:     #141D23;
+    --surface-alt: #1A252C;
+    --ink:         #E2EAEF;
+    --ink-soft:    #BDCBD5;
+    --muted:       #93A5B2;
+    --rule:        #25333C;
+    --rule-soft:   #1C282F;
+    --accent:      #54B5D0;
+    --accent-soft: #12303A;
+    --good:        #6FBE92;
+    --good-bg:     #163024;
+    --warn:        #D6A45C;
+    --warn-bg:     #33260F;
+    --bad:         #E08088;
+    --bad-bg:      #351A1D;
+    --shadow:      0 1px 2px rgba(0,0,0,.4), 0 8px 24px -16px rgba(0,0,0,.7);
+  }
+
+  body {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.62;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap {
+    max-width: 62rem;
+    margin: 0 auto;
+    padding: clamp(1.75rem, 4vw, 4rem) clamp(1.1rem, 4vw, 2.5rem) 5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 3.25rem;
+  }
+  .prose { max-width: 44rem; }
+
+  /* ---- masthead ---------------------------------------------------- */
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: .72rem;
+    letter-spacing: .13em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  h1 {
+    font-family: var(--serif);
+    font-size: clamp(2.1rem, 5.5vw, 3.1rem);
+    line-height: 1.08;
+    letter-spacing: -.015em;
+    font-weight: 600;
+    margin: .55rem 0 0;
+    text-wrap: balance;
+  }
+  .standfirst {
+    font-family: var(--serif);
+    font-size: clamp(1.05rem, 2.2vw, 1.28rem);
+    line-height: 1.5;
+    color: var(--ink-soft);
+    margin: 1rem 0 0;
+    max-width: 40rem;
+    text-wrap: pretty;
+  }
+  .masthead { border-bottom: 2px solid var(--ink); padding-bottom: 1.75rem; }
+
+  /* ---- sections ---------------------------------------------------- */
+  section { display: flex; flex-direction: column; gap: 1.1rem; }
+  h2 {
+    font-family: var(--serif);
+    font-size: clamp(1.4rem, 3vw, 1.72rem);
+    line-height: 1.2;
+    font-weight: 600;
+    letter-spacing: -.01em;
+    margin: 0;
+    padding-bottom: .5rem;
+    border-bottom: 1px solid var(--rule);
+    text-wrap: balance;
+  }
+  h3 {
+    font-size: .95rem;
+    font-weight: 650;
+    margin: 0;
+    letter-spacing: -.005em;
+  }
+  p { margin: 0; }
+  .prose p + p { margin-top: .85rem; }
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  a:focus-visible, summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+  code {
+    font-family: var(--mono);
+    font-size: .855em;
+    background: var(--surface-alt);
+    border: 1px solid var(--rule-soft);
+    border-radius: 3px;
+    padding: .08em .34em;
+  }
+  strong { font-weight: 650; }
+
+  /* ---- timeline ---------------------------------------------------- */
+  .timeline {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 1px;
+    background: var(--rule);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .tl-cell { background: var(--surface); padding: 1rem 1.1rem 1.15rem; }
+  .tl-cell.now { background: var(--accent-soft); }
+  .tl-when {
+    font-family: var(--mono);
+    font-size: .72rem;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .tl-cell.now .tl-when { color: var(--accent); font-weight: 600; }
+  .tl-what { font-size: 1.32rem; font-family: var(--serif); font-weight: 600; margin-top: .2rem; line-height: 1.15; }
+  .tl-note { font-size: .82rem; color: var(--muted); margin-top: .3rem; line-height: 1.45; }
+
+  /* ---- tables ------------------------------------------------------ */
+  .scroll { overflow-x: auto; border: 1px solid var(--rule); border-radius: 6px; background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; font-size: .875rem; min-width: 44rem; }
+  th, td { text-align: left; padding: .68rem .85rem; border-bottom: 1px solid var(--rule-soft); vertical-align: top; }
+  thead th {
+    font-family: var(--mono);
+    font-size: .68rem;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+    background: var(--surface-alt);
+    border-bottom: 1px solid var(--rule);
+    white-space: nowrap;
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  td.id { font-family: var(--mono); font-size: .8rem; white-space: nowrap; font-variant-numeric: tabular-nums; }
+  td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+  /* ---- chips ------------------------------------------------------- */
+  .chip {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: .66rem;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    padding: .18em .5em;
+    border-radius: 3px;
+    white-space: nowrap;
+    font-weight: 600;
+  }
+  .chip.done    { background: var(--good-bg); color: var(--good); }
+  .chip.flight  { background: var(--accent-soft); color: var(--accent); }
+  .chip.blocked { background: var(--bad-bg); color: var(--bad); }
+  .chip.none    { background: var(--warn-bg); color: var(--warn); }
+
+  /* ---- callouts ---------------------------------------------------- */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 1.15rem 1.3rem;
+    box-shadow: var(--shadow);
+  }
+  .card + .card { margin-top: .8rem; }
+  .card p { font-size: .93rem; color: var(--ink-soft); }
+  .card h3 + p { margin-top: .4rem; }
+
+  .recommend {
+    background: var(--surface);
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .recommend-head {
+    background: var(--accent-soft);
+    padding: 1rem 1.3rem;
+    border-bottom: 1px solid var(--accent);
+  }
+  .recommend-head .eyebrow { color: var(--accent); }
+  .recommend-head .title { font-family: var(--serif); font-size: 1.3rem; font-weight: 600; margin-top: .2rem; line-height: 1.2; }
+  .recommend-body { padding: 1.2rem 1.3rem; display: flex; flex-direction: column; gap: .9rem; }
+  .recommend-body p { font-size: .93rem; }
+
+  ul.steps { margin: 0; padding-left: 1.15rem; display: flex; flex-direction: column; gap: .45rem; font-size: .93rem; color: var(--ink-soft); }
+  ul.steps li::marker { color: var(--accent); }
+
+  .caveats { display: flex; flex-direction: column; gap: .75rem; }
+  .caveat {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: .8rem;
+    align-items: baseline;
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--warn);
+    border-radius: 4px;
+    padding: .85rem 1rem;
+    font-size: .91rem;
+    color: var(--ink-soft);
+  }
+  .caveat .n {
+    font-family: var(--mono);
+    font-size: .72rem;
+    color: var(--warn);
+    font-weight: 700;
+  }
+
+  .kv { display: grid; grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr)); gap: 1px; background: var(--rule); border: 1px solid var(--rule); border-radius: 6px; overflow: hidden; }
+  .kv > div { background: var(--surface); padding: .85rem 1rem; }
+  .kv dt { font-family: var(--mono); font-size: .67rem; letter-spacing: .09em; text-transform: uppercase; color: var(--muted); }
+  .kv dd { margin: .25rem 0 0; font-size: 1.22rem; font-family: var(--serif); font-weight: 600; font-variant-numeric: tabular-nums; }
+  .kv .sub { display: block; font-size: .78rem; color: var(--muted); font-family: var(--sans); font-weight: 400; margin-top: .1rem; }
+
+  footer {
+    border-top: 1px solid var(--rule);
+    padding-top: 1.25rem;
+    font-size: .82rem;
+    color: var(--muted);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+  }
+</style>
+
+<div class="wrap">
+
+  <header class="masthead">
+    <div class="eyebrow">ODELIA · WP2 / WP3 · 9 September 2026</div>
+    <h1>ODELIA at M45</h1>
+    <p class="standfirst">
+      The capability that blocked all four outstanding grant tasks is fixed, and now verified on
+      real hospital data. Three deliverables are due in three months. The obstacle is no longer
+      the software — it is that the consortium fleet cannot currently hold a run together.
+    </p>
+  </header>
+
+  <!-- ============================================================ -->
+  <section>
+    <h2>The clock</h2>
+    <div class="timeline">
+      <div class="tl-cell now">
+        <div class="tl-when">Now</div>
+        <div class="tl-what">M45</div>
+        <div class="tl-note">Sep 2026. 15 months of the 60&#8209;month grant remain.</div>
+      </div>
+      <div class="tl-cell">
+        <div class="tl-when">In 3 months</div>
+        <div class="tl-what">M48</div>
+        <div class="tl-note">D2.5, D3.2, D3.4 — three deliverables at once.</div>
+      </div>
+      <div class="tl-cell">
+        <div class="tl-when">In 9 months</div>
+        <div class="tl-what">M54</div>
+        <div class="tl-note">D3.3 and MS6. MS6 needs partner scheduling now.</div>
+      </div>
+      <div class="tl-cell">
+        <div class="tl-when">In 15 months</div>
+        <div class="tl-what">M60</div>
+        <div class="tl-note">D3.5. Largely evidenced already by the 8&#8209;site run.</div>
+      </div>
+    </div>
+    <div class="prose">
+      <p>
+        Every one of these is typed in Part&nbsp;A as <em>R — Document, report</em>, including D3.3,
+        which reads like a software release. The grant asks for evidence and documentation; software
+        is the means. That makes the M48 cluster achievable — but only if the experiments behind
+        the reports start now.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section>
+    <h2>What landed today</h2>
+    <div class="prose">
+      <p>
+        Per-site metrics never reached the coordinator.
+        <code>cross_site_val/cross_val_results.json</code> came back <code>{}</code> after every
+        peer-to-peer run — the two-day 20-round run and a 52-second smoke run alike — so per-site
+        figures had to be gathered by logging into each hospital by hand.
+      </p>
+      <p>
+        This was the critical path. The regulatory testing node in T3.2 exists specifically to
+        receive per-site performance figures; D2.5 needs per-region metrics to compare against; the
+        T3.3 privacy work needs per-round epsilon logged beside utility. None of it could be built
+        on top of nothing.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>Two bugs, not one</h3>
+      <p>
+        The first was the expected gap: nothing on the server handled the
+        <code>fed.analytix_log_stats</code> event the clients were already streaming. A collector
+        component closes that hop.
+      </p>
+      <p>
+        The second only appeared once the first was fixed, and it is the interesting one. The server
+        log said the metrics had arrived —
+        <code>Published metrics for 8 site(s)</code> — and the file was
+        <em>still</em> <code>{}</code>. Two components act on the same <code>END_RUN</code> event,
+        and components fire in the order they appear in the job config. The JSON writer is listed
+        first in all seven configs, so it wrote the file and only then did the collector publish into
+        it. Now published on <code>ABOUT_TO_END_RUN</code>, which is fired strictly earlier, so the
+        result no longer depends on config ordering.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>CI was green throughout</h3>
+      <p>
+        The collector's test file was skipped in its entirety, because the unit-test workflow never
+        installed NVFlare — and a skipped file reports the same green as a passing one. That is why
+        a broken metric path survived two live eight-site runs. The workflow now installs the
+        in-tree fork; the tests run and are visible by name. This is the third time this repository
+        has been bitten by a missing test dependency.
+      </p>
+    </div>
+
+    <dl class="kv">
+      <div><dt>Verification run</dt><dd>8 / 8<span class="sub">sites reporting, job <code>c5520641</code></span></dd></div>
+      <div><dt>Run time</dt><dd>34 s<span class="sub">a fast loop for future checks</span></dd></div>
+      <div><dt>Unit tests</dt><dd>392<span class="sub">passing in CI, 13 previously skipped</span></dd></div>
+      <div><dt>Catalogued as</dt><dd>F10<span class="sub">in the swarm failure modes doc</span></dd></div>
+    </dl>
+  </section>
+
+  <!-- ============================================================ -->
+  <section>
+    <h2>The four tasks</h2>
+    <div class="scroll">
+      <table>
+        <thead>
+          <tr>
+            <th>Deliverable</th><th>Task</th><th>Due</th><th>Left</th><th>Status</th><th>Position</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="id">D2.5</td><td class="id">T2.4</td><td class="id">M48</td><td class="num">3 mo</td>
+            <td><span class="chip flight">In progress</span></td>
+            <td>Fine-tuning ran; paired analysis built. Was blocked on retrieving the model — #556 removes that need.</td>
+          </tr>
+          <tr>
+            <td class="id">D3.2</td><td class="id">T3.2</td><td class="id">M48</td><td class="num">3 mo</td>
+            <td><span class="chip flight">Started</span></td>
+            <td>Selection strategies built (#555). Federated form would cost ~110&nbsp;h; simulated instead, with one confirmation run.</td>
+          </tr>
+          <tr>
+            <td class="id">D3.4</td><td class="id">WP3</td><td class="id">M48</td><td class="num">3 mo</td>
+            <td><span class="chip flight">Started</span></td>
+            <td>Design on #529. All nine jobs aggregate by plain weighted mean; the fork ships no robust alternative, so one participant can move the global model.</td>
+          </tr>
+          <tr>
+            <td class="id">D3.3</td><td class="id">T3.2</td><td class="id">M54</td><td class="num">9 mo</td>
+            <td><span class="chip none">Not started</span></td>
+            <td>Regulatory testing node. Depended entirely on today's fix.</td>
+          </tr>
+          <tr>
+            <td class="id">MS6</td><td class="id">T3.3</td><td class="id">M54</td><td class="num">9 mo</td>
+            <td><span class="chip blocked">Needs partners</span></td>
+            <td>White-hat attack requires CAM and RUMC. The one item not executable alone.</td>
+          </tr>
+          <tr>
+            <td class="id">D3.5</td><td class="id">T3.4</td><td class="id">M60</td><td class="num">15 mo</td>
+            <td><span class="chip flight">Part-evidenced</span></td>
+            <td>The 8-site run is the demonstration. Needs a re-run on the released version.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="prose">
+      <p>
+        <strong>The round-cost budget is measured, not guessed.</strong> The reference run completed
+        20 rounds across 8 sites in 1&nbsp;day 19&nbsp;h 53&nbsp;m — <strong>2.2&nbsp;hours per
+        round</strong>, gated by the slowest site. Any active-learning loop must be costed against
+        that: five selection iterations of five rounds each is roughly 55&nbsp;hours per
+        configuration. Design the D3.2 experiment to fit, or it will not land by M48.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section>
+    <h2>What is verified, and what is not</h2>
+    <div class="prose">
+      <p>
+        The metric path is <strong>verified end to end on the production trainer</strong>, at real
+        sites, on real data. Job <code>513c8988</code> (RUMC + UMCU) returned this to the
+        coordinator — the file that came back empty after every previous peer-to-peer run:
+      </p>
+    </div>
+
+    <div class="scroll">
+      <table>
+        <thead>
+          <tr><th>Site</th><th>n</th><th>No lesion</th><th>Benign</th><th>Malignant</th><th>Accuracy</th><th>AUROC</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="id">RUMC_1</td><td class="num">896</td><td class="num">888</td><td class="num">0</td><td class="num">8</td><td class="num">0.991</td><td class="num">0.417</td></tr>
+          <tr><td class="id">UMCU_1</td><td class="num">1557</td><td class="num">1361</td><td class="num">186</td><td class="num">10</td><td class="num">0.874</td><td class="num">0.698</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h3>These two rows are the argument for the whole change</h3>
+      <p>
+        RUMC reports <strong>99.1&#8239;% accuracy with an AUROC of 0.417 — below chance</strong>.
+        The support columns explain it at a glance: 888 no-lesion cases, <strong>zero</strong>
+        benign, 8 malignant. The model answers "no lesion" almost always, scores 99&#8239;% on a
+        99:1 split, and discriminates nothing.
+      </p>
+      <p>
+        Reported without its support — which is how per-site figures were gathered until now — RUMC
+        would read as the consortium's strongest site. That is E1 and E3 from the evaluation
+        pitfalls, not argued but demonstrated, on the first run that could produce the evidence.
+      </p>
+    </div>
+
+    <div class="prose"><p>Four things remain genuinely open:</p></div>
+    <div class="caveats">
+      <div class="caveat">
+        <span class="n">01</span>
+        <span>
+          <strong>Model transfers are relayed through Frankfurt.</strong> Eight consecutive runs
+          failed with no code defect among them, and the in-house loop finally gave the mechanism:
+          dl0 and dl2 sit on one subnet and reach each other directly in 1&nbsp;ms, but the
+          coordinating server is in another city and unreachable directly, so Tailscale falls back
+          to a DERP relay — and the swarm routes peer traffic through the server. A 700&nbsp;MB
+          model travels Dresden&nbsp;→&nbsp;Frankfurt&nbsp;→&nbsp;Heidelberg&nbsp;→&nbsp;Frankfurt&nbsp;→&nbsp;Dresden,
+          twice per round (#553). Topology, not a defect in the training software.
+        </span>
+      </div>
+      <div class="caveat">
+        <span class="n">02</span>
+        <span>
+          <strong>D2.5's fine-tuned model cannot be reached.</strong> Peer-to-peer runs leave the
+          model client-side only — the server archive holds no checkpoint at all — so the Dutch
+          model exists solely at RUMC and UMCU, which nobody here can log into.
+        </span>
+      </div>
+      <div class="caveat">
+        <span class="n">03</span>
+        <span>
+          <strong>A run can finish its rounds and never publish.</strong> <code>513c8988</code>
+          completed all five rounds, then sat five hours without firing end-of-run; the results
+          appeared only when it was aborted. Separate from the metric path, and it would silently
+          lose a completed benchmark.
+        </span>
+      </div>
+      <div class="caveat">
+        <span class="n">04</span>
+        <span>
+          <strong>Excluding a site from training does not exclude it from the job.</strong> UKA and
+          CAM both reported dead into runs they were not participating in, because the job still
+          deploys everywhere.
+        </span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section>
+    <h2>What to do next</h2>
+
+    <div class="recommend">
+      <div class="recommend-head">
+        <div class="eyebrow">Recommended next task</div>
+        <div class="title">Return per-case predictions through the channel that now works</div>
+      </div>
+      <div class="recommend-body">
+        <p>
+          D2.5 is blocked on retrieving a 722&nbsp;MB checkpoint from hospitals nobody can log into.
+          That is the wrong problem to solve. The fix that landed this week already carries per-site
+          results out of the sites without moving a model — it just carries aggregates today.
+        </p>
+        <ul class="steps">
+          <li>Extend the same path to return <strong>per-case predictions</strong> — a row index, the ground-truth label, and the class probabilities. <strong>No case or patient identifier</strong>: the index is a position in the site's own split and means nothing outside it, which is enough to pair two models because the validation loader is not shuffled.</li>
+          <li>D2.5 then needs no checkpoint transfer at all: evaluate both models site-side, compare centrally.</li>
+          <li>It also unblocks the paired bootstrap, which needs case-level pairing and cannot run on aggregates.</li>
+          <li>And it is the mechanism D3.3's regulatory testing node was always going to require.</li>
+        </ul>
+        <p>
+          One deliverable's blocker, the analysis method it needs, and an M54 deliverable's core
+          capability turn out to be the same piece of work. <strong>Built and open as #556</strong>,
+          off by default: nothing leaves a site unless that site sets the flag itself, because
+          returning patient-derived data is the consortium's decision and not a maintainer's.
+        </p>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Stop iterating on the partner fleet</h3>
+      <p>
+        Five failed runs cost days and partner GPU time while teaching nothing about the code. Both
+        in-house dl servers sit idle, and the two-node config already maps them to real site names.
+        Development and testing move there; the consortium is reserved for final benchmarks.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>Worth starting in parallel</h3>
+      <p>
+        MS6's white-hat attack needs CAM and RUMC, and M54 arrives after a coordination round-trip,
+        so that request should go out regardless of the rest. And the shared warm-start checkpoint
+        path (#535) came within one round of destroying the pan-European baseline three separate
+        times this week — a small fix guarding a large and entirely silent loss.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section>
+    <h2>Board</h2>
+    <div class="scroll">
+      <table>
+        <thead>
+          <tr><th>Item</th><th>What</th><th>State</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="id">Merged 8 Sep</td><td>#533 pitfalls · #544 deploy test · #446 supply chain · #514 strict swarm · #520 STAMP</td><td><span class="chip done">5 merged</span></td></tr>
+          <tr><td class="id">PR #534</td><td>Per-site metrics with class support</td><td><span class="chip flight">6/6 green — needs review</span></td></tr>
+          <tr><td class="id">PR #545</td><td>Warm-start provenance guard (#535)</td><td><span class="chip flight">6/6 green — needs review</span></td></tr>
+          <tr><td class="id">PR #552</td><td>Weekly all-models preflight never ran</td><td><span class="chip flight">6/6 green — needs review</span></td></tr>
+          <tr><td class="id">main</td><td>Post-merge health, checked by hand</td><td><span class="chip done">25/26 steps pass</span></td></tr>
+          <tr><td class="id">#525 · #441</td><td>Per-site metrics and metric alignment</td><td><span class="chip done">Verified on real data</span></td></tr>
+          <tr><td class="id">#541–#543</td><td>Model mismatch · run never publishes · deploy not scoped</td><td><span class="chip blocked">Filed 8 Sep</span></td></tr>
+          <tr><td class="id">#553 · #554</td><td>Frankfurt relay · nothing validates main after a merge</td><td><span class="chip blocked">Filed</span></td></tr>
+          <tr><td class="id">M48</td><td>D2.5, D3.2, D3.4 — three months out</td><td>4 open</td></tr>
+          <tr><td class="id">M54</td><td>D3.3, MS6, differential privacy phase 2</td><td>3 open</td></tr>
+          <tr><td class="id">M60</td><td>D3.5 operational demonstration</td><td>1 open</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="prose">
+      <p>
+        Three pull requests sit green on all six checks, blocked only on a review that cannot come
+        from their author. That is the cheapest unblock available — no code, no compute, just a
+        second pair of eyes.
+      </p>
+    </div>
+  </section>
+
+  <footer>
+    Status as of 9 September 2026. Every figure here was read from the live server, the site logs or
+    CI on 8 September. The per-site training-set sizes previously quoted in planning were wrong by
+    two orders of magnitude and have been corrected at source.
+  </footer>
+
+</div>


### PR DESCRIPTION
Puts the three current pages under `docs/` so they are versioned alongside the code that produced their numbers, and adds `docs/PRESENTATIONS.md` naming which is current.

| File | What it is |
|---|---|
| `presentation_consortium_briefing.html` | 8 slides for the technical meeting |
| `presentation_data_by_site.html` | training data and class distribution, 4 charts |
| `report_wp2_wp3_status_M45.html` | WP2/WP3 status for the committee |

The June experiments deck (`presentation_swarm_results.html`) was already here and is indexed as earlier material.

## New: model comparison

The briefing gains a slide placing the current model against what came before.

| Model | Sites | Malignant AUROC | Macro AUROC |
|---|---:|---:|---:|
| **Swarm · 1DivideAndConquer** | **8** | **0.887** | **0.820** |
| Swarm · 4LME_ABMIL (Jun) | 6 | 0.847 | 0.764 |
| Best single site — UKA · 1DC | 1 | 0.858 | 0.709 |
| Median of 10 single-site models | 1 | 0.658 | 0.601 |
| Weakest single site — RUMC · 1DC | 1 | 0.408 | 0.483 |

**+0.229** malignant AUROC over the median single-site model, **+0.029** over the strongest — which is UKA, the site holding half the consortium's data — and **+0.040** over the previous six-site swarm.

## The caveat is on the slide, not buried

These are three separate evaluations on overlapping but **not identical** challenge subsets — 165 cases for the eight-site run, 300 for the June matrix. The direction is consistent and repeated across them; the exact gaps are not a controlled comparison. Both the slide and the index say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)