### PR TITLE
docs: rewrite the consortium briefing for a non-technical audience

### DIFF
--- a/docs/PRESENTATIONS.md
+++ b/docs/PRESENTATIONS.md
@@ -6,17 +6,33 @@ verified, the page says so rather than omitting the gap.
 
 ## Current
 
-### `presentation_consortium_briefing.html` — consortium technical meeting
-**8 slides · 9 September 2026 · built for a meeting, prints one slide per page**
+### `presentation_consortium_briefing.html` — consortium briefing
+**12 slides · 10 September 2026 · built for a meeting, prints one slide per page**
 
-The deck to show partners. Opens with per-site results now reaching the coordinator,
-uses Radboud's 99.1 % accuracy against an AUROC of 0.417 to explain why support
-counts travel with every metric, states plainly that five consecutive runs failed on
-infrastructure, and closes on one request: permission in principle to return
-per-case predictions.
+The deck to show partners, rewritten for a non-technical audience: no job IDs, no
+config paths, no code identifiers. It explains the *design* first and the
+*achievement* second, and carries four hand-drawn diagrams.
 
-Slide 6 is the model comparison — the eight-site swarm against the previous six-site
-swarm and against ten single-site models.
+| Slide | What it does |
+|---|---|
+| 2 | **Infrastructure diagram** — the eight sites as a ring, the model travelling between them, the coordinator drawn deliberately small because it holds no data |
+| 3 | **Flow diagram** — one training round in four steps, with the return loop that makes eight hops into a round |
+| 4 | **Boundary diagram** — what stays inside a hospital against what crosses the network, including the opt-in per-case predictions |
+| 5 | Per-site training volumes at true scale, stacked by class |
+| 6–7 | The model comparison, and why the smallest sites gain most |
+| 8 | **Prevention-loop diagram** — how one site's incident becomes a permanent fix for all eight, beside the recent failure timeline |
+| 9 | Radboud's 99.1 % accuracy against an AUROC of 0.417, as the plain-language case for reporting support counts |
+| 10 | The active-learning negative result and the privacy budget |
+| 12 | The ask: per-case predictions, and a slot with Cambridge and Nijmegen |
+
+The diagrams are **inline SVG, not mermaid**. Mermaid only auto-renders inside the
+artifact viewer; this file is also opened directly from the repo, where a mermaid
+fence would show as raw text. The SVG picks up the deck's own theme tokens and works
+in both light and dark.
+
+Rebuild with `scripts/presentation/build_consortium_briefing.py` rather than editing
+the HTML by hand — the diagram coordinates are computed, and the data assertions in
+it are what keep the class counts summing.
 
 ### `presentation_data_by_site.html` — training data by site
 **5 charts · 9 September 2026**
@@ -34,12 +50,29 @@ eight-site swarm against the six-site swarm and ten single-site models — so th
 and what it produced sit on one page.
 
 ### `report_wp2_wp3_status_M45.html` — WP2/WP3 status at M45
-**9 September 2026 · for the technical committee**
+**10 September 2026 · for the technical committee · stays technical on purpose**
 
 Where the four outstanding grant tasks stand with three deliverables due at M48, what
-is verified and what is not, and the recommended next task. A `.docx` of the same
-material for committee submission is at
-`workspace/reports/ODELIA_WP2_WP3_progress_2026-09-08.docx`.
+is verified and what is not, and the recommended next task.
+
+Updated 10 September with the section **"Two tasks produced their first result"**:
+
+- **D3.2** — uncertainty sampling *lost* to random at every labelling budget
+  (19 / 21 / 22.2 ± 2.8 malignant at a 100-label budget). The calibration diagnostic
+  explains it: the model is most confident on benign cases, the rarest class, so an
+  uncertainty rule deprioritises exactly what you want it to find. Reported as a
+  finding about calibration, not a verdict on active learning.
+- **T3.3 Phase 2** — the privacy guarantee is now a number. Over 20 rounds at
+  δ = 10⁻⁵: ε ≤ 10 needs σ ≥ 2.4, ε ≤ 3 needs σ ≥ 6.7, ε ≤ 1 needs σ ≥ 18.1. The
+  guarantee is client-level, not record-level, and the report says so.
+
+The board also reflects the nine PRs merged on 9–10 September and the recommended next
+task has changed accordingly: D2.5 no longer needs anything built, it needs a two-site
+run with per-case return enabled.
+
+A `.docx` of the earlier material for committee submission is at
+`workspace/reports/ODELIA_WP2_WP3_progress_2026-09-08.docx` — it predates the
+10 September update.
 
 ## Earlier
 

--- a/docs/PRESENTATIONS.md
+++ b/docs/PRESENTATIONS.md
@@ -35,15 +35,16 @@ the HTML by hand — the diagram coordinates are computed, and the data assertio
 it are what keep the class counts summing.
 
 ### `presentation_data_by_site.html` — training data by site
-**5 charts · 9 September 2026**
+**5 charts · 10 September 2026**
 
 How much data each hospital brought when it joined, how the consortium total
 accumulated to 34,462 volumes across eight sites, and the class distribution shown
 twice: at true scale and as shares. Reading them together is the point — RSH looks
 malignant-rich at 63 % until you see that is 221 volumes against UKA's 1,251.
 
-Sources are each site's own `Class counts` and `Weighted epochs` log lines, so every
-site's three classes sum exactly to its training size.
+Every count was emitted by that site's own trainer as it loaded its dataset, so each
+site's three classes sum exactly to its training size. The captions say this in plain
+language rather than by naming log lines — the deck is shown to partners.
 
 The last chart carries the same model comparison as slide 6 of the briefing — the
 eight-site swarm against the six-site swarm and ten single-site models — so the data

--- a/docs/presentation_data_by_site.html
+++ b/docs/presentation_data_by_site.html
@@ -104,7 +104,7 @@
 <div class="viz-root">
 
   <header>
-    <div class="eyebrow">ODELIA · breast-MRI swarm learning · 9 September 2026</div>
+    <div class="eyebrow">ODELIA · breast-MRI swarm learning · 10 September 2026</div>
     <h1>Training data by site</h1>
     <p class="sub">
       How much data each hospital brought when it joined, how the consortium total accumulated,
@@ -117,8 +117,8 @@
     <figure>
       <h2>What each site contributes today</h2>
       <figcaption>
-        Training samples per site (unilateral breast volumes), from each site's
-        <code>Weighted epochs</code> log line — <code>len(ds_train)</code> at batch size 1.
+        Training samples per site — one breast, one volume. Counted by each site's own
+        trainer as it loaded its dataset, and read back from that site's run log.
       </figcaption>
       <svg viewBox="0 0 720 300" role="img" aria-label="Training samples per site: UKA 17834, UMCU 6133, RUMC 3608, USZ 3448, CAM 1778, MHA 1120, RSH 351, VHIO 190">
         <g id="sizeBars"></g>
@@ -179,9 +179,9 @@
     <figure>
       <h2>Class distribution as shares</h2>
       <figcaption>
-        Composition of each site's <strong>training set</strong>, logged by the trainer at dataset
-        setup (<code>Class counts</code>). Bars show each site's own class mix; the label gives its
-        size and benign count.
+        Composition of each site's <strong>training set</strong>, counted by that site's own
+        trainer as it loaded the data. Bars show each site's class mix; the label gives its size
+        and benign count.
       </figcaption>
       <div class="legend" aria-hidden="true">
         <span><i class="swatch" style="background:var(--series-1)"></i> No lesion</span>
@@ -260,8 +260,8 @@
 
   <section class="card">
     <div class="note">
-      <strong>Provenance.</strong> Class counts are the trainer's own <code>Class counts</code> line,
-      emitted at dataset setup; each site's three classes sum exactly to its training size, and the
+      <strong>Provenance.</strong> Every count here was emitted by the site's own trainer as it
+      loaded its dataset — not transcribed from a spreadsheet or a planning note. Each site's three classes sum exactly to its training size, and the
       eight sites sum to 34,462. Figures are the most recent run whose training size matches the
       site's production configuration — 7 Sep for five sites, 4 Sep for UKA, 6 Jul for USZ and
       21 Jun for RUMC, those two having not run since. Records written by the two-node deploy test,

--- a/docs/report_wp2_wp3_status_M45.html
+++ b/docs/report_wp2_wp3_status_M45.html
@@ -278,12 +278,14 @@
 <div class="wrap">
 
   <header class="masthead">
-    <div class="eyebrow">ODELIA · WP2 / WP3 · 9 September 2026</div>
+    <div class="eyebrow">ODELIA · WP2 / WP3 · 10 September 2026</div>
     <h1>ODELIA at M45</h1>
     <p class="standfirst">
-      The capability that blocked all four outstanding grant tasks is fixed, and now verified on
-      real hospital data. Three deliverables are due in three months. The obstacle is no longer
-      the software — it is that the consortium fleet cannot currently hold a run together.
+      The capability that blocked all four outstanding grant tasks is fixed, verified on real
+      hospital data, and now merged along with the eight PRs behind it. Two of the four tasks have
+      produced their first result — one of them negative and informative. Three deliverables are
+      due in three months. The obstacle is no longer the software; it is that the consortium fleet
+      cannot currently hold a run together.
     </p>
   </header>
 
@@ -392,12 +394,12 @@
           <tr>
             <td class="id">D2.5</td><td class="id">T2.4</td><td class="id">M48</td><td class="num">3 mo</td>
             <td><span class="chip flight">In progress</span></td>
-            <td>Fine-tuning ran; paired analysis built. Was blocked on retrieving the model — #556 removes that need.</td>
+            <td>Fine-tuning ran; paired analysis built. The checkpoint-retrieval blocker is gone — #556 and #557 are merged. Needs one run with per-case return enabled at RUMC and UMCU.</td>
           </tr>
           <tr>
             <td class="id">D3.2</td><td class="id">T3.2</td><td class="id">M48</td><td class="num">3 mo</td>
-            <td><span class="chip flight">Started</span></td>
-            <td>Selection strategies built (#555). Federated form would cost ~110&nbsp;h; simulated instead, with one confirmation run.</td>
+            <td><span class="chip flight">First result</span></td>
+            <td>Strategies merged (#555); acquisition experiment run (#563). <strong>Negative result</strong> — uncertainty sampling underperforms random on this pool. Cause identified and reported below.</td>
           </tr>
           <tr>
             <td class="id">D3.4</td><td class="id">WP3</td><td class="id">M48</td><td class="num">3 mo</td>
@@ -413,6 +415,11 @@
             <td class="id">MS6</td><td class="id">T3.3</td><td class="id">M54</td><td class="num">9 mo</td>
             <td><span class="chip blocked">Needs partners</span></td>
             <td>White-hat attack requires CAM and RUMC. The one item not executable alone.</td>
+          </tr>
+          <tr>
+            <td class="id">T3.3</td><td class="id">T3.3</td><td class="id">M54</td><td class="num">9 mo</td>
+            <td><span class="chip flight">Phase 2 built</span></td>
+            <td>Calibrated-noise filter and an RDP accountant (#563). The guarantee is now a number the consortium can choose, not a claim. Phase 3 (record-level) not started.</td>
           </tr>
           <tr>
             <td class="id">D3.5</td><td class="id">T3.4</td><td class="id">M60</td><td class="num">15 mo</td>
@@ -515,30 +522,111 @@
 
   <!-- ============================================================ -->
   <section>
+    <h2>Two tasks produced their first result</h2>
+    <div class="prose">
+      <p>
+        Both were built as minimum viable versions against the M48 clock rather than the full
+        experiment in the proposal, and both are open as <strong>#563</strong>. One of them
+        returned a negative result, which is reported here as a finding rather than buried.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>D3.2 — uncertainty sampling is worse than random on this pool</h3>
+      <p>
+        The full deliverable is a labelling-budget curve of model performance, which needs a
+        retraining run per acquisition round per arm — roughly 110&nbsp;h of consortium GPU at the
+        measured 2.2&nbsp;h per round. That does not fit before M48, so the experiment answers the
+        part that needs no retraining: given a fixed model's per-case probabilities, does an
+        uncertainty rule surface the cases worth labelling sooner than random?
+      </p>
+      <p>
+        It does not. Over a pool of 165 cases (111 no-lesion, 17 benign, 37 malignant), at a
+        100-label budget: <strong>entropy 19 malignant, margin 21, random 22.2&nbsp;±&nbsp;2.8</strong>.
+        Entropy loses at <em>every</em> budget.
+      </p>
+      <p>
+        The calibration diagnostic shipped alongside it explains why, and this is the part worth
+        carrying forward. Mean predictive entropy is near-identical across the three classes —
+        0.987 / 0.878 / 0.981 — and the model is <strong>most confident on benign cases</strong>,
+        the rarest class: <strong>12 of 17 benign fall in the 30 lowest-entropy cases</strong>.
+        The model's confidence does not track whether it is right, so a rule that asks for the
+        cases it is least sure about actively deprioritises the rare ones.
+      </p>
+      <p>
+        <strong>This is a property of the model's calibration, not a verdict on active learning.</strong>
+        It says calibration has to be addressed before an uncertainty-based acquisition rule can be
+        expected to help, and that is a more useful thing to write in D3.2 than a curve produced by
+        a rule nobody checked.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>T3.3 Phase 2 — the privacy guarantee is now a number</h3>
+      <p>
+        The <code>PercentilePrivacy</code> filter wired into every job clips nothing and calibrates
+        noise to nothing, so it carries no formal guarantee at all. Phase 2 adds a filter that
+        clips each site's update to a known L2 norm and adds Gaussian noise scaled to it, plus a
+        self-contained Rényi-DP accountant — self-contained because Opacus is not in the ODELIA
+        image and adding it would force a rebuild and redistribution to all eight sites.
+      </p>
+      <p>
+        Over a 20-round run at δ&nbsp;=&nbsp;10⁻⁵, the cost of each guarantee is:
+      </p>
+      <div class="scroll">
+        <table>
+          <thead><tr><th>Target ε</th><th>Noise multiplier σ required</th><th>Reading</th></tr></thead>
+          <tbody>
+            <tr><td class="num">≤ 10</td><td class="num">2.4</td><td>Weak but non-vacuous; commonly accepted in practice</td></tr>
+            <tr><td class="num">≤ 3</td><td class="num">6.7</td><td>Strong</td></tr>
+            <tr><td class="num">≤ 1</td><td class="num">18.1</td><td>Strictest commonly cited; likely destroys utility at this scale</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        Two qualifications are stated in the code and must survive into the deliverable. The
+        guarantee is <strong>client-level, not record-level</strong> — it hides whether a site
+        participated in a round, and says nothing about whether a given patient was in that site's
+        training set; that needs DP-SGD during local training, which is Phase 3. And the accounting
+        assumes a sampling rate of 1, which is our case and is the conservative direction: it
+        over-states the privacy cost rather than under-stating it.
+      </p>
+    </div>
+
+    <div class="prose">
+      <p>
+        <strong>What neither of these is yet.</strong> No model has been trained on an
+        actively-selected set, and no model has been trained with the noise filter enabled, so the
+        utility cost of any σ above is unmeasured. Both are the next runs, not the next builds.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section>
     <h2>What to do next</h2>
 
     <div class="recommend">
       <div class="recommend-head">
         <div class="eyebrow">Recommended next task</div>
-        <div class="title">Return per-case predictions through the channel that now works</div>
+        <div class="title">Close D2.5 with a two-site run that returns per-case predictions</div>
       </div>
       <div class="recommend-body">
         <p>
-          D2.5 is blocked on retrieving a 722&nbsp;MB checkpoint from hospitals nobody can log into.
-          That is the wrong problem to solve. The fix that landed this week already carries per-site
-          results out of the sites without moving a model — it just carries aggregates today.
+          The mechanism D2.5 was waiting on is merged (#556, #557). Nothing further needs building:
+          the deliverable now needs a <em>run</em>. The checkpoint that could not be retrieved from
+          RUMC and UMCU no longer has to be — both models are evaluated where they sit and only the
+          predictions come back.
         </p>
         <ul class="steps">
-          <li>Extend the same path to return <strong>per-case predictions</strong> — a row index, the ground-truth label, and the class probabilities. <strong>No case or patient identifier</strong>: the index is a position in the site's own split and means nothing outside it, which is enough to pair two models because the validation loader is not shuffled.</li>
-          <li>D2.5 then needs no checkpoint transfer at all: evaluate both models site-side, compare centrally.</li>
-          <li>It also unblocks the paired bootstrap, which needs case-level pairing and cannot run on aggregates.</li>
-          <li>And it is the mechanism D3.3's regulatory testing node was always going to require.</li>
+          <li>Ask RUMC and UMCU to set the opt-in flag. This is a consortium decision, not a maintainer's: it is off by default and stays off until each site turns it on.</li>
+          <li>Run the pan-European baseline and the Dutch fine-tuned model over each site's own validation split, returning row index, ground-truth label and class probabilities. No case or patient identifier — the index is a position in the site's own split and means nothing outside it.</li>
+          <li>Feed both prediction sets to <code>compare_regional_finetune.py</code>. The primary endpoint is malignant-vs-rest, paired bootstrap over jointly resampled cases; macro AUROC is reported only with support attached, never as a ranking.</li>
+          <li>Expect the honest answer to be "no difference detectable at this sample size" — 49 paired Dutch cases with 9 malignant. That is a publishable result for D2.5 provided the interval is reported, and it is far better than a point estimate from an uncontrolled comparison.</li>
         </ul>
         <p>
-          One deliverable's blocker, the analysis method it needs, and an M54 deliverable's core
-          capability turn out to be the same piece of work. <strong>Built and open as #556</strong>,
-          off by default: nothing leaves a site unless that site sets the flag itself, because
-          returning patient-derived data is the consortium's decision and not a maintainer's.
+          One request to two partners converts a blocked deliverable into a measured one. It also
+          exercises, on real sites, the exact path D3.3's regulatory testing node will need at M54.
         </p>
       </div>
     </div>
@@ -556,9 +644,16 @@
       <h3>Worth starting in parallel</h3>
       <p>
         MS6's white-hat attack needs CAM and RUMC, and M54 arrives after a coordination round-trip,
-        so that request should go out regardless of the rest. And the shared warm-start checkpoint
-        path (#535) came within one round of destroying the pan-European baseline three separate
-        times this week — a small fix guarding a large and entirely silent loss.
+        so that request should go out regardless of the rest. The warm-start guard (#535) is merged
+        as #545, after the shared checkpoint path came within one round of destroying the
+        pan-European baseline three separate times.
+      </p>
+      <p>
+        Two items also need owning rather than waiting: <strong>calibration</strong>, which the
+        D3.2 negative result puts on the critical path for both active learning and any
+        confidence-based clinical claim; and the <strong>utility cost of privacy noise</strong>,
+        which cannot be argued from the accountant alone and needs one training run at
+        σ&nbsp;=&nbsp;2.4 to become a real trade-off rather than a table.
       </p>
     </div>
   </section>
@@ -573,13 +668,16 @@
         </thead>
         <tbody>
           <tr><td class="id">Merged 8 Sep</td><td>#533 pitfalls · #544 deploy test · #446 supply chain · #514 strict swarm · #520 STAMP</td><td><span class="chip done">5 merged</span></td></tr>
-          <tr><td class="id">PR #534</td><td>Per-site metrics with class support</td><td><span class="chip flight">6/6 green — needs review</span></td></tr>
-          <tr><td class="id">PR #545</td><td>Warm-start provenance guard (#535)</td><td><span class="chip flight">6/6 green — needs review</span></td></tr>
-          <tr><td class="id">PR #552</td><td>Weekly all-models preflight never ran</td><td><span class="chip flight">6/6 green — needs review</span></td></tr>
-          <tr><td class="id">main</td><td>Post-merge health, checked by hand</td><td><span class="chip done">25/26 steps pass</span></td></tr>
+          <tr><td class="id">Merged 9–10 Sep</td><td>#534 per-site metrics · #545 warm-start guard · #552 weekly preflight · #555 AL strategies · #558 deck index</td><td><span class="chip done">5 merged</span></td></tr>
+          <tr><td class="id">Merged 10 Sep</td><td>#556 + #557 per-case predictions, wired end to end · #560 run history frozen</td><td><span class="chip done">D2.5 unblocked</span></td></tr>
+          <tr><td class="id">Merged 10 Sep</td><td>#559 all-models preflight (Ole's, reviewed against his cited green run) · #548 · #549 · #551 dependabot</td><td><span class="chip done">Critical trivy alert closed — 0 open</span></td></tr>
+          <tr><td class="id">PR #563</td><td>Active-learning and privacy-accounting MVPs</td><td><span class="chip flight">5/6 green, swarm check running</span></td></tr>
+          <tr><td class="id">PR #550</td><td>Dependabot upload-artifact 4 → 7</td><td><span class="chip blocked">Failed 4×, rerun queued</span></td></tr>
+          <tr><td class="id">PR #547</td><td>Ole's — clarify run_3dcnn_training_in_swarm</td><td><span class="chip blocked">Real failure: test expects ResNet101, actual is MST</span></td></tr>
           <tr><td class="id">#525 · #441</td><td>Per-site metrics and metric alignment</td><td><span class="chip done">Verified on real data</span></td></tr>
-          <tr><td class="id">#541–#543</td><td>Model mismatch · run never publishes · deploy not scoped</td><td><span class="chip blocked">Filed 8 Sep</span></td></tr>
-          <tr><td class="id">#553 · #554</td><td>Frankfurt relay · nothing validates main after a merge</td><td><span class="chip blocked">Filed</span></td></tr>
+          <tr><td class="id">Run history</td><td>101 jobs, 231 site-rows, Mar–Sep 2026, committed to the repo</td><td><span class="chip done">Frozen — 59 real-site jobs</span></td></tr>
+          <tr><td class="id">#541–#543 · #562</td><td>Model mismatch · run never publishes · deploy not scoped · Swin3D cannot train</td><td><span class="chip blocked">Open</span></td></tr>
+          <tr><td class="id">#553 · #554</td><td>Frankfurt relay · nothing validates main after a merge</td><td><span class="chip blocked">Open</span></td></tr>
           <tr><td class="id">M48</td><td>D2.5, D3.2, D3.4 — three months out</td><td>4 open</td></tr>
           <tr><td class="id">M54</td><td>D3.3, MS6, differential privacy phase 2</td><td>3 open</td></tr>
           <tr><td class="id">M60</td><td>D3.5 operational demonstration</td><td>1 open</td></tr>
@@ -588,17 +686,24 @@
     </div>
     <div class="prose">
       <p>
-        Three pull requests sit green on all six checks, blocked only on a review that cannot come
-        from their author. That is the cheapest unblock available — no code, no compute, just a
-        second pair of eyes.
+        The review backlog that dominated this board a day ago is gone: nine pull requests merged,
+        the critical supply-chain alert closed, and the two changes D2.5 was waiting on are on
+        <code>main</code>. What is left is not a code queue. <strong>#563</strong> needs its swarm
+        check to finish; <strong>#550</strong> has failed four times and needs someone to read the
+        failure rather than rerun it a fifth; <strong>#547</strong> has a genuine test failure — it
+        asserts a <code>ResNet101</code> default where the actual default is <code>MST</code>, which
+        is worth resolving as a question about which is correct, not as a test fix.
       </p>
     </div>
   </section>
 
   <footer>
-    Status as of 9 September 2026. Every figure here was read from the live server, the site logs or
-    CI on 8 September. The per-site training-set sizes previously quoted in planning were wrong by
-    two orders of magnitude and have been corrected at source.
+    Status as of 10 September 2026. Every figure here was read from the live server, the site logs,
+    the committed run-history dataset, or CI. The active-learning and privacy figures were
+    regenerated from <code>workspace/active_learning/acquisition_curve.csv</code> and the accountant
+    itself while writing this page, not copied from notes. The per-site training-set sizes
+    previously quoted in planning were wrong by two orders of magnitude and have been corrected at
+    source.
   </footer>
 
 </div>

--- a/scripts/presentation/build_consortium_briefing.py
+++ b/scripts/presentation/build_consortium_briefing.py
@@ -1,4 +1,221 @@
-<title>ODELIA Consortium Briefing</title>
+#!/usr/bin/env python3
+"""Build docs/presentation_consortium_briefing.html.
+
+Regenerate rather than editing the HTML by hand: the diagram coordinates are
+computed here, and the assertions in `bars()` are what keep the per-site class
+counts summing to each site's training total.
+
+Diagrams are **inline SVG, not mermaid**. Mermaid auto-renders inside the Claude
+artifact viewer but this file is also opened straight from the repo, where a
+mermaid fence would show as raw text. Inline SVG renders everywhere and inherits
+the deck's own theme tokens, so it works in light and dark alike.
+
+    python3 scripts/presentation/build_consortium_briefing.py \
+        docs/presentation_consortium_briefing.html
+"""
+
+import math
+import sys
+
+def esc(s):
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+# ---------------------------------------------------------------- 1. the ring
+SITES = [
+    ("UKA",  "Aachen"),
+    ("RSH",  "Guildford"),
+    ("CAM",  "Cambridge"),
+    ("MHA",  "Athens"),
+    ("VHIO", "Barcelona"),
+    ("USZ",  "Zurich"),
+    ("UMCU", "Utrecht"),
+    ("RUMC", "Nijmegen"),
+]
+
+def ring():
+    cx, cy, r = 255, 262, 155
+    bw, bh = 100, 38
+    out = []
+    out.append('<svg viewBox="0 0 500 486" role="img" aria-label="Eight hospitals arranged in a ring. The model is passed clockwise from hospital to hospital: Aachen, Guildford, Cambridge, Athens, Barcelona, Zurich, Utrecht, Nijmegen. Patient data stays inside each hospital. A coordination server in Dresden only schedules whose turn it is.">')
+    # travel path
+    out.append(f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="var(--accent)" stroke-width="1.6" stroke-dasharray="7 6" opacity=".55"/>')
+    # direction arrowheads at the midpoints between nodes
+    for i in range(8):
+        th = math.radians(-90 + 45 * i + 22.5)
+        x, y = cx + r * math.cos(th), cy + r * math.sin(th)
+        rot = math.degrees(th) + 90
+        out.append(f'<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" '
+                   f'transform="translate({x:.1f} {y:.1f}) rotate({rot:.1f})"/>')
+    # centre
+    out.append(f'<circle cx="{cx}" cy="{cy}" r="66" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.4"/>')
+    out.append(f'<text class="d-ctr-h" x="{cx}" y="{cy-14}" text-anchor="middle">THE MODEL</text>')
+    out.append(f'<text class="d-ctr" x="{cx}" y="{cy+6}" text-anchor="middle">a file of numbers</text>')
+    out.append(f'<text class="d-ctr" x="{cx}" y="{cy+22}" text-anchor="middle">no images inside</text>')
+    out.append(f'<text class="d-ctr-g" x="{cx}" y="{cy+42}" text-anchor="middle">better at every stop</text>')
+    # nodes
+    for i, (code, city) in enumerate(SITES):
+        th = math.radians(-90 + 45 * i)
+        x, y = cx + r * math.cos(th), cy + r * math.sin(th)
+        out.append(f'<g><rect x="{x-bw/2:.1f}" y="{y-bh/2:.1f}" width="{bw}" height="{bh}" rx="6" '
+                   f'fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>')
+        out.append(f'<text class="d-node" x="{x:.1f}" y="{y-2:.1f}" text-anchor="middle">{code}</text>')
+        out.append(f'<text class="d-node-sub" x="{x:.1f}" y="{y+11:.1f}" text-anchor="middle">{esc(city)}</text></g>')
+    # coordinator, deliberately small
+    out.append('<g><rect x="6" y="10" width="196" height="36" rx="6" fill="none" stroke="var(--muted)" '
+               'stroke-width="1.1" stroke-dasharray="4 4"/>')
+    out.append('<text class="d-note" x="104" y="26" text-anchor="middle">Coordination server · Dresden</text>')
+    out.append('<text class="d-note-sm" x="104" y="39" text-anchor="middle">schedules turns · holds no data</text></g>')
+    out.append('<path d="M104 46 L104 70 Q104 82 116 88 L140 108" fill="none" stroke="var(--muted)" '
+               'stroke-width="1.1" stroke-dasharray="4 4"/>')
+    out.append('</svg>')
+    return "\n".join(out)
+
+# --------------------------------------------------------------- 2. the round
+def round_flow():
+    steps = [
+        ("1", "The coordinator", "sets the order", "for this round"),
+        ("2", "A hospital receives", "the current model", "over the network"),
+        ("3", "It trains", "on its own patients,", "on its own hardware"),
+        ("4", "It hands the", "improved model", "to the next hospital"),
+    ]
+    bw, bh, gap, y = 190, 84, 34, 18
+    out = ['<svg viewBox="0 0 880 200" role="img" aria-label="A training round in four steps: the coordinator sets the order; a hospital receives the current model; it trains on its own patients on its own hardware; it hands the improved model to the next hospital. The last three steps repeat once per hospital, and eight hops complete one round.">']
+    xs = []
+    for i, (n, l1, l2, l3) in enumerate(steps):
+        x = 12 + i * (bw + gap)
+        xs.append(x)
+        fill = "var(--accent-soft)" if i == 2 else "var(--slide-alt)"
+        stroke = "var(--accent)" if i == 2 else "var(--rule)"
+        out.append(f'<rect x="{x}" y="{y}" width="{bw}" height="{bh}" rx="7" fill="{fill}" stroke="{stroke}" stroke-width="1.2"/>')
+        out.append(f'<text class="d-step-n" x="{x+13}" y="{y+21}">{n}</text>')
+        out.append(f'<text class="d-step" x="{x+13}" y="{y+43}">{esc(l1)}</text>')
+        out.append(f'<text class="d-step" x="{x+13}" y="{y+59}">{esc(l2)}</text>')
+        out.append(f'<text class="d-step" x="{x+13}" y="{y+75}">{esc(l3)}</text>')
+        if i < 3:
+            ax = x + bw + 6
+            out.append(f'<path d="M{ax} {y+bh/2} L{ax+gap-12} {y+bh/2}" stroke="var(--muted)" stroke-width="1.4"/>')
+            out.append(f'<polygon points="-5,-4 5,0 -5,4" fill="var(--muted)" transform="translate({ax+gap-11} {y+bh/2})"/>')
+    # return loop: step 4 -> step 2
+    x4c = xs[3] + bw / 2
+    x2c = xs[1] + bw / 2
+    ly = y + bh + 36
+    out.append(f'<path d="M{x4c} {y+bh} L{x4c} {ly} L{x2c} {ly} L{x2c} {y+bh+9}" fill="none" '
+               f'stroke="var(--accent)" stroke-width="1.4" stroke-dasharray="6 5"/>')
+    out.append(f'<polygon points="-4.5,4.5 0,-5 4.5,4.5" fill="var(--accent)" transform="translate({x2c} {y+bh+7})"/>')
+    out.append(f'<rect x="{(x2c+x4c)/2-142}" y="{ly-13}" width="284" height="26" rx="5" fill="var(--slide)"/>')
+    out.append(f'<text class="d-loop" x="{(x2c+x4c)/2}" y="{ly+4}" text-anchor="middle">eight hops — one per hospital — complete one round</text>')
+    out.append('</svg>')
+    return "\n".join(out)
+
+# ------------------------------------------------------------ 3. the boundary
+def boundary():
+    stay = [
+        ("MRI images and the raw DICOM series", None),
+        ("Patient names, dates of birth, record numbers", None),
+        ("Radiology reports and clinical notes", None),
+        ("The hospital's own database and file store", None),
+    ]
+    cross = [
+        ("The model itself — weights, which are numbers", "no images and no text are stored inside it"),
+        ("How many cases the site trained on", "and how many of each of the three classes"),
+        ("How well the shared model scored at that site", "accuracy and AUROC, with the counts behind them"),
+        ("Per-case predictions — opt-in, off by default", "a row number, the label, the probabilities. No identifier."),
+    ]
+    out = ['<svg viewBox="0 0 880 312" role="img" aria-label="Two columns divided by the hospital boundary. Staying inside: MRI images and raw DICOM, patient identifiers, radiology reports, the hospital database. Crossing the boundary: the model weights, case counts per class, accuracy scores, and optionally per-case predictions carrying a row number but no identifier.">']
+    # left
+    out.append('<rect x="6" y="34" width="394" height="272" rx="8" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>')
+    out.append('<text class="d-panel-h" x="24" y="22">STAYS INSIDE THE HOSPITAL — ALWAYS</text>')
+    for i, (t, _) in enumerate(stay):
+        yy = 74 + i * 58
+        out.append(f'<circle cx="34" cy="{yy-5}" r="9" fill="var(--bad-bg)"/>')
+        out.append(f'<path d="M30 {yy-9} L38 {yy-1} M38 {yy-9} L30 {yy-1}" stroke="var(--bad)" stroke-width="1.8" stroke-linecap="round"/>')
+        out.append(f'<text class="d-item" x="54" y="{yy}">{esc(t)}</text>')
+    # boundary
+    out.append('<path d="M436 8 L436 306" stroke="var(--rule)" stroke-width="2" stroke-dasharray="6 6"/>')
+    out.append('<rect x="404" y="140" width="64" height="34" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>')
+    out.append('<text class="d-note-sm" x="436" y="154" text-anchor="middle">HOSPITAL</text>')
+    out.append('<text class="d-note-sm" x="436" y="166" text-anchor="middle">BOUNDARY</text>')
+    # right
+    out.append('<rect x="472" y="34" width="402" height="272" rx="8" fill="var(--slide)" stroke="var(--accent)" stroke-width="1.2"/>')
+    out.append('<text class="d-panel-h" x="490" y="22">CROSSES THE BOUNDARY</text>')
+    for i, (t, sub) in enumerate(cross):
+        yy = 70 + i * 58
+        col = "var(--warn)" if i == 3 else "var(--good)"
+        bg = "var(--warn-bg)" if i == 3 else "var(--good-bg)"
+        out.append(f'<circle cx="500" cy="{yy-5}" r="9" fill="{bg}"/>')
+        out.append(f'<path d="M496 {yy-5} L505 {yy-5} M501.5 {yy-9} L505.5 {yy-5} L501.5 {yy-1}" fill="none" stroke="{col}" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>')
+        out.append(f'<text class="d-item" x="520" y="{yy}">{esc(t)}</text>')
+        if sub:
+            out.append(f'<text class="d-item-sub" x="520" y="{yy+16}">{esc(sub)}</text>')
+    out.append('</svg>')
+    return "\n".join(out)
+
+# ------------------------------------------------------- 4. prevention loop
+def loop():
+    nodes = [
+        ("A run fails", "at one hospital"),
+        ("We reproduce it", "on our own machines"),
+        ("The cause is fixed", "in the software"),
+        ("An automatic check", "is added"),
+        ("The next run", "cannot hit it again"),
+    ]
+    cx, cy, r = 250, 208, 138
+    bw, bh = 138, 46
+    out = ['<svg viewBox="0 0 500 376" role="img" aria-label="A five-step loop: a run fails at one hospital, we reproduce it on our own machines, the cause is fixed in the software, an automatic check is added, and the next run cannot hit it again. At the centre: ten named failure modes, all written up for partners.">']
+    out.append(f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="var(--rule)" stroke-width="1.4" stroke-dasharray="6 6"/>')
+    for i in range(5):
+        th = math.radians(-90 + 72 * i + 36)
+        x, y = cx + r * math.cos(th), cy + r * math.sin(th)
+        rot = math.degrees(th) + 90
+        out.append(f'<polygon points="-5,-4 6,0 -5,4" fill="var(--accent)" transform="translate({x:.1f} {y:.1f}) rotate({rot:.1f})"/>')
+    out.append(f'<text class="d-ctr-h" x="{cx}" y="{cy-6}" text-anchor="middle">10 NAMED FAILURE MODES</text>')
+    out.append(f'<text class="d-ctr" x="{cx}" y="{cy+14}" text-anchor="middle">each one written up for partners</text>')
+    for i, (l1, l2) in enumerate(nodes):
+        th = math.radians(-90 + 72 * i)
+        x, y = cx + r * math.cos(th), cy + r * math.sin(th)
+        out.append(f'<rect x="{x-bw/2:.1f}" y="{y-bh/2:.1f}" width="{bw}" height="{bh}" rx="6" '
+                   f'fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>')
+        out.append(f'<text class="d-node" x="{x:.1f}" y="{y-3:.1f}" text-anchor="middle">{esc(l1)}</text>')
+        out.append(f'<text class="d-node-sub" x="{x:.1f}" y="{y+11:.1f}" text-anchor="middle">{esc(l2)}</text>')
+    out.append('</svg>')
+    return "\n".join(out)
+
+# ------------------------------------------------------------- 5. data bars
+DATA = [
+    ("UKA",  "Aachen",     17834, 4747, 11836, 1251),
+    ("UMCU", "Utrecht",     6133, 5337,   740,   56),
+    ("RUMC", "Nijmegen",    3608, 3571,     2,   35),
+    ("USZ",  "Zurich",      3448, 1911,  1244,  293),
+    ("CAM",  "Cambridge",   1778, 1678,    42,   58),
+    ("MHA",  "Athens",      1120,  904,   120,   96),
+    ("RSH",  "Guildford",    351,    4,   126,  221),
+    ("VHIO", "Barcelona",    190,  159,     0,   31),
+]
+
+def bars():
+    assert all(n == a + b + c for _, _, n, a, b, c in DATA), "class counts must sum to n"
+    total = sum(d[2] for d in DATA)
+    assert total == 34462, total
+    x0, maxw = 96, 500
+    rh, gapy, y0 = 26, 8, 14
+    sc = maxw / DATA[0][2]
+    out = [f'<svg viewBox="0 0 720 {y0 + len(DATA)*(rh+gapy) + 6}" role="img" '
+           f'aria-label="Training volumes per hospital at true scale: Aachen 17834, Utrecht 6133, Nijmegen 3608, Zurich 3448, Cambridge 1778, Athens 1120, Guildford 351, Barcelona 190. Total 34462.">']
+    for i, (code, city, n, c0, c1, c2) in enumerate(DATA):
+        y = y0 + i * (rh + gapy)
+        out.append(f'<text class="d-bar-lbl" x="{x0-12}" y="{y+17}" text-anchor="end">{code}</text>')
+        xx = x0
+        for val, col in ((c0, "var(--s1)"), (c1, "var(--s2)"), (c2, "var(--s3)")):
+            w = val * sc
+            if w > 0:
+                out.append(f'<rect x="{xx:.1f}" y="{y}" width="{max(w,0.8):.1f}" height="{rh}" fill="{col}"/>')
+            xx += w
+        out.append(f'<text class="d-bar-val" x="{x0+maxw+18}" y="{y+17}" text-anchor="end">{n:,}</text>')
+    out.append('</svg>')
+    return "\n".join(out)
+
+
+CSS = """<title>ODELIA Consortium Briefing</title>
 <style>
   :root {
     --ground:      #FAFBFC;
@@ -143,15 +360,24 @@
     .slide { page-break-after: always; border: none; border-radius: 0; min-height: 100vh; }
   }
 </style>
+"""
 
-<div class="deck">
+SLIDES = []
 
-  <!-- 1 -->
+def slide(n, eyebrow, head, body, h="h2"):
+    SLIDES.append(f'''
+  <!-- {n} -->
   <section class="slide">
-    <span class="num">1</span>
-    <div class="eyebrow">ODELIA consortium · September 2026</div>
-    <h1>Eight hospitals, one shared model, no patient data moved</h1>
-    <p class="sub">
+    <span class="num">{n}</span>
+    <div class="eyebrow">{eyebrow}</div>
+    <{h}>{head}</{h}>
+{body}
+  </section>''')
+
+# ---- 1 -------------------------------------------------------------------
+slide(1, "ODELIA consortium · September 2026",
+      "Eight hospitals, one shared model, no patient data moved",
+      '''    <p class="sub">
       How the system works, what it has achieved, and what we need from partners next.
       This briefing avoids technical detail on purpose — everything here is the plain version.
     </p>
@@ -162,15 +388,12 @@
         <div><dt>Best shared model</dt><dd>0.887<span class="cap">detecting malignancy — better than any single hospital achieved alone</span></dd></div>
         <div><dt>Project month</dt><dd>45<span class="cap">of 60</span></dd></div>
       </div>
-    </div>
-  </section>
+    </div>''', h="h1")
 
-  <!-- 2 -->
-  <section class="slide">
-    <span class="num">2</span>
-    <div class="eyebrow">The design</div>
-    <h2>The model travels. The data never does.</h2>
-    <div class="split">
+# ---- 2 -------------------------------------------------------------------
+slide(2, "The design",
+      "The model travels. The data never does.",
+      f'''    <div class="split">
       <div style="display:flex;flex-direction:column;gap:.8rem">
         <ul>
           <li>Every hospital keeps its images on its own machines, behind its own firewall. Nothing is copied to a central store, because there is no central store.</li>
@@ -185,94 +408,17 @@
         </div>
       </div>
       <figure class="fig">
-        <svg viewBox="0 0 500 486" role="img" aria-label="Eight hospitals arranged in a ring. The model is passed clockwise from hospital to hospital: Aachen, Guildford, Cambridge, Athens, Barcelona, Zurich, Utrecht, Nijmegen. Patient data stays inside each hospital. A coordination server in Dresden only schedules whose turn it is.">
-<circle cx="255" cy="262" r="155" fill="none" stroke="var(--accent)" stroke-width="1.6" stroke-dasharray="7 6" opacity=".55"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(314.3 118.8) rotate(22.5)"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(398.2 202.7) rotate(67.5)"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(398.2 321.3) rotate(112.5)"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(314.3 405.2) rotate(157.5)"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(195.7 405.2) rotate(202.5)"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(111.8 321.3) rotate(247.5)"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(111.8 202.7) rotate(292.5)"/>
-<polygon points="-5.5,-4.5 6,0 -5.5,4.5" fill="var(--accent)" transform="translate(195.7 118.8) rotate(337.5)"/>
-<circle cx="255" cy="262" r="66" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.4"/>
-<text class="d-ctr-h" x="255" y="248" text-anchor="middle">THE MODEL</text>
-<text class="d-ctr" x="255" y="268" text-anchor="middle">a file of numbers</text>
-<text class="d-ctr" x="255" y="284" text-anchor="middle">no images inside</text>
-<text class="d-ctr-g" x="255" y="304" text-anchor="middle">better at every stop</text>
-<g><rect x="205.0" y="88.0" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="255.0" y="105.0" text-anchor="middle">UKA</text>
-<text class="d-node-sub" x="255.0" y="118.0" text-anchor="middle">Aachen</text></g>
-<g><rect x="314.6" y="133.4" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="364.6" y="150.4" text-anchor="middle">RSH</text>
-<text class="d-node-sub" x="364.6" y="163.4" text-anchor="middle">Guildford</text></g>
-<g><rect x="360.0" y="243.0" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="410.0" y="260.0" text-anchor="middle">CAM</text>
-<text class="d-node-sub" x="410.0" y="273.0" text-anchor="middle">Cambridge</text></g>
-<g><rect x="314.6" y="352.6" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="364.6" y="369.6" text-anchor="middle">MHA</text>
-<text class="d-node-sub" x="364.6" y="382.6" text-anchor="middle">Athens</text></g>
-<g><rect x="205.0" y="398.0" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="255.0" y="415.0" text-anchor="middle">VHIO</text>
-<text class="d-node-sub" x="255.0" y="428.0" text-anchor="middle">Barcelona</text></g>
-<g><rect x="95.4" y="352.6" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="145.4" y="369.6" text-anchor="middle">USZ</text>
-<text class="d-node-sub" x="145.4" y="382.6" text-anchor="middle">Zurich</text></g>
-<g><rect x="50.0" y="243.0" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="100.0" y="260.0" text-anchor="middle">UMCU</text>
-<text class="d-node-sub" x="100.0" y="273.0" text-anchor="middle">Utrecht</text></g>
-<g><rect x="95.4" y="133.4" width="100" height="38" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="145.4" y="150.4" text-anchor="middle">RUMC</text>
-<text class="d-node-sub" x="145.4" y="163.4" text-anchor="middle">Nijmegen</text></g>
-<g><rect x="6" y="10" width="196" height="36" rx="6" fill="none" stroke="var(--muted)" stroke-width="1.1" stroke-dasharray="4 4"/>
-<text class="d-note" x="104" y="26" text-anchor="middle">Coordination server · Dresden</text>
-<text class="d-note-sm" x="104" y="39" text-anchor="middle">schedules turns · holds no data</text></g>
-<path d="M104 46 L104 70 Q104 82 116 88 L140 108" fill="none" stroke="var(--muted)" stroke-width="1.1" stroke-dasharray="4 4"/>
-</svg>
+        {ring()}
         <figcaption>The eight ODELIA sites and the path the model takes.</figcaption>
       </figure>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 3 -->
-  <section class="slide">
-    <span class="num">3</span>
-    <div class="eyebrow">The design</div>
-    <h2>What actually happens during a training round</h2>
-    <div class="body">
+# ---- 3 -------------------------------------------------------------------
+slide(3, "The design",
+      "What actually happens during a training round",
+      f'''    <div class="body">
       <figure class="fig">
-        <svg viewBox="0 0 880 200" role="img" aria-label="A training round in four steps: the coordinator sets the order; a hospital receives the current model; it trains on its own patients on its own hardware; it hands the improved model to the next hospital. The last three steps repeat once per hospital, and eight hops complete one round.">
-<rect x="12" y="18" width="190" height="84" rx="7" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-step-n" x="25" y="39">1</text>
-<text class="d-step" x="25" y="61">The coordinator</text>
-<text class="d-step" x="25" y="77">sets the order</text>
-<text class="d-step" x="25" y="93">for this round</text>
-<path d="M208 60.0 L230 60.0" stroke="var(--muted)" stroke-width="1.4"/>
-<polygon points="-5,-4 5,0 -5,4" fill="var(--muted)" transform="translate(231 60.0)"/>
-<rect x="236" y="18" width="190" height="84" rx="7" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-step-n" x="249" y="39">2</text>
-<text class="d-step" x="249" y="61">A hospital receives</text>
-<text class="d-step" x="249" y="77">the current model</text>
-<text class="d-step" x="249" y="93">over the network</text>
-<path d="M432 60.0 L454 60.0" stroke="var(--muted)" stroke-width="1.4"/>
-<polygon points="-5,-4 5,0 -5,4" fill="var(--muted)" transform="translate(455 60.0)"/>
-<rect x="460" y="18" width="190" height="84" rx="7" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.2"/>
-<text class="d-step-n" x="473" y="39">3</text>
-<text class="d-step" x="473" y="61">It trains</text>
-<text class="d-step" x="473" y="77">on its own patients,</text>
-<text class="d-step" x="473" y="93">on its own hardware</text>
-<path d="M656 60.0 L678 60.0" stroke="var(--muted)" stroke-width="1.4"/>
-<polygon points="-5,-4 5,0 -5,4" fill="var(--muted)" transform="translate(679 60.0)"/>
-<rect x="684" y="18" width="190" height="84" rx="7" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-step-n" x="697" y="39">4</text>
-<text class="d-step" x="697" y="61">It hands the</text>
-<text class="d-step" x="697" y="77">improved model</text>
-<text class="d-step" x="697" y="93">to the next hospital</text>
-<path d="M779.0 102 L779.0 138 L331.0 138 L331.0 111" fill="none" stroke="var(--accent)" stroke-width="1.4" stroke-dasharray="6 5"/>
-<polygon points="-4.5,4.5 0,-5 4.5,4.5" fill="var(--accent)" transform="translate(331.0 109)"/>
-<rect x="413.0" y="125" width="284" height="26" rx="5" fill="var(--slide)"/>
-<text class="d-loop" x="555.0" y="142" text-anchor="middle">eight hops — one per hospital — complete one round</text>
-</svg>
+        {round_flow()}
       </figure>
       <div class="two">
         <div class="panel">
@@ -288,54 +434,14 @@
           with a hundred and ninety are both taking a full turn.</p>
         </div>
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 4 -->
-  <section class="slide">
-    <span class="num">4</span>
-    <div class="eyebrow">The design · what partners are usually asked</div>
-    <h2>What leaves a hospital, and what never does</h2>
-    <div class="body">
+# ---- 4 -------------------------------------------------------------------
+slide(4, "The design · what partners are usually asked",
+      "What leaves a hospital, and what never does",
+      f'''    <div class="body">
       <figure class="fig">
-        <svg viewBox="0 0 880 312" role="img" aria-label="Two columns divided by the hospital boundary. Staying inside: MRI images and raw DICOM, patient identifiers, radiology reports, the hospital database. Crossing the boundary: the model weights, case counts per class, accuracy scores, and optionally per-case predictions carrying a row number but no identifier.">
-<rect x="6" y="34" width="394" height="272" rx="8" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-panel-h" x="24" y="22">STAYS INSIDE THE HOSPITAL — ALWAYS</text>
-<circle cx="34" cy="69" r="9" fill="var(--bad-bg)"/>
-<path d="M30 65 L38 73 M38 65 L30 73" stroke="var(--bad)" stroke-width="1.8" stroke-linecap="round"/>
-<text class="d-item" x="54" y="74">MRI images and the raw DICOM series</text>
-<circle cx="34" cy="127" r="9" fill="var(--bad-bg)"/>
-<path d="M30 123 L38 131 M38 123 L30 131" stroke="var(--bad)" stroke-width="1.8" stroke-linecap="round"/>
-<text class="d-item" x="54" y="132">Patient names, dates of birth, record numbers</text>
-<circle cx="34" cy="185" r="9" fill="var(--bad-bg)"/>
-<path d="M30 181 L38 189 M38 181 L30 189" stroke="var(--bad)" stroke-width="1.8" stroke-linecap="round"/>
-<text class="d-item" x="54" y="190">Radiology reports and clinical notes</text>
-<circle cx="34" cy="243" r="9" fill="var(--bad-bg)"/>
-<path d="M30 239 L38 247 M38 239 L30 247" stroke="var(--bad)" stroke-width="1.8" stroke-linecap="round"/>
-<text class="d-item" x="54" y="248">The hospital's own database and file store</text>
-<path d="M436 8 L436 306" stroke="var(--rule)" stroke-width="2" stroke-dasharray="6 6"/>
-<rect x="404" y="140" width="64" height="34" rx="6" fill="var(--slide)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-note-sm" x="436" y="154" text-anchor="middle">HOSPITAL</text>
-<text class="d-note-sm" x="436" y="166" text-anchor="middle">BOUNDARY</text>
-<rect x="472" y="34" width="402" height="272" rx="8" fill="var(--slide)" stroke="var(--accent)" stroke-width="1.2"/>
-<text class="d-panel-h" x="490" y="22">CROSSES THE BOUNDARY</text>
-<circle cx="500" cy="65" r="9" fill="var(--good-bg)"/>
-<path d="M496 65 L505 65 M501.5 61 L505.5 65 L501.5 69" fill="none" stroke="var(--good)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text class="d-item" x="520" y="70">The model itself — weights, which are numbers</text>
-<text class="d-item-sub" x="520" y="86">no images and no text are stored inside it</text>
-<circle cx="500" cy="123" r="9" fill="var(--good-bg)"/>
-<path d="M496 123 L505 123 M501.5 119 L505.5 123 L501.5 127" fill="none" stroke="var(--good)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text class="d-item" x="520" y="128">How many cases the site trained on</text>
-<text class="d-item-sub" x="520" y="144">and how many of each of the three classes</text>
-<circle cx="500" cy="181" r="9" fill="var(--good-bg)"/>
-<path d="M496 181 L505 181 M501.5 177 L505.5 181 L501.5 185" fill="none" stroke="var(--good)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text class="d-item" x="520" y="186">How well the shared model scored at that site</text>
-<text class="d-item-sub" x="520" y="202">accuracy and AUROC, with the counts behind them</text>
-<circle cx="500" cy="239" r="9" fill="var(--warn-bg)"/>
-<path d="M496 239 L505 239 M501.5 235 L505.5 239 L501.5 243" fill="none" stroke="var(--warn)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text class="d-item" x="520" y="244">Per-case predictions — opt-in, off by default</text>
-<text class="d-item-sub" x="520" y="260">a row number, the label, the probabilities. No identifier.</text>
-</svg>
+        {boundary()}
       </figure>
       <div class="callout">
         <strong>The last row is the one we would like to discuss.</strong> Returning
@@ -343,57 +449,14 @@
         It is what makes proper statistical comparison between hospitals possible, and it
         is required for the regulatory testing node due next year.
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 5 -->
-  <section class="slide">
-    <span class="num">5</span>
-    <div class="eyebrow">The achievement · the data</div>
-    <h2>What the consortium can now train on</h2>
-    <div class="body">
+# ---- 5 -------------------------------------------------------------------
+slide(5, "The achievement · the data",
+      "What the consortium can now train on",
+      f'''    <div class="body">
       <figure class="fig">
-        <svg viewBox="0 0 720 292" role="img" aria-label="Training volumes per hospital at true scale: Aachen 17834, Utrecht 6133, Nijmegen 3608, Zurich 3448, Cambridge 1778, Athens 1120, Guildford 351, Barcelona 190. Total 34462.">
-<text class="d-bar-lbl" x="84" y="31" text-anchor="end">UKA</text>
-<rect x="96.0" y="14" width="133.1" height="26" fill="var(--s1)"/>
-<rect x="229.1" y="14" width="331.8" height="26" fill="var(--s2)"/>
-<rect x="560.9" y="14" width="35.1" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="31" text-anchor="end">17,834</text>
-<text class="d-bar-lbl" x="84" y="65" text-anchor="end">UMCU</text>
-<rect x="96.0" y="48" width="149.6" height="26" fill="var(--s1)"/>
-<rect x="245.6" y="48" width="20.7" height="26" fill="var(--s2)"/>
-<rect x="266.4" y="48" width="1.6" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="65" text-anchor="end">6,133</text>
-<text class="d-bar-lbl" x="84" y="99" text-anchor="end">RUMC</text>
-<rect x="96.0" y="82" width="100.1" height="26" fill="var(--s1)"/>
-<rect x="196.1" y="82" width="0.8" height="26" fill="var(--s2)"/>
-<rect x="196.2" y="82" width="1.0" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="99" text-anchor="end">3,608</text>
-<text class="d-bar-lbl" x="84" y="133" text-anchor="end">USZ</text>
-<rect x="96.0" y="116" width="53.6" height="26" fill="var(--s1)"/>
-<rect x="149.6" y="116" width="34.9" height="26" fill="var(--s2)"/>
-<rect x="184.5" y="116" width="8.2" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="133" text-anchor="end">3,448</text>
-<text class="d-bar-lbl" x="84" y="167" text-anchor="end">CAM</text>
-<rect x="96.0" y="150" width="47.0" height="26" fill="var(--s1)"/>
-<rect x="143.0" y="150" width="1.2" height="26" fill="var(--s2)"/>
-<rect x="144.2" y="150" width="1.6" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="167" text-anchor="end">1,778</text>
-<text class="d-bar-lbl" x="84" y="201" text-anchor="end">MHA</text>
-<rect x="96.0" y="184" width="25.3" height="26" fill="var(--s1)"/>
-<rect x="121.3" y="184" width="3.4" height="26" fill="var(--s2)"/>
-<rect x="124.7" y="184" width="2.7" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="201" text-anchor="end">1,120</text>
-<text class="d-bar-lbl" x="84" y="235" text-anchor="end">RSH</text>
-<rect x="96.0" y="218" width="0.8" height="26" fill="var(--s1)"/>
-<rect x="96.1" y="218" width="3.5" height="26" fill="var(--s2)"/>
-<rect x="99.6" y="218" width="6.2" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="235" text-anchor="end">351</text>
-<text class="d-bar-lbl" x="84" y="269" text-anchor="end">VHIO</text>
-<rect x="96.0" y="252" width="4.5" height="26" fill="var(--s1)"/>
-<rect x="100.5" y="252" width="0.9" height="26" fill="var(--s3)"/>
-<text class="d-bar-val" x="614" y="269" text-anchor="end">190</text>
-</svg>
+        {bars()}
         <figcaption>Training volumes per hospital, drawn at true scale. Read from each
         site's own training logs; the three classes sum exactly to each site's total.</figcaption>
       </figure>
@@ -409,15 +472,12 @@
         seven put together — and the range from largest to smallest is 94-fold. Timeouts,
         round budgets and the way results are weighted all had to be designed around that.
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 6 -->
-  <section class="slide">
-    <span class="num">6</span>
-    <div class="eyebrow">The achievement · the result</div>
-    <h2>The shared model beats what any hospital could train alone</h2>
-    <div class="body">
+# ---- 6 -------------------------------------------------------------------
+slide(6, "The achievement · the result",
+      "The shared model beats what any hospital could train alone",
+      '''    <div class="body">
       <div class="scroll">
         <table>
           <thead>
@@ -459,15 +519,12 @@
         overlapping but not identical sets of test cases. The ordering is consistent and
         has repeated; the exact size of each gap is not a controlled comparison.
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 7 -->
-  <section class="slide">
-    <span class="num">7</span>
-    <div class="eyebrow">The achievement · why it matters</div>
-    <h2>The smaller the hospital, the more it gains</h2>
-    <div class="body">
+# ---- 7 -------------------------------------------------------------------
+slide(7, "The achievement · why it matters",
+      "The smaller the hospital, the more it gains",
+      '''    <div class="body">
       <p class="sub" style="margin-top:0">
         This is the case for the consortium existing, stated in one line: a hospital that
         trains alone is limited by the patients it happens to have seen.
@@ -492,15 +549,12 @@
         the data and still ends up with a better model by taking part. Being the largest
         contributor is not the same as having seen enough.
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 8 -->
-  <section class="slide">
-    <span class="num">8</span>
-    <div class="eyebrow">What the work actually was</div>
-    <h2>Most of the effort went into making it survive the real world</h2>
-    <div class="split" style="align-items:start">
+# ---- 8 -------------------------------------------------------------------
+slide(8, "What the work actually was",
+      "Most of the effort went into making it survive the real world",
+      f'''    <div class="split" style="align-items:start">
       <div style="display:flex;flex-direction:column;gap:.8rem">
         <p class="sub" style="margin-top:0">
           The learning itself was rarely the hard part. Hospital IT is eight different
@@ -533,42 +587,15 @@
         </div>
       </div>
       <figure class="fig">
-        <svg viewBox="0 0 500 376" role="img" aria-label="A five-step loop: a run fails at one hospital, we reproduce it on our own machines, the cause is fixed in the software, an automatic check is added, and the next run cannot hit it again. At the centre: ten named failure modes, all written up for partners.">
-<circle cx="250" cy="208" r="138" fill="none" stroke="var(--rule)" stroke-width="1.4" stroke-dasharray="6 6"/>
-<polygon points="-5,-4 6,0 -5,4" fill="var(--accent)" transform="translate(331.1 96.4) rotate(36.0)"/>
-<polygon points="-5,-4 6,0 -5,4" fill="var(--accent)" transform="translate(381.2 250.6) rotate(108.0)"/>
-<polygon points="-5,-4 6,0 -5,4" fill="var(--accent)" transform="translate(250.0 346.0) rotate(180.0)"/>
-<polygon points="-5,-4 6,0 -5,4" fill="var(--accent)" transform="translate(118.8 250.6) rotate(252.0)"/>
-<polygon points="-5,-4 6,0 -5,4" fill="var(--accent)" transform="translate(168.9 96.4) rotate(324.0)"/>
-<text class="d-ctr-h" x="250" y="202" text-anchor="middle">10 NAMED FAILURE MODES</text>
-<text class="d-ctr" x="250" y="222" text-anchor="middle">each one written up for partners</text>
-<rect x="181.0" y="47.0" width="138" height="46" rx="6" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="250.0" y="67.0" text-anchor="middle">A run fails</text>
-<text class="d-node-sub" x="250.0" y="81.0" text-anchor="middle">at one hospital</text>
-<rect x="312.2" y="142.4" width="138" height="46" rx="6" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="381.2" y="162.4" text-anchor="middle">We reproduce it</text>
-<text class="d-node-sub" x="381.2" y="176.4" text-anchor="middle">on our own machines</text>
-<rect x="262.1" y="296.6" width="138" height="46" rx="6" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="331.1" y="316.6" text-anchor="middle">The cause is fixed</text>
-<text class="d-node-sub" x="331.1" y="330.6" text-anchor="middle">in the software</text>
-<rect x="99.9" y="296.6" width="138" height="46" rx="6" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="168.9" y="316.6" text-anchor="middle">An automatic check</text>
-<text class="d-node-sub" x="168.9" y="330.6" text-anchor="middle">is added</text>
-<rect x="49.8" y="142.4" width="138" height="46" rx="6" fill="var(--slide-alt)" stroke="var(--rule)" stroke-width="1.2"/>
-<text class="d-node" x="118.8" y="162.4" text-anchor="middle">The next run</text>
-<text class="d-node-sub" x="118.8" y="176.4" text-anchor="middle">cannot hit it again</text>
-</svg>
+        {loop()}
         <figcaption>How an incident at one hospital becomes a permanent fix for all eight.</figcaption>
       </figure>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 9 -->
-  <section class="slide">
-    <span class="num">9</span>
-    <div class="eyebrow">How we read the results</div>
-    <h2>A number without its denominator is not a result</h2>
-    <div class="body">
+# ---- 9 : merged from the previously published deck (its slides 2-4) ------
+slide(9, "How we read the results",
+      "A number without its denominator is not a result",
+      '''    <div class="body">
       <p class="sub" style="margin-top:0">
         Until recently, each hospital's results had to be collected by logging into that
         hospital by hand. They now come back to the coordinator automatically — and the
@@ -606,15 +633,12 @@
         were summarising it. Every figure now travels with the counts behind it, and we no
         longer rank centres on an average where a class has only a handful of cases.
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 10 -->
-  <section class="slide">
-    <span class="num">10</span>
-    <div class="eyebrow">New this quarter</div>
-    <h2>Two new capabilities — and one useful negative result</h2>
-    <div class="body">
+# ---- 10 ------------------------------------------------------------------
+slide(10, "New this quarter",
+      "Two new capabilities — and one useful negative result",
+      '''    <div class="body">
       <div class="two">
         <div class="panel">
           <h3>Choosing what to label next</h3>
@@ -650,15 +674,12 @@
         <em>patient</em> was in a hospital's data is a further step, and we are not
         claiming it yet.
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 11 -->
-  <section class="slide">
-    <span class="num">11</span>
-    <div class="eyebrow">Where we stand</div>
-    <h2>Three deliverables due in three months</h2>
-    <div class="body">
+# ---- 10 ------------------------------------------------------------------
+slide(11, "Where we stand",
+      "Three deliverables due in three months",
+      '''    <div class="body">
       <div class="scroll">
         <table>
           <thead><tr><th>Deliverable</th><th>Due</th><th>Status</th><th>What it still needs</th></tr></thead>
@@ -673,15 +694,12 @@
           </tbody>
         </table>
       </div>
-    </div>
-  </section>
+    </div>''')
 
-  <!-- 12 -->
-  <section class="slide">
-    <span class="num">12</span>
-    <div class="eyebrow">What we need from partners</div>
-    <h2>Two things, and neither is technical</h2>
-    <div class="body">
+# ---- 12 : the ask, restored in full from the previously published deck ----
+slide(12, "What we need from partners",
+      "Two things, and neither is technical",
+      '''    <div class="body">
       <div class="ask">
         <div class="ask-h">1 · Let sites return per-case predictions, not just summaries</div>
         <div class="ask-b">
@@ -718,8 +736,13 @@
           own system to show what it withstands. We are scheduling this now.
         </div>
       </div>
-    </div>
-  </section>
+    </div>''')
+
+html = CSS + '\n<div class="deck">\n' + "\n".join(SLIDES) + '''
 
   <footer>ODELIA WP2 / WP3 · 10 September 2026 · every figure read from the coordination server, the sites' own training logs, or CI</footer>
 </div>
+'''
+out_path = sys.argv[1] if len(sys.argv) > 1 else "docs/presentation_consortium_briefing.html"
+open(out_path, "w").write(html)
+print(f"wrote {out_path} — {len(html):,} bytes, {html.count(chr(60) + chr(115) + chr(101) + chr(99))} slides")


### PR DESCRIPTION
The consortium briefing was written for a technical meeting and read like one — job ids, config paths, `ABOUT_TO_END_RUN`, `posix_spawn`. Partners need the **design** and the **achievement** explained plainly. This rewrites it around those two things and adds diagrams to do the explaining.

## The deck — 12 slides, up from 7

| Slide | What it does |
|---|---|
| 2 | **Infrastructure diagram** — the eight sites as a ring, the model travelling between them, the coordinator drawn deliberately small because it holds no data |
| 3 | **Flow diagram** — one training round in four steps, with the return loop that turns eight hops into a round |
| 4 | **Boundary diagram** — what stays inside a hospital vs. what crosses the network, including the opt-in per-case predictions |
| 5 | Per-site training volumes at true scale, stacked by class |
| 6–7 | The model comparison, and why the smallest sites gain most |
| 8 | **Prevention-loop diagram** — how one site's incident becomes a permanent fix for all eight, beside the recent failure timeline |
| 9 | Radboud's 99.1 % accuracy against an AUROC of 0.417, as the plain-language case for reporting support counts |
| 10 | The active-learning negative result and the privacy budget |
| 12 | The ask: per-case predictions, and a slot with Cambridge and Nijmegen |

Nothing from the previous deck was dropped — the evaluation-validity slides and the failure timeline are merged in, restated without the jargon.

### Why inline SVG and not mermaid

Mermaid auto-renders inside the Claude artifact viewer, but this file is also opened straight from the repo, where a mermaid fence shows as raw text. Inline SVG renders in both, inherits the deck's own theme tokens, and works in light and dark.

### The deck is now generated

`scripts/presentation/build_consortium_briefing.py` reproduces the committed HTML **byte-identically**. The diagram coordinates are computed rather than typed, and `bars()` asserts that each site's three class counts sum to its training total and that the eight sites sum to 34,462 — so the figures cannot silently drift.

## The M45 report stays technical

It is for the technical committee, so the register does not change. It gains the two first results, both from #563:

- **D3.2 — a negative result, reported as one.** Uncertainty sampling found *fewer* malignant cases than random at every labelling budget: 19 (entropy) / 21 (margin) / 22.2 ± 2.8 (random) at a 100-label budget. The calibration diagnostic explains why — mean predictive entropy is near-identical across classes (0.987 / 0.878 / 0.981) and the model is **most confident on benign cases**, the rarest class, with 12 of 17 benign in the 30 lowest-entropy cases. Its confidence does not track correctness, so an uncertainty rule deprioritises exactly what you want it to surface. That is a calibration finding, not a verdict on active learning, and it is a more useful thing to write in D3.2 than a curve from a rule nobody checked.
- **T3.3 Phase 2 — the guarantee is now a number.** Over 20 rounds at δ = 10⁻⁵: ε ≤ 10 needs σ ≥ 2.4, ε ≤ 3 needs σ ≥ 6.7, ε ≤ 1 needs σ ≥ 18.1. Stated as **client-level, not record-level** — it hides whether a *site* participated, not whether a *patient* was in that site's data.

The board reflects the nine PRs merged on 9–10 September, and the recommended next task changes with them: D2.5 no longer needs anything built, it needs a two-site run with per-case return enabled at RUMC and UMCU.

## Verification

- Build script reproduces `docs/presentation_consortium_briefing.html` byte-identically
- Both files parse with no unclosed tags and no stray closers
- Every `var(--token)` used is defined in the bare `:root`, so neither page can render one theme's text on the other's ground
- Slide numbering is contiguous 1–12
- Privacy figures regenerated from `privacy_accounting.py` itself; AL figures read from `workspace/active_learning/acquisition_curve.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
